### PR TITLE
feat: add ai_synthesis field and normalise phase string

### DIFF
--- a/src/hestai_context_mcp/core/phase.py
+++ b/src/hestai_context_mcp/core/phase.py
@@ -67,7 +67,9 @@ def _read_first_north_star_phase(working_dir: Path) -> str | None:
     for candidate in sorted(ns_dir.glob("*.oct.md")):
         try:
             content = candidate.read_text()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            # UnicodeDecodeError is a ValueError subclass raised when the
+            # file bytes are not valid UTF-8. Treat as absent and fall back.
             continue
         phase = _extract_phase_from_content(content)
         if phase:
@@ -82,7 +84,7 @@ def _read_project_context_phase(working_dir: Path) -> str | None:
         return None
     try:
         content = path.read_text()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     return _extract_phase_from_content(content)
 

--- a/src/hestai_context_mcp/core/phase.py
+++ b/src/hestai_context_mcp/core/phase.py
@@ -1,0 +1,119 @@
+"""Phase resolver — extract the declared full phase identifier.
+
+Reads ``PHASE::<FULL_FORM>`` from the project's North Star summary or the
+``PROJECT-CONTEXT.oct.md`` file. Returns the full form (e.g.
+``B1_FOUNDATION_COMPLETE``) rather than the bare prefix ``B1``. The bare
+prefix is still available via :func:`phase_prefix` for callers (such as
+:class:`ContextSteward`) that key off prefix markers in workflow documents.
+
+Issue #4 acceptance criterion 2: Payload Compiler shape-parity requires the
+legacy full-form phase string.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Default when no declaration can be found. Matches the current repo state
+# per .hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md and
+# .hestai/state/context/PROJECT-CONTEXT.oct.md. Callers may override.
+DEFAULT_PHASE: str = "B1_FOUNDATION_COMPLETE"
+
+
+def phase_prefix(phase: str) -> str:
+    """Return the leading prefix of a phase identifier.
+
+    ``"B1_FOUNDATION_COMPLETE"`` → ``"B1"``; ``"B1"`` → ``"B1"``. Used by
+    consumers that need the workflow-document marker (e.g. ``B1_BUILD_PLAN``)
+    rather than the full declared phase.
+
+    Args:
+        phase: Full or bare phase identifier.
+
+    Returns:
+        Prefix up to the first underscore.
+    """
+    if "_" in phase:
+        return phase.split("_", 1)[0]
+    return phase
+
+
+def _extract_phase_from_content(content: str) -> str | None:
+    """Extract the first ``PHASE::<value>`` declaration from OCTAVE text.
+
+    Args:
+        content: File contents.
+
+    Returns:
+        The trimmed phase value, or ``None`` if no well-formed declaration
+        exists.
+    """
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("PHASE::"):
+            continue
+        value = line.split("::", 1)[1].strip()
+        if value:
+            return value
+    return None
+
+
+def _read_first_north_star_phase(working_dir: Path) -> str | None:
+    """Read the phase declaration from the first North Star summary file."""
+    ns_dir = working_dir / ".hestai" / "north-star"
+    if not ns_dir.is_dir():
+        return None
+    # Deterministic ordering so precedence is stable across platforms.
+    for candidate in sorted(ns_dir.glob("*.oct.md")):
+        try:
+            content = candidate.read_text()
+        except OSError:
+            continue
+        phase = _extract_phase_from_content(content)
+        if phase:
+            return phase
+    return None
+
+
+def _read_project_context_phase(working_dir: Path) -> str | None:
+    """Read the phase declaration from ``PROJECT-CONTEXT.oct.md``."""
+    path = working_dir / ".hestai" / "state" / "context" / "PROJECT-CONTEXT.oct.md"
+    if not path.is_file():
+        return None
+    try:
+        content = path.read_text()
+    except OSError:
+        return None
+    return _extract_phase_from_content(content)
+
+
+def resolve_phase(working_dir: Path, *, default: str = DEFAULT_PHASE) -> str:
+    """Resolve the full declared phase identifier for ``working_dir``.
+
+    Precedence:
+        1. First ``.oct.md`` file under ``.hestai/north-star/`` with a
+           ``PHASE::`` declaration.
+        2. ``.hestai/state/context/PROJECT-CONTEXT.oct.md``.
+        3. ``default``.
+
+    The function is a pure read — no side effects — so it is safe for use
+    from ``get_context`` (PROD::I5 READ_ONLY_CONTEXT_QUERY).
+
+    Args:
+        working_dir: Project root.
+        default: Value to return when no declaration is found.
+
+    Returns:
+        Full-form phase identifier (never the bare ``"B1"`` abbreviation
+        unless the source file declares it that way).
+    """
+    phase = _read_first_north_star_phase(working_dir)
+    if phase:
+        return phase
+    phase = _read_project_context_phase(working_dir)
+    if phase:
+        return phase
+    return default
+
+
+__all__: list[str] = ["DEFAULT_PHASE", "phase_prefix", "resolve_phase"]

--- a/src/hestai_context_mcp/core/synthesis.py
+++ b/src/hestai_context_mcp/core/synthesis.py
@@ -1,0 +1,181 @@
+"""AI synthesis seam (provider-agnostic).
+
+This module provides the boundary at which ``clock_in`` attempts AI-backed
+context synthesis. The boundary is deliberately a module-level function with
+no provider SDK imports — honouring PROD::I3 (PROVIDER_AGNOSTIC_CONTEXT) and
+PROD::I6 (LEGACY_INDEPENDENCE).
+
+Issue #4 lands the seam with a *fallback-only* implementation. The real
+provider wiring (AIClient port) is deferred to issue #5. Consumers obtain a
+deterministic, structured fallback when no provider is available; they never
+see a missing ``ai_synthesis`` field in the ``clock_in`` response
+(PROD::I4 STRUCTURED_RETURN_SHAPES).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+# Valid values for the ``source`` discriminator. Anything else must be
+# rejected by :func:`resolve_ai_synthesis` to keep the response dict shape
+# stable for the Payload Compiler (PROD::I4).
+_VALID_SOURCES: frozenset[str] = frozenset({"ai", "fallback"})
+
+
+class AiSynthesisResult(TypedDict):
+    """Structured shape of the ``ai_synthesis`` response field.
+
+    Keys:
+        source:    ``"ai"`` when a provider produced the synthesis,
+                   ``"fallback"`` when the deterministic template was used.
+        synthesis: OCTAVE-formatted string consumable by the Payload Compiler
+                   at KVAEPH Position 3 (ADR-0353).
+    """
+
+    source: str
+    synthesis: str
+
+
+def synthesize_ai_context(
+    *,
+    role: str,
+    focus: str,
+    phase: str,
+    context_summary: str,
+) -> AiSynthesisResult | None:
+    """Attempt AI-backed synthesis of the clock-in context.
+
+    This is the provider-agnostic seam for issue #5. In this PR, the function
+    intentionally returns ``None`` because no AI provider is wired. Tests that
+    need the ``source == "ai"`` path monkeypatch this symbol.
+
+    Args:
+        role: Agent role name.
+        focus: Resolved focus string.
+        phase: Full phase identifier (e.g. ``"B1_FOUNDATION_COMPLETE"``).
+        context_summary: Pre-built context summary for the AI to synthesise.
+
+    Returns:
+        :class:`AiSynthesisResult` when a provider successfully synthesises,
+        otherwise ``None``. In this PR, always ``None``.
+    """
+    # Parameters are part of the stable seam signature consumed by issue #5.
+    _ = (role, focus, phase, context_summary)
+    return None
+
+
+def build_fallback_synthesis(
+    *,
+    role: str,
+    focus: str,
+    phase: str,
+) -> AiSynthesisResult:
+    """Construct the deterministic OCTAVE fallback synthesis.
+
+    Matches the legacy ``CLOCK_IN_SYNTHESIS_PROTOCOL`` shape so the Payload
+    Compiler can read it identically to a legacy response. Returned whenever
+    :func:`synthesize_ai_context` returns ``None`` or raises.
+
+    Args:
+        role: Agent role name.
+        focus: Resolved focus string.
+        phase: Full phase identifier.
+
+    Returns:
+        :class:`AiSynthesisResult` with ``source == "fallback"``.
+    """
+    synthesis = (
+        "CONTEXT_FILES::[@.hestai/state/context/PROJECT-CONTEXT.oct.md, "
+        "@.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md]\n"
+        f"FOCUS::{focus}\n"
+        f"PHASE::{phase}\n"
+        "BLOCKERS::[]\n"
+        f"TASKS::[Review context for {role}, Complete {focus} objectives]\n"
+        "FRESHNESS_WARNING::AI_SYNTHESIS_UNAVAILABLE"
+    )
+    return {"source": "fallback", "synthesis": synthesis}
+
+
+def resolve_ai_synthesis(
+    *,
+    role: str,
+    focus: str,
+    phase: str,
+    context_summary: str,
+) -> AiSynthesisResult:
+    """Return an :class:`AiSynthesisResult`; never ``None``.
+
+    Calls :func:`synthesize_ai_context`; if it returns ``None`` or raises,
+    constructs the deterministic fallback. This is the single entry point
+    callers should use to guarantee PROD::I4 structured shape.
+
+    Args:
+        role: Agent role name.
+        focus: Resolved focus string.
+        phase: Full phase identifier.
+        context_summary: Pre-built context summary (passed through to seam).
+
+    Returns:
+        Always a populated :class:`AiSynthesisResult`.
+    """
+    # Look up the seam via module attribute so monkeypatched replacements
+    # (in tests and issue #5 wiring) are honoured.
+    from hestai_context_mcp.core import synthesis as _mod
+
+    try:
+        result = _mod.synthesize_ai_context(
+            role=role,
+            focus=focus,
+            phase=phase,
+            context_summary=context_summary,
+        )
+    except Exception as exc:  # noqa: BLE001 — seam must be total; fall back on any failure.
+        # Observable degradation — log at warning so issue #5 provider failures
+        # surface in the logs rather than silently collapsing to fallback.
+        logger.warning(
+            "AI synthesis seam raised %s; falling back to deterministic template.",
+            exc.__class__.__name__,
+        )
+        result = None
+
+    if result is None:
+        return build_fallback_synthesis(role=role, focus=focus, phase=phase)
+
+    if not _is_valid_result(result):
+        logger.warning(
+            "AI synthesis seam returned malformed payload %r; falling back.",
+            result,
+        )
+        return build_fallback_synthesis(role=role, focus=focus, phase=phase)
+
+    return result
+
+
+def _is_valid_result(result: object) -> bool:
+    """Strict structural validation of the seam's return value.
+
+    Guards against future provider-port bugs silently leaking malformed
+    payloads (e.g. ``{"source": None, "synthesis": []}``) into the
+    ``clock_in`` response. Checks presence, types, non-emptiness, and
+    source-discriminator membership.
+    """
+    if not isinstance(result, dict):
+        return False
+    if "source" not in result or "synthesis" not in result:
+        return False
+    source = result["source"]
+    synthesis = result["synthesis"]
+    if not isinstance(source, str) or source not in _VALID_SOURCES:
+        return False
+    return isinstance(synthesis, str) and bool(synthesis.strip())
+
+
+__all__: list[str] = [
+    "AiSynthesisResult",
+    "build_fallback_synthesis",
+    "resolve_ai_synthesis",
+    "synthesize_ai_context",
+]

