### PR TITLE
chore: establish CI infrastructure with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Ruff
+        run: uv run ruff check src tests
+      - name: Black
+        run: uv run black --check src tests
+
+  typecheck:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Mypy
+        run: uv run mypy src
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Pytest with coverage threshold
+        run: uv run pytest --cov-fail-under=85
+
+  final_gate:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [lint, typecheck, test]
+    steps:
+      - name: Final gate
+        run: |
+          set -euo pipefail
+
+          echo "RESULT::lint=${{ needs.lint.result }}"
+          echo "RESULT::typecheck=${{ needs.typecheck.result }}"
+          echo "RESULT::test=${{ needs.test.result }}"
+
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "ERROR::required_job_failed::lint::${{ needs.lint.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.typecheck.result }}" != "success" ]; then
+            echo "ERROR::required_job_failed::typecheck::${{ needs.typecheck.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "ERROR::required_job_failed::test::${{ needs.test.result }}"
+            exit 1
+          fi
+
+          echo "OK::final_gate_passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --all-extras --python ${{ matrix.python-version }}
+        run: uv sync --all-extras
       - name: Ruff
         run: uv run ruff check src tests
       - name: Black
@@ -51,8 +52,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --all-extras --python ${{ matrix.python-version }}
+        run: uv sync --all-extras
       - name: Mypy
         run: uv run mypy src
 
@@ -71,8 +73,9 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --all-extras --python ${{ matrix.python-version }}
+        run: uv sync --all-extras
       - name: Pytest with coverage threshold
         run: uv run pytest --cov-fail-under=85
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:
@@ -24,8 +27,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
       - name: Ruff
         run: uv run ruff check src tests
       - name: Black
@@ -44,8 +49,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
       - name: Mypy
         run: uv run mypy src
 
@@ -62,8 +69,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
       - name: Pytest with coverage threshold
         run: uv run pytest --cov-fail-under=85
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Current coverage: ~89%.
 
 ```bash
 # Run by marker
-.venv/bin/python -m pytest -m smoke         # Fast sanity checks (~20 tests)
+.venv/bin/python -m pytest -m smoke         # Fast sanity checks
 .venv/bin/python -m pytest -m unit          # Unit tests
 .venv/bin/python -m pytest -m behavior      # Behavioral tests
 .venv/bin/python -m pytest -m contract      # Contract tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # HestAI Context MCP Server
 
+[![CI](https://github.com/elevanaltd/hestai-context-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/elevanaltd/hestai-context-mcp/actions/workflows/ci.yml)
+
 Python MCP server providing session lifecycle, context synthesis, and review infrastructure.
 
 ## Quick Commands
@@ -22,6 +24,32 @@ The `.venv` is created by `uv sync --all-extras`.
 .venv/bin/python -m pytest -m smoke       # Fast sanity checks
 .venv/bin/python -m pytest -m behavior    # Behavioral tests
 .venv/bin/python -m pytest -m contract    # Contract tests
+```
+
+## CI Pipeline
+
+GitHub Actions CI runs on push to `main` and all PRs. Three jobs:
+- **lint**: `ruff check` + `black --check` (Python 3.11, 3.12)
+- **typecheck**: `mypy src` (Python 3.11, 3.12)
+- **test**: `pytest --cov-fail-under=85` (Python 3.11, 3.12)
+
+Coverage threshold: **85%** (enforced in CI only, not in local pytest addopts).
+Current coverage: ~89%.
+
+## Testing
+
+- **pytest markers**: `smoke`, `unit`, `behavior`, `contract`, `integration`
+- Strict markers mode enabled (unknown markers cause errors)
+- Coverage: 85% threshold enforced in CI
+- Tests live in `tests/` mirroring `src/` structure
+
+```bash
+# Run by marker
+.venv/bin/python -m pytest -m smoke         # Fast sanity checks (~20 tests)
+.venv/bin/python -m pytest -m unit          # Unit tests
+.venv/bin/python -m pytest -m behavior      # Behavioral tests
+.venv/bin/python -m pytest -m contract      # Contract tests
+.venv/bin/python -m pytest -m integration   # Integration tests
 ```
 
 ## Core Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ addopts = [
     "--strict-markers",
     "-v",
 ]