--- a/src/hestai_context_mcp/core/synthesis.py
+++ b/src/hestai_context_mcp/core/synthesis.py
@@ -67,6 +67,33 @@ def synthesize_ai_context(
     return None
 
 
+def _sanitise_single_line(value: str) -> str:
+    """Collapse line-breaking and control characters to prevent OCTAVE injection.
+
+    Defensive against malicious or accidental inputs containing ``\\n``,
+    ``\\r``, or other line-breaking characters that would otherwise let the
+    caller synthesise additional protocol fields (e.g. a focus value of
+    ``"bug\\nBLOCKERS::[pwned]"``).
+
+    Replaces with a single space:
+      * C0 controls (``\\x00``-``\\x1F``) — includes ``\\n``, ``\\r``, ``\\t``.
+      * DEL (``\\x7F``).
+      * C1 controls (``\\x80``-``\\x9F``) — includes NEL ``\\x85``.
+      * Unicode line separators ``\\u2028`` and paragraph separators ``\\u2029``.
+    These together form the full set on which Python's ``str.splitlines()``
+    splits, so the sanitised value is guaranteed to be a single line for
+    any downstream parser that uses ``splitlines`` semantics. Non-ASCII
+    printable characters (e.g. Latin-1 Supplement from ``\\u00A0``) are
+    preserved; the filter is not over-aggressive against international text.
+    """
+    if not isinstance(value, str):  # defence-in-depth; typing says str
+        return ""
+    return "".join(
+        " " if (cp < 0x20 or cp == 0x7F or 0x80 <= cp <= 0x9F or cp in (0x2028, 0x2029)) else c
+        for c, cp in ((c, ord(c)) for c in value)
+    ).strip()
+
+
 def build_fallback_synthesis(
     *,
     role: str,
@@ -79,6 +106,9 @@ def build_fallback_synthesis(
     Compiler can read it identically to a legacy response. Returned whenever
     :func:`synthesize_ai_context` returns ``None`` or raises.
 
+    All interpolated values are sanitised to a single line so a crafted
+    ``focus`` / ``role`` / ``phase`` cannot inject synthetic OCTAVE fields.
+
     Args:
         role: Agent role name.
         focus: Resolved focus string.
@@ -87,13 +117,16 @@ def build_fallback_synthesis(
     Returns:
         :class:`AiSynthesisResult` with ``source == "fallback"``.
     """
+    safe_role = _sanitise_single_line(role)
+    safe_focus = _sanitise_single_line(focus)
+    safe_phase = _sanitise_single_line(phase)
     synthesis = (
         "CONTEXT_FILES::[@.hestai/state/context/PROJECT-CONTEXT.oct.md, "
         "@.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md]\n"
-        f"FOCUS::{focus}\n"
-        f"PHASE::{phase}\n"
+        f"FOCUS::{safe_focus}\n"
+        f"PHASE::{safe_phase}\n"
         "BLOCKERS::[]\n"
-        f"TASKS::[Review context for {role}, Complete {focus} objectives]\n"
+        f"TASKS::[Review context for {safe_role}, Complete {safe_focus} objectives]\n"
         "FRESHNESS_WARNING::AI_SYNTHESIS_UNAVAILABLE"
     )
     return {"source": "fallback", "synthesis": synthesis}

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -15,7 +15,9 @@ from hestai_context_mcp.core.git_state import (
     get_current_branch,
     get_git_state,
 )
+from hestai_context_mcp.core.phase import phase_prefix, resolve_phase
 from hestai_context_mcp.core.session import SessionManager
+from hestai_context_mcp.core.synthesis import resolve_ai_synthesis
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +161,13 @@ def clock_in(
             "modified_files": [],
         }
 
-    # Phase constraints (graceful fallback)
+    # Resolve the declared full-form phase (e.g. "B1_FOUNDATION_COMPLETE").
+    # Full form is the Payload Compiler shape-parity contract (issue #4).
+    phase = resolve_phase(working_dir_path)
+
+    # Phase constraints (graceful fallback). The workflow document uses
+    # prefix markers (B1_BUILD_PLAN, etc.), so pass the prefix — not the
+    # full form — to ContextSteward.
     phase_constraints = None
     try:
         # Look for workflow files in common locations
@@ -173,11 +181,26 @@ def clock_in(
         ]:
             if workflow_candidate.exists():
                 steward = ContextSteward(workflow_path=workflow_candidate)
-                constraints = steward.synthesize_active_state("B1")
+                constraints = steward.synthesize_active_state(phase_prefix(phase))
                 phase_constraints = constraints.to_dict()
                 break
     except (FileNotFoundError, ValueError) as e:
         logger.debug(f"Phase constraints not available: {e}")
+
+    # Build AI synthesis via the provider-agnostic seam (issue #5 replaces
+    # the body of synthesize_ai_context with a real provider call). The
+    # ai_synthesis field is ALWAYS present per PROD::I4 STRUCTURED_RETURN_SHAPES.
+    context_summary = _build_context_summary(
+        product_north_star=product_north_star,
+        project_context=project_context,
+        git_state=git_state,
+    )
+    ai_synthesis = resolve_ai_synthesis(
+        role=role,
+        focus=focus_resolved["value"],
+        phase=phase,
+        context_summary=context_summary,
+    )
 
     return {
         "session_id": session_id,
@@ -186,7 +209,9 @@ def clock_in(
         "focus_source": focus_resolved["source"],
         "branch": branch,
         "working_dir": str(working_dir_path),
+        "phase": phase,
         "context_paths": context_paths,
+        "ai_synthesis": ai_synthesis,
         "context": {
             "product_north_star": product_north_star,
             "project_context": project_context,
@@ -195,3 +220,23 @@ def clock_in(
             "active_sessions": active_sessions,
         },
     }
+
+
+def _build_context_summary(
+    *,
+    product_north_star: str | None,
+    project_context: str | None,
+    git_state: dict[str, Any],
+) -> str:
+    """Assemble a lightweight context summary for the AI synthesis seam.
+
+    Kept simple in this PR; issue #5 may extend with richer signals. No
+    provider-specific formatting is applied here (PROD::I3).
+    """
+    parts: list[str] = []
+    if product_north_star:
+        parts.append(f"NORTH_STAR::\n{product_north_star}")
+    if project_context:
+        parts.append(f"PROJECT_CONTEXT::\n{project_context}")
+    parts.append(f"GIT_STATE::{git_state}")
+    return "\n\n".join(parts)

--- a/tests/tools/test_clock_in.py
+++ b/tests/tools/test_clock_in.py
@@ -151,14 +151,81 @@ class TestClockInReturnShape:
         assert result["context"]["project_context"] == ctx_content
 
     @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
-    def test_ai_synthesis_is_null(self, mock_branch, tmp_path):
-        """AI synthesis is not included (deferred per spec)."""
+    def test_ai_synthesis_always_present_as_structured_dict(self, mock_branch, tmp_path):
+        """ai_synthesis is ALWAYS in the response (PROD::I4 structured shape).
+
+        Issue #4: ai_synthesis must never be absent. With no provider wired,
+        the fallback dict must still be returned with {source, synthesis}.
+        """
         result = clock_in(
             role="test-role",
             working_dir=str(tmp_path),
         )
-        # ai_synthesis should not be in the response at all, or be None
-        assert result.get("ai_synthesis") is None
+        assert "ai_synthesis" in result
+        ai_syn = result["ai_synthesis"]
+        assert isinstance(ai_syn, dict)
+        assert set(ai_syn.keys()) == {"source", "synthesis"}
+        assert ai_syn["source"] == "fallback"
+        assert isinstance(ai_syn["synthesis"], str)
+        assert len(ai_syn["synthesis"]) > 0
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_ai_synthesis_fallback_synthesis_is_octave_template(self, mock_branch, tmp_path):
+        """Fallback synthesis string follows the OCTAVE template shape."""
+        result = clock_in(
+            role="test-role",
+            working_dir=str(tmp_path),
+            focus="explicit-focus",
+        )
+        synthesis_str = result["ai_synthesis"]["synthesis"]
+        # OCTAVE template contract: contains key::value lines per legacy reference
+        assert "FOCUS::" in synthesis_str
+        assert "PHASE::" in synthesis_str
+        assert "CONTEXT_FILES::" in synthesis_str
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_ai_synthesis_ai_seam_returns_source_ai(self, mock_branch, tmp_path, monkeypatch):
+        """When the AI seam returns a synthesis dict, response carries source:'ai'.
+
+        Issue #4: AI-success path is wired in #5; this test proves the seam exists
+        and is honoured. No provider SDK is imported here — we monkeypatch the seam
+        function directly.
+        """
+        from hestai_context_mcp.core import synthesis as synthesis_mod
+
+        def fake_ai_synthesis(**_kwargs):
+            return {"source": "ai", "synthesis": "PHASE::B1_FOUNDATION_COMPLETE\nFOCUS::mocked"}
+
+        monkeypatch.setattr(synthesis_mod, "synthesize_ai_context", fake_ai_synthesis)
+
+        result = clock_in(
+            role="test-role",
+            working_dir=str(tmp_path),
+        )
+        assert result["ai_synthesis"]["source"] == "ai"
+        assert "mocked" in result["ai_synthesis"]["synthesis"]
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_phase_string_is_full_form_not_abbreviated(self, mock_branch, tmp_path):
+        """Phase string returned is the full declared form (e.g. B1_FOUNDATION_COMPLETE).
+
+        Issue #4 acceptance criterion 2: legacy returns full phase strings, new
+        server must too. The bare 'B1' form would break the Payload Compiler
+        shape-parity gate.
+        """
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-TEST-NORTH-STAR-SUMMARY.oct.md").write_text(
+            "===NORTH_STAR===\nPHASE::B1_FOUNDATION_COMPLETE\n===END==="
+        )
+
+        result = clock_in(
+            role="test-role",
+            working_dir=str(tmp_path),
+        )
+        assert result["phase"] == "B1_FOUNDATION_COMPLETE"
+        # Must NOT be the bare abbreviation
+        assert result["phase"] != "B1"
 
 
 class TestClockInValidation:

--- a/tests/unit/core/test_phase.py
+++ b/tests/unit/core/test_phase.py
@@ -1,0 +1,73 @@
+"""Tests for the phase resolver (``hestai_context_mcp.core.phase``).
+
+Resolves the full declared phase string (e.g. ``B1_FOUNDATION_COMPLETE``)
+from North Star / PROJECT-CONTEXT files. Issue #4 acceptance criterion 2:
+phase string must match legacy's full form, not the bare abbreviation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hestai_context_mcp.core.phase import (
+    DEFAULT_PHASE,
+    phase_prefix,
+    resolve_phase,
+)
+
+
+class TestPhasePrefix:
+    def test_prefix_of_full_form(self):
+        assert phase_prefix("B1_FOUNDATION_COMPLETE") == "B1"
+
+    def test_prefix_of_bare_form(self):
+        assert phase_prefix("B1") == "B1"
+
+    def test_prefix_of_unknown(self):
+        # Unknown phase string → best-effort underscore split.
+        assert phase_prefix("XX_WHATEVER") == "XX"
+
+
+class TestResolvePhase:
+    def test_reads_from_north_star_summary(self, tmp_path: Path):
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-TEST-NORTH-STAR-SUMMARY.oct.md").write_text(
+            "===NORTH_STAR===\nPHASE::B1_FOUNDATION_COMPLETE\n===END==="
+        )
+        assert resolve_phase(tmp_path) == "B1_FOUNDATION_COMPLETE"
+
+    def test_reads_from_project_context_when_no_north_star(self, tmp_path: Path):
+        ctx_dir = tmp_path / ".hestai" / "state" / "context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "PROJECT-CONTEXT.oct.md").write_text(
+            "===PROJECT_CONTEXT===\nMETA:\n  PHASE::D2_DESIGN_REVIEW\n===END==="
+        )
+        assert resolve_phase(tmp_path) == "D2_DESIGN_REVIEW"
+
+    def test_north_star_takes_precedence_over_project_context(self, tmp_path: Path):
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-TEST-NORTH-STAR-SUMMARY.oct.md").write_text("PHASE::B2_INTEGRATION")
+        ctx_dir = tmp_path / ".hestai" / "state" / "context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "PROJECT-CONTEXT.oct.md").write_text("PHASE::D0_STALE")
+        assert resolve_phase(tmp_path) == "B2_INTEGRATION"
+
+    def test_returns_default_when_no_files(self, tmp_path: Path):
+        assert resolve_phase(tmp_path) == DEFAULT_PHASE
+
+    def test_ignores_malformed_phase_line(self, tmp_path: Path):
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        # PHASE marker with no value → skip, fall through to default.
+        (ns_dir / "000-TEST-NORTH-STAR-SUMMARY.oct.md").write_text("PHASE::\n")
+        assert resolve_phase(tmp_path) == DEFAULT_PHASE
+
+    def test_trims_whitespace_and_inline_comments(self, tmp_path: Path):
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-TEST-NORTH-STAR-SUMMARY.oct.md").write_text(
+            "  PHASE::  B1_FOUNDATION_COMPLETE  \n"
+        )
+        assert resolve_phase(tmp_path) == "B1_FOUNDATION_COMPLETE"

--- a/tests/unit/core/test_phase.py
+++ b/tests/unit/core/test_phase.py
@@ -71,3 +71,37 @@ class TestResolvePhase:
             "  PHASE::  B1_FOUNDATION_COMPLETE  \n"
         )
         assert resolve_phase(tmp_path) == "B1_FOUNDATION_COMPLETE"
+
+    def test_non_utf8_north_star_does_not_abort_resolution(self, tmp_path: Path):
+        """A non-decodable North Star file must not raise; resolver falls through.
+
+        Defensive: ``Path.read_text`` raises ``UnicodeDecodeError`` (a
+        ``ValueError`` subclass) rather than ``OSError`` when the bytes are
+        not valid UTF-8. The original ``except OSError`` would have let this
+        abort the whole resolution.
+        """
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        bad = ns_dir / "000-BAD-ENCODING-SUMMARY.oct.md"
+        # 0xFF is invalid as the first byte of any UTF-8 sequence.
+        bad.write_bytes(b"\xff\xfe\xffPHASE::SHOULD_NOT_BE_READ")
+        # With the broken file and no PROJECT-CONTEXT we must degrade to the
+        # default rather than raise.
+        assert resolve_phase(tmp_path) == DEFAULT_PHASE
+
+    def test_non_utf8_north_star_falls_through_to_project_context(self, tmp_path: Path):
+        """If the North Star cannot decode, PROJECT-CONTEXT is still consulted."""
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-BAD-SUMMARY.oct.md").write_bytes(b"\xff\xfe")
+        ctx_dir = tmp_path / ".hestai" / "state" / "context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "PROJECT-CONTEXT.oct.md").write_text("PHASE::D3_PROTOTYPE")
+        assert resolve_phase(tmp_path) == "D3_PROTOTYPE"
+
+    def test_non_utf8_project_context_does_not_abort_resolution(self, tmp_path: Path):
+        """A non-decodable PROJECT-CONTEXT must not raise."""
+        ctx_dir = tmp_path / ".hestai" / "state" / "context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "PROJECT-CONTEXT.oct.md").write_bytes(b"\xff\xfe\xff")
+        assert resolve_phase(tmp_path) == DEFAULT_PHASE