+# Note: --cov-fail-under=85 is enforced in CI only (not here)
+# Reason: pyproject.toml addopts apply to ALL pytest runs including:
+#   - Subset test runs: pytest tests/unit/core/
+#   - TDD cycles: pytest tests/test_specific.py
+#   - Debugging: pytest -k "test_case"
+# These can't meet full-suite coverage thresholds.
+# Coverage threshold belongs at release gate (CI), not tool defaults.
 asyncio_mode = "auto"
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`) with three jobs: lint, typecheck, test
- Python 3.11 + 3.12 matrix across all jobs using `uv` for dependency management
- Coverage threshold enforced at 85% in CI (current: 89%)
- Final gate job ensures all required jobs pass before merge
- Document CI pipeline, coverage threshold, and test markers in CLAUDE.md
- Add CI-only coverage threshold rationale comment to pyproject.toml

## Details

### CI Jobs

| Job | Tools | Matrix |
|-----|-------|--------|
| lint | `ruff check` + `black --check` | 3.11, 3.12 |
| typecheck | `mypy src` | 3.11, 3.12 |
| test | `pytest --cov-fail-under=85` | 3.11, 3.12 |
| final_gate | Aggregates all job results | - |

### Already in place (no changes needed)

- pytest markers: `smoke`, `unit`, `behavior`, `contract`, `integration` (already registered in pyproject.toml)
- Strict markers mode (already configured)
- 11 smoke tests already marked in `tests/test_server.py`
- conftest.py with shared fixtures

### Design decisions

- **85% threshold** (not 89%): Leaves headroom for new code without immediately breaking CI. Current coverage is 89%.
- **`uv` over `pip`**: Matches the project's package manager (uv.lock present).
- **No preflight/docs/artifact jobs**: Simpler project than legacy monolith. Can add later as needed.
- **Coverage in CI only**: Coverage threshold in pyproject.toml addopts would break subset test runs and TDD cycles.

## Test plan

- [x] All 361 tests pass locally
- [x] `ruff check src tests` passes
- [x] `black --check src tests` passes
- [x] `mypy src` passes
- [x] `pytest --cov-fail-under=85` passes (89% > 85%)
- [x] `pytest -m smoke --no-cov` correctly selects 11 smoke tests
- [ ] CI workflow runs successfully on this PR (will verify after creation)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up GitHub Actions CI to run lint, type checks, and tests on Python 3.11 and 3.12 using `uv`, with an 85% coverage gate and a final merge gate. Hardened the workflow and updated docs with a CI badge and accurate test info.

- **New Features**
  - Add `.github/workflows/ci.yml` with jobs: lint (`ruff` + `black`), typecheck (`mypy`), test (`pytest --cov-fail-under=85`) on 3.11/3.12 via `uv`.
  - Add `final_gate` job that blocks merge unless all jobs pass.
  - Update docs with CI badge and pipeline details; note in `pyproject.toml` that the coverage threshold is CI-only.

- **Bug Fixes**
  - Set `permissions: contents: read` for least-privilege `GITHUB_TOKEN`.
  - Do not cancel in-progress runs on `main`.
  - Pin Python via `astral-sh/setup-uv` `python-version` (instead of `uv sync --python`) to fix 3.12 job failures and ensure correct interpreter selection.
  - Enable `uv` cache for faster, reliable installs.
  - Fix smoke test count in `CLAUDE.md`.

<sup>Written for commit 300ce55bec6cf18faaeb40c357fa17bbebb69c93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated CI/CD pipeline with linting, type checking, and testing.
  * Added code coverage enforcement at 85% threshold in CI.
  * Added CI status badge and updated testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->