--- a/tests/unit/core/test_synthesis.py
+++ b/tests/unit/core/test_synthesis.py
@@ -1,0 +1,219 @@
+"""Tests for the AI synthesis seam (``hestai_context_mcp.core.synthesis``).
+
+The seam is provider-agnostic (PROD::I3): the module never imports any AI
+SDK. Issue #4 lands the seam with a fallback-only implementation; issue #5
+replaces ``synthesize_ai_context`` with a real provider call. These tests
+lock the structural contract so that replacement cannot regress shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hestai_context_mcp.core import synthesis as synthesis_mod
+from hestai_context_mcp.core.synthesis import (
+    AiSynthesisResult,
+    build_fallback_synthesis,
+    resolve_ai_synthesis,
+    synthesize_ai_context,
+)
+
+
+class TestSynthesizeAiContextDefault:
+    """``synthesize_ai_context`` is the seam for issue #5; default returns None."""
+
+    def test_default_returns_none(self):
+        """No provider wired yet → returns None (issue #5 replaces the body)."""
+        assert (
+            synthesize_ai_context(
+                role="test-role",
+                focus="test-focus",
+                phase="B1_FOUNDATION_COMPLETE",
+                context_summary="",
+            )
+            is None
+        )
+
+
+class TestBuildFallbackSynthesis:
+    """Fallback synthesis must match the OCTAVE contract shape."""
+
+    def test_returns_structured_dict(self):
+        result = build_fallback_synthesis(
+            role="implementation-lead",
+            focus="fix-thing",
+            phase="B1_FOUNDATION_COMPLETE",
+        )
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"source", "synthesis"}
+        assert result["source"] == "fallback"
+        assert isinstance(result["synthesis"], str)
+
+    def test_synthesis_contains_octave_markers(self):
+        result = build_fallback_synthesis(
+            role="test-role",
+            focus="some-focus",
+            phase="B1_FOUNDATION_COMPLETE",
+        )
+        s = result["synthesis"]
+        assert "CONTEXT_FILES::" in s
+        assert "FOCUS::some-focus" in s
+        assert "PHASE::B1_FOUNDATION_COMPLETE" in s
+        assert "BLOCKERS::" in s
+        assert "TASKS::" in s
+        assert "FRESHNESS_WARNING::" in s
+
+
+class TestResolveAiSynthesis:
+    """``resolve_ai_synthesis`` must ALWAYS return a populated result."""
+
+    def test_falls_back_when_seam_returns_none(self, monkeypatch):
+        monkeypatch.setattr(synthesis_mod, "synthesize_ai_context", lambda **_: None)
+        result = resolve_ai_synthesis(
+            role="r",
+            focus="f",
+            phase="B1_FOUNDATION_COMPLETE",
+            context_summary="",
+        )
+        assert result["source"] == "fallback"
+        assert "PHASE::B1_FOUNDATION_COMPLETE" in result["synthesis"]
+
+    def test_returns_ai_result_when_seam_succeeds(self, monkeypatch):
+        expected: AiSynthesisResult = {
+            "source": "ai",
+            "synthesis": "PHASE::B1_FOUNDATION_COMPLETE\nFOCUS::from-ai",
+        }
+        monkeypatch.setattr(
+            synthesis_mod,
+            "synthesize_ai_context",
+            lambda **_: expected,
+        )
+        result = resolve_ai_synthesis(
+            role="r",
+            focus="f",
+            phase="B1_FOUNDATION_COMPLETE",
+            context_summary="",
+        )
+        assert result == expected
+
+    def test_falls_back_when_seam_raises(self, monkeypatch):
+        def raiser(**_):
+            raise RuntimeError("provider offline")
+
+        monkeypatch.setattr(synthesis_mod, "synthesize_ai_context", raiser)
+        result = resolve_ai_synthesis(
+            role="r",
+            focus="f",
+            phase="B1_FOUNDATION_COMPLETE",
+            context_summary="",
+        )
+        assert result["source"] == "fallback"
+
+    def test_falls_back_when_seam_returns_malformed_dict(self, monkeypatch):
+        """Defensive: malformed dict from a future seam must not leak to caller."""
+        monkeypatch.setattr(
+            synthesis_mod,
+            "synthesize_ai_context",
+            lambda **_: {"wrong_key": "oops"},
+        )
+        result = resolve_ai_synthesis(
+            role="r",
+            focus="f",
+            phase="B1_FOUNDATION_COMPLETE",
+            context_summary="",
+        )
+        assert result["source"] == "fallback"
+
+    @pytest.mark.parametrize(
+        "bad_payload",
+        [
+            {"source": None, "synthesis": "text"},
+            {"source": "ai", "synthesis": None},
+            {"source": "ai", "synthesis": []},
+            {"source": "ai", "synthesis": ""},
+            {"source": "ai", "synthesis": "   "},
+            {"source": "unknown", "synthesis": "text"},
+            {"source": 42, "synthesis": "text"},
+            ["source", "synthesis"],  # wrong container type entirely
+            "source::synthesis",  # bare string
+            42,  # bare scalar
+        ],
+        ids=[
+            "source-is-None",
+            "synthesis-is-None",
+            "synthesis-is-list",
+            "synthesis-is-empty-string",
+            "synthesis-is-whitespace",
+            "source-not-in-enum",
+            "source-is-int",
+            "result-is-list",
+            "result-is-str",
+            "result-is-int",
+        ],
+    )
+    def test_falls_back_on_value_type_violations(self, monkeypatch, bad_payload):
+        """CE gate: strict validation of value types, not just key presence.
+
+        A future AIClient (issue #5) returning malformed values (wrong types,
+        empty strings, or off-enum ``source`` values) must degrade to the
+        deterministic fallback, not leak a broken shape to the Payload
+        Compiler.
+        """
+        monkeypatch.setattr(
+            synthesis_mod,
+            "synthesize_ai_context",
+            lambda **_: bad_payload,
+        )
+        result = resolve_ai_synthesis(
+            role="r",
+            focus="f",
+            phase="B1_FOUNDATION_COMPLETE",
+            context_summary="",
+        )
+        assert result["source"] == "fallback"
+        assert isinstance(result["synthesis"], str)
+        assert result["synthesis"].strip()
+
+    def test_warns_on_seam_exception(self, monkeypatch, caplog):
+        """Observability: seam exceptions must surface in logs (CE Q3)."""
+
+        def raiser(**_):
+            raise RuntimeError("provider timeout")
+
+        monkeypatch.setattr(synthesis_mod, "synthesize_ai_context", raiser)
+        with caplog.at_level("WARNING", logger="hestai_context_mcp.core.synthesis"):
+            resolve_ai_synthesis(
+                role="r",
+                focus="f",
+                phase="B1_FOUNDATION_COMPLETE",
+                context_summary="",
+            )
+        assert any("AI synthesis seam raised" in rec.message for rec in caplog.records)
+
+    def test_warns_on_seam_malformed_result(self, monkeypatch, caplog):
+        """Observability: malformed seam payloads must surface in logs."""
+        monkeypatch.setattr(
+            synthesis_mod,
+            "synthesize_ai_context",
+            lambda **_: {"source": "ai", "synthesis": ""},
+        )
+        with caplog.at_level("WARNING", logger="hestai_context_mcp.core.synthesis"):
+            resolve_ai_synthesis(
+                role="r",
+                focus="f",
+                phase="B1_FOUNDATION_COMPLETE",
+                context_summary="",
+            )
+        assert any("malformed payload" in rec.message for rec in caplog.records)
+
+
+class TestProviderAgnosticImports:
+    """PROD::I3 guard: the seam module must not import any AI provider SDK."""
+
+    def test_no_provider_sdk_imports(self):
+        import hestai_context_mcp.core.synthesis as mod
+
+        source = pytest.importorskip("inspect").getsource(mod)
+        forbidden = ("import anthropic", "import openai", "openrouter", "from openai")
+        for token in forbidden:
+            assert token not in source, f"PROD::I3 violation: found {token!r} in synthesis.py"

--- a/tests/unit/core/test_synthesis.py
+++ b/tests/unit/core/test_synthesis.py
@@ -63,6 +63,89 @@ class TestBuildFallbackSynthesis:
         assert "TASKS::" in s
         assert "FRESHNESS_WARNING::" in s
 
+    def test_injected_newline_in_focus_cannot_add_synthetic_field(self):
+        """Defensive: a focus containing a newline must not inject an OCTAVE line.
+
+        Without sanitisation, ``focus="bug\\nBLOCKERS::[pwned]"`` would cause
+        the template to emit a second BLOCKERS:: line, letting an attacker
+        override protocol fields consumed by the Payload Compiler.
+        """
+        result = build_fallback_synthesis(
+            role="r",
+            focus="bug\nBLOCKERS::[pwned]",
+            phase="B1_FOUNDATION_COMPLETE",
+        )
+        synthesis = result["synthesis"]
+        lines = synthesis.splitlines()
+        # Exactly one line must START with BLOCKERS:: — no injected protocol
+        # line from the focus value. (Substring occurrences are acceptable
+        # inside other field values such as TASKS, as long as they cannot
+        # be parsed as a standalone OCTAVE field.)
+        blockers_lines = [ln for ln in lines if ln.startswith("BLOCKERS::")]
+        assert len(blockers_lines) == 1
+        assert blockers_lines[0] == "BLOCKERS::[]"
+        # The FOCUS line must remain a single line (no embedded newline).
+        focus_lines = [ln for ln in lines if ln.startswith("FOCUS::")]
+        assert len(focus_lines) == 1
+        assert "\n" not in focus_lines[0]
+
+    @pytest.mark.parametrize(
+        "separator",
+        ["\n", "\r", "\r\n", "\x85", "\u2028", "\u2029"],
+        ids=["LF", "CR", "CRLF", "NEL", "LINE_SEP", "PARA_SEP"],
+    )
+    def test_all_line_breaking_chars_are_neutralised(self, separator):
+        """All characters on which ``str.splitlines()`` splits must be stripped.
+
+        Covers the full Unicode line-breaking set (C0, C1 NEL, U+2028, U+2029)
+        so downstream parsers using ``splitlines`` semantics cannot be fooled
+        into seeing an injected OCTAVE line.
+        """
+        injected = f"benign{separator}BLOCKERS::[pwned]"
+        result = build_fallback_synthesis(
+            role="r",
+            focus=injected,
+            phase="B1_FOUNDATION_COMPLETE",
+        )
+        synthesis = result["synthesis"]
+        # No matter which separator was supplied, splitlines must not see
+        # an attacker-supplied BLOCKERS line.
+        lines = synthesis.splitlines()
+        blockers_lines = [ln for ln in lines if ln.startswith("BLOCKERS::")]
+        assert len(blockers_lines) == 1
+        assert blockers_lines[0] == "BLOCKERS::[]"
+
+    def test_preserves_international_characters(self):
+        """Non-ASCII printable characters must survive sanitisation."""
+        result = build_fallback_synthesis(
+            role="tëst-röle",
+            focus="日本語-焦点",
+            phase="B1_FOUNDATION_COMPLETE",
+        )
+        synthesis = result["synthesis"]
+        assert "tëst-röle" in synthesis
+        assert "日本語-焦点" in synthesis
+
+    def test_injected_control_chars_in_role_and_phase_are_sanitised(self):
+        """Role and phase inputs are also sanitised (defence in depth)."""
+        result = build_fallback_synthesis(
+            role="admin\r\nPHASE::B9_TAKEOVER",
+            focus="f",
+            phase="B1\nFRESHNESS_WARNING::FAKE",
+        )
+        synthesis = result["synthesis"]
+        lines = synthesis.splitlines()
+        # Each protocol field appears exactly once as a line start.
+        assert len([ln for ln in lines if ln.startswith("PHASE::")]) == 1
+        assert len([ln for ln in lines if ln.startswith("FRESHNESS_WARNING::")]) == 1
+        # The only FRESHNESS_WARNING line must be the legitimate one; no
+        # attacker-supplied FAKE value must become a new line.
+        freshness = next(ln for ln in lines if ln.startswith("FRESHNESS_WARNING::"))
+        assert freshness == "FRESHNESS_WARNING::AI_SYNTHESIS_UNAVAILABLE"
+        # PHASE line must not carry the injected takeover string as its value.
+        phase_line = next(ln for ln in lines if ln.startswith("PHASE::"))
+        assert "B9_TAKEOVER" not in phase_line
+
 
 class TestResolveAiSynthesis:
     """``resolve_ai_synthesis`` must ALWAYS return a populated result."""


### PR DESCRIPTION
## Summary

Closes #4 — P0a integration viability for hestai-context-mcp. The Payload Compiler at KVAEPH Position 3 (ADR-0353) requires shape-parity with the legacy `clock_in` response before issue #5 wires the real AIClient port. This PR lands the seam only; no provider SDK is imported.

- NEW `core/synthesis.py`: provider-agnostic seam (PROD::I3) — `AiSynthesisResult` TypedDict, `synthesize_ai_context()` placeholder returning `None` (replaced by #5), `build_fallback_synthesis()` deterministic OCTAVE template, `resolve_ai_synthesis()` totality wrapper with strict structural validation and WARNING-level observability on degradation.
- NEW `core/phase.py`: pure-read resolver (PROD::I5) extracting declared `PHASE::<FULL_FORM>` from North Star summary or `PROJECT-CONTEXT.oct.md`; provides `phase_prefix()` for `ContextSteward` workflow-doc lookups.
- MODIFIED `tools/clock_in.py`: replaces hardcoded `"B1"` at line 176 with `resolve_phase(working_dir_path)`; response gains top-level `phase` (full form, e.g. `B1_FOUNDATION_COMPLETE`) and `ai_synthesis` dict (**always present**, per PROD::I4).

## Constraint compliance

- **PROD::I3 PROVIDER_AGNOSTIC_CONTEXT** — `synthesis.py` has no AI SDK imports; enforced by `TestProviderAgnosticImports` source-grep test.
- **PROD::I4 STRUCTURED_RETURN_SHAPES** — `AiSynthesisResult` TypedDict {source, synthesis}; `resolve_ai_synthesis()` validates types, enum membership, and non-emptiness before returning.
- **PROD::I5 READ_ONLY_CONTEXT_QUERY** — `get_context` unchanged; `resolve_phase` is pure I/O.
- **PROD::I6 LEGACY_INDEPENDENCE** — no `hestai_mcp` runtime imports; legacy file referenced only as design source in docstrings.

## Evidence

### Quality gates

| Gate | Result |
|------|--------|
| `ruff check src tests` | All checks passed! |
| `black --check src tests` | 53 files unchanged |
| `mypy src` | Success: no issues found in 22 source files |
| `pytest` | **408 passed** (was 361, +47) |
| Coverage | **90%** (was 89%; floor 89%) |
| `synthesis.py` coverage | 100% |

### Gate chain (T2 triad)

| Reviewer | Model | Verdict | Continuation |
|----------|-------|---------|--------------|
| **TMG** (test-methodology-guardian) | goose / minimax-m2.7 | **APPROVED** | `b904b4e4-e9ce-4731-a681-7fa0c7bff009` |
| **CRS** (code-review-specialist) | gemini-3.1-pro-preview | **APPROVED** (100/100 reliability) | — |
| **CE** (critical-engineer) | codex | **APPROVED** after strict-validation + observability iteration | `7988ba1d-0651-4025-a4b6-945267afbe6a` |

CE first pass raised BLOCKING on incomplete value-type validation (`{"source": None, "synthesis": []}` could leak). Fixed by adding `_is_valid_result()` with enum/type/non-empty checks, logger warnings on both seam-exception and malformed-payload paths, and 12 new parametrised/observability tests.

### Delta

- +710 lines / -6 lines across 6 files (2 new production modules, 2 new test modules, clock_in.py + its test file modified).
- Test count delta: **+47**.
- Coverage delta: **+1pp** (89 → 90).

## Seam for #5

`synthesize_ai_context()` body is replaceable without signature change. Monkeypatch-driven tests lock the `{source, synthesis}` contract and validation semantics so that issue #5's AIClient cannot regress shape-parity.

## Test plan

- [x] Unit: `tests/unit/core/test_synthesis.py` (18 tests — fallback shape, resolver totality, malformed payload matrix, observability)
- [x] Unit: `tests/unit/core/test_phase.py` (9 tests — prefix, NS precedence, PC fallback, default, malformed, whitespace)
- [x] Behaviour: `tests/tools/test_clock_in.py` (4 new tests — ai_synthesis structured dict, OCTAVE template, AI seam via monkeypatch, phase full form)
- [x] Full suite green; coverage ≥ 89%
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-agnostic synthesis seam and returns a structured `ai_synthesis` plus a full-form `phase` in `clock_in`, matching the legacy response shape and closing #4. Also hardens phase decoding and sanitizes the fallback synthesis to prevent OCTAVE injection.

- **New Features**
  - `core/synthesis.py`: `resolve_ai_synthesis()` with strict validation and a deterministic OCTAVE fallback; no provider SDK imports.
  - `core/phase.py`: resolves `PHASE::<FULL_FORM>` from `.hestai/north-star/*.oct.md` or `PROJECT-CONTEXT.oct.md`; adds `phase_prefix()`.
  - `tools/clock_in.py`: uses `resolve_phase()`; response now includes full-form `phase` and an always-present `ai_synthesis` dict; passes `phase_prefix(...)` to `ContextSteward`.

- **Bug Fixes**
  - `core/phase.py`: handle `UnicodeDecodeError` when reading phase files; degrades to other sources/defaults instead of aborting.
  - `core/synthesis.py`: sanitize `role`, `focus`, and `phase` in the fallback using a single-line filter to neutralize all line-breaking/control chars and prevent OCTAVE field injection.

<sup>Written for commit cd4408395d4028086316c525548387e8f80b043b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

