### PR TITLE
feat: harvest North Star structured constraint extraction

### DIFF
--- a/src/hestai_context_mcp/core/north_star_parser.py
+++ b/src/hestai_context_mcp/core/north_star_parser.py
@@ -130,24 +130,58 @@ def extract_constraints(text: str | None) -> NorthStarConstraints:
     return {"scope_boundaries": scope_boundaries, "immutables": immutables}
 
 
+def _find_section_header(text: str, token: str, start_pos: int = 0) -> int:
+    """Return the start index of ``token`` when it appears as an OCTAVE
+    section header, or ``-1`` if absent.
+
+    A section header is strictly one of the following structural forms:
+
+    * ``(^|\\n)§<digits>::TOKEN(\\n|$)`` — the OCTAVE ``§N::TOKEN``
+      conventional form, the entire token+suffix occupying its own line.
+    * ``(^|\\n)TOKEN::`` — a bare line-start ``TOKEN::`` key (the OCTAVE
+      key/value shape with the token itself being the key).
+
+    Both forms pin TOKEN to a line-start position AND require the OCTAVE
+    ``::`` separator, so neither a free-text occurrence inside a bullet
+    body (e.g. ``"cross-reference the IMMUTABLES section"``) nor an
+    inline ``::TOKEN`` reference inside a quoted body
+    (e.g. ``"depends on ::CAPABILITIES"``) nor a sentence opener
+    (e.g. ``"\\nIMMUTABLES are essential ..."``) will be falsely
+    anchored. This closes PR #10 cubic P2 (CRS delta verdict).
+    """
+    # Header anchor: TOKEN must (a) sit at file head or directly after a
+    # newline (LF or the LF tail of CRLF) optionally prefixed with the
+    # OCTAVE ``§N::`` numbering, and (b) be followed by either ``::`` (the
+    # OCTAVE key/value separator), an EOL char, or end-of-string. The
+    # ``\r`` admittance handles CRLF inputs without falsely admitting an
+    # in-body inline reference.
+    pattern = re.compile(r"(?:^|\n)(?:§\d+::)?" + re.escape(token) + r"(?=::|\r|\n|$)")
+    match = pattern.search(text, start_pos)
+    if match is None:
+        return -1
+    # Return the index of the TOKEN itself within the match, regardless
+    # of which form (with or without the ``§N::`` prefix) was matched.
+    return match.start() + match.group(0).find(token)
+
+
 def _section_slice(text: str, token: str) -> str | None:
-    """Return the substring from the first occurrence of ``token`` up to
-    the next known section token, or ``None`` if ``token`` is absent.
+    """Return the substring starting at a properly anchored ``token`` header
+    and ending at the next such header (or ``===END``), or ``None`` if the
+    header is absent.
 
     Keyed off literal section names (see :data:`_SECTION_TOKENS`) rather
     than OCTAVE ``§N`` numbering to survive renumbering drift.
     """
-    start = text.find(token)
+    start = _find_section_header(text, token)
     if start < 0:
         return None
 
-    # Scan forward past ``token`` itself for the earliest next section.
     scan_from = start + len(token)
     end = len(text)
     for other in _SECTION_TOKENS:
         if other == token:
             continue
-        pos = text.find(other, scan_from)
+        pos = _find_section_header(text, other, scan_from)
         if 0 <= pos < end:
             end = pos
 

--- a/src/hestai_context_mcp/core/north_star_parser.py
+++ b/src/hestai_context_mcp/core/north_star_parser.py
@@ -1,0 +1,243 @@
+"""North Star structured constraint extraction.
+
+Issue #6: Harvest ``SCOPE_BOUNDARIES`` and ``IMMUTABLES`` from the Product
+North Star so the Payload Compiler can extract architectural constraints
+programmatically (PROD::I4 STRUCTURED_RETURN_SHAPES) without re-implementing
+parsing at each consumer.
+
+Design invariants
+-----------------
+* **Pure function** (PROD::I5) — text in, dict out. No I/O beyond DEBUG
+  logging on malformed input; no filesystem access; no side effects.
+* **Provider-agnostic** (PROD::I3) — parses the OCTAVE North Star summary
+  format, not any provider-specific representation.
+* **Legacy-independent** (PROD::I6) — design-time re-derivation of the
+  legacy ``_extract_north_star_constraints`` logic; no runtime import of
+  ``hestai_mcp``.
+
+Format understood
+-----------------
+The parser targets the OCTAVE North Star summary document shape::
+
+    §N::IMMUTABLES
+    I1::"TOKEN<PRINCIPLE::…,WHY::…,STATUS::…>"
+    I2::"…"
+
+    §N::SCOPE_BOUNDARIES
+    IS::[
+      "item one",
+      "item two"
+    ]
+    IS_NOT::[
+      "other"
+    ]
+
+Section numbering (``§2`` / ``§4`` / …) is irrelevant — the parser keys
+off the literal ``IMMUTABLES`` and ``SCOPE_BOUNDARIES`` tokens. Immutable
+lines are recognised by the ``I<digits>::`` prefix anywhere inside the
+``IMMUTABLES`` block, and list items are any quoted strings within the
+bracketed ``IS::[ … ]`` / ``IS_NOT::[ … ]`` blocks.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class NorthStarConstraints(TypedDict):
+    """Structured extraction of a Product North Star summary document.
+
+    Fields
+    ------
+    scope_boundaries:
+        Keyed by the lowercase section label (``"is"`` / ``"is_not"``).
+        Each value is an ordered list of bullet strings extracted from the
+        ``§N::SCOPE_BOUNDARIES`` block. When the block is present but one
+        sub-list is absent, that key is still returned with an empty list
+        (PROD::I4 consistent shape). When the whole block is absent, the
+        dict is empty.
+    immutables:
+        Ordered list of immutable declarations (``"I1::…"``, ``"I2::…"``,
+        …) extracted from the ``§N::IMMUTABLES`` block. Empty list when
+        the block is absent.
+    """
+
+    scope_boundaries: dict[str, list[str]]
+    immutables: list[str]
+
+
+# Section delimiters inside an OCTAVE North Star summary. We key off the
+# literal section TOKEN rather than the numeric ``§N`` prefix so format
+# drift in section numbering does not break the parser.
+_SECTION_TOKENS = (
+    "IMMUTABLES",
+    "SCOPE_BOUNDARIES",
+    "ASSUMPTIONS",
+    "CONSTRAINED_VARIABLES",
+    "GATES",
+    "ESCALATION",
+    "TRIGGERS",
+    "PROTECTION",
+    "IDENTITY",
+)
+
+# An immutable line: ``I1::"…"`` or ``I12::"…"`` at line start (OCTAVE
+# bodies are whitespace-tolerant — we strip each line before matching).
+_IMMUTABLE_LINE_RE = re.compile(r"^(I\d+::.*)$")
+
+# A quoted list item inside an ``IS::[ … ]`` / ``IS_NOT::[ … ]`` block.
+# Captures the inner content. We accept both straight ASCII quotes and
+# curly typographic quotes to survive document re-serialisation.
+_QUOTED_ITEM_RE = re.compile(r'"([^"\n]*)"|“([^”\n]*)”')
+
+
+def extract_constraints(text: str | None) -> NorthStarConstraints:
+    """Parse a North Star document into structured constraints.
+
+    Pure function — text in, structured dict out. Graceful on empty,
+    ``None``, whitespace-only, and malformed input (returns an empty
+    structured result and DEBUG-logs on parse exceptions; never raises).
+
+    Args:
+        text: Raw North Star document text, or ``None``.
+
+    Returns:
+        A :class:`NorthStarConstraints` dict with ``scope_boundaries`` and
+        ``immutables`` keys. Both keys are always present; values are
+        empty when the corresponding sections are absent or unparseable.
+    """
+    empty: NorthStarConstraints = {"scope_boundaries": {}, "immutables": []}
+
+    if not text or not text.strip():
+        return empty
+
+    try:
+        immutables = _extract_immutables(text)
+    except Exception as exc:  # pragma: no cover - defensive only
+        logger.debug("north_star_parser: immutables parse failed: %s", exc)
+        immutables = []
+
+    try:
+        scope_boundaries = _extract_scope_boundaries(text)
+    except Exception as exc:  # pragma: no cover - defensive only
+        logger.debug("north_star_parser: scope_boundaries parse failed: %s", exc)
+        scope_boundaries = {}
+
+    return {"scope_boundaries": scope_boundaries, "immutables": immutables}
+
+
+def _section_slice(text: str, token: str) -> str | None:
+    """Return the substring from the first occurrence of ``token`` up to
+    the next known section token, or ``None`` if ``token`` is absent.
+
+    Keyed off literal section names (see :data:`_SECTION_TOKENS`) rather
+    than OCTAVE ``§N`` numbering to survive renumbering drift.
+    """
+    start = text.find(token)
+    if start < 0:
+        return None
+
+    # Scan forward past ``token`` itself for the earliest next section.
+    scan_from = start + len(token)
+    end = len(text)
+    for other in _SECTION_TOKENS:
+        if other == token:
+            continue
+        pos = text.find(other, scan_from)
+        if 0 <= pos < end:
+            end = pos
+
+    # Also honour the OCTAVE document terminator ``===END`` if present.
+    end_marker = text.find("===END", scan_from)
+    if 0 <= end_marker < end:
+        end = end_marker
+
+    return text[start:end]
+
+
+def _extract_immutables(text: str) -> list[str]:
+    """Extract ``I<n>::…`` lines from the IMMUTABLES section in order."""
+    section = _section_slice(text, "IMMUTABLES")
+    if section is None:
+        return []
+
+    results: list[str] = []
+    for raw_line in section.splitlines():
+        line = raw_line.strip()
+        match = _IMMUTABLE_LINE_RE.match(line)
+        if match:
+            results.append(match.group(1))
+    return results
+
+
+def _extract_scope_boundaries(text: str) -> dict[str, list[str]]:
+    """Extract ``IS::[ … ]`` and ``IS_NOT::[ … ]`` lists from SCOPE_BOUNDARIES.
+
+    When the block is present, both keys (``is``, ``is_not``) are returned
+    with list values; whichever sub-list is absent gets an empty list so
+    the :class:`NorthStarConstraints` shape is stable (PROD::I4).
+    """
+    section = _section_slice(text, "SCOPE_BOUNDARIES")
+    if section is None:
+        return {}
+
+    is_items = _parse_bracketed_list(section, "IS")
+    is_not_items = _parse_bracketed_list(section, "IS_NOT")
+
+    if is_items is None and is_not_items is None:
+        # Block header present but no parseable sub-lists — still return
+        # the shape so downstream consumers do not special-case absence.
+        return {"is": [], "is_not": []}
+
+    return {
+        "is": is_items or [],
+        "is_not": is_not_items or [],
+    }
+
+
+def _parse_bracketed_list(section: str, label: str) -> list[str] | None:
+    """Return quoted list items inside ``{label}::[ … ]``, or ``None`` if
+    the labelled block is not found. ``IS_NOT`` is matched before ``IS``
+    at call time to avoid prefix collisions.
+    """
+    # Locate the label, then the opening bracket. We scan conservatively:
+    # first ``\n{label}::`` (line-anchored) with a fallback to whitespace-
+    # prefixed forms so edge-of-section lines are still caught.
+    candidates = (f"\n{label}::", f" {label}::", f"\t{label}::")
+    idx = -1
+    for cand in candidates:
+        idx = section.find(cand)
+        if idx >= 0:
+            idx += len(cand)
+            break
+    if idx < 0 and section.startswith(f"{label}::"):
+        idx = len(f"{label}::")
+    if idx < 0:
+        return None
+
+    # Find the opening bracket after the label.
+    open_bracket = section.find("[", idx)
+    if open_bracket < 0:
+        return None
+
+    # Find the matching close bracket. We do not attempt deep nesting — the
+    # OCTAVE dialect does not put brackets inside these bullet strings. If
+    # unterminated (malformed), read to the next section/end-of-string.
+    close_bracket = section.find("]", open_bracket + 1)
+    if close_bracket < 0:
+        logger.debug("north_star_parser: unterminated %s bracket list; best-effort parse", label)
+        body = section[open_bracket + 1 :]
+    else:
+        body = section[open_bracket + 1 : close_bracket]
+
+    items: list[str] = []
+    for match in _QUOTED_ITEM_RE.finditer(body):
+        # Exactly one of the two capture groups is populated per match.
+        item = match.group(1) if match.group(1) is not None else match.group(2)
+        if item is not None:
+            items.append(item)
+    return items

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -15,6 +15,10 @@ from hestai_context_mcp.core.git_state import (
     get_current_branch,
     get_git_state,
 )
+from hestai_context_mcp.core.north_star_parser import (
+    NorthStarConstraints,
+    extract_constraints,
+)
 from hestai_context_mcp.core.phase import phase_prefix, resolve_phase
 from hestai_context_mcp.core.session import SessionManager
 from hestai_context_mcp.core.synthesis import resolve_ai_synthesis
@@ -94,10 +98,17 @@ def clock_in(
         {
             session_id, role, focus, focus_source, branch, working_dir,
             context_paths, context: {
-                product_north_star, project_context, phase_constraints,
-                git_state, active_sessions
+                product_north_star, product_north_star_constraints,
+                project_context, phase_constraints, git_state,
+                active_sessions
             }
         }
+
+        ``product_north_star_constraints`` is a ``NorthStarConstraints``
+        TypedDict with ``scope_boundaries`` (dict) and ``immutables`` (list);
+        the structured sibling of the raw ``product_north_star`` blob per
+        PROD::I4 STRUCTURED_RETURN_SHAPES. See
+        :mod:`hestai_context_mcp.core.north_star_parser` for schema.
 
     Raises:
         ValueError: If role is invalid.
@@ -133,11 +144,18 @@ def clock_in(
     # Get active session focuses
     active_sessions = mgr.get_active_session_focuses()
 
-    # Read North Star contents
+    # Read North Star contents (raw blob for backward compatibility).
     product_north_star = None
     ns_path = mgr._find_north_star_file()
     if ns_path:
         product_north_star = mgr.read_file_contents(ns_path)
+
+    # Issue #6: harvest structured SCOPE_BOUNDARIES / IMMUTABLES alongside
+    # the raw blob so the Payload Compiler can extract architectural
+    # constraints programmatically (PROD::I4 STRUCTURED_RETURN_SHAPES).
+    # The parser is a pure function (PROD::I5); it returns an empty
+    # structured result when product_north_star is None/empty/malformed.
+    product_north_star_constraints: NorthStarConstraints = extract_constraints(product_north_star)
 
     # Read PROJECT-CONTEXT contents
     project_context_path = (
@@ -214,6 +232,7 @@ def clock_in(
         "ai_synthesis": ai_synthesis,
         "context": {
             "product_north_star": product_north_star,
+            "product_north_star_constraints": product_north_star_constraints,
             "project_context": project_context,
             "phase_constraints": phase_constraints,
             "git_state": git_state,

--- a/tests/tools/test_clock_in.py
+++ b/tests/tools/test_clock_in.py
@@ -228,6 +228,85 @@ class TestClockInReturnShape:
         assert result["phase"] != "B1"
 
 
+class TestClockInNorthStarConstraints:
+    """Issue #6: structured North Star constraint extraction alongside raw blob.
+
+    The raw `context.product_north_star` field MUST remain unchanged (backward
+    compat). A new sibling key `context.product_north_star_constraints` carries
+    the structured {scope_boundaries, immutables} dict for the Payload Compiler.
+    """
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_constraints_key_always_present(self, mock_branch, tmp_path):
+        """The structured key is always in the response (PROD::I4), even when
+        no North Star file exists — value is an empty structured result.
+        """
+        result = clock_in(role="test-role", working_dir=str(tmp_path))
+        ctx = result["context"]
+        assert "product_north_star_constraints" in ctx
+        constraints = ctx["product_north_star_constraints"]
+        assert isinstance(constraints, dict)
+        assert set(constraints.keys()) == {"scope_boundaries", "immutables"}
+        assert constraints["scope_boundaries"] == {}
+        assert constraints["immutables"] == []
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_constraints_extracted_from_real_ns_format(self, mock_branch, tmp_path):
+        """When an OCTAVE North Star summary exists, structured fields parse.
+
+        Uses the same §2 IMMUTABLES / §4 SCOPE_BOUNDARIES shape as the real repo
+        North Star summary file.
+        """
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        (ns_dir / "000-TEST-NORTH-STAR.oct.md").write_text(
+            "===NORTH_STAR_SUMMARY===\n"
+            "§2::IMMUTABLES\n"
+            'I1::"FOO<PRINCIPLE::a,WHY::b,STATUS::IMPLEMENTED>"\n'
+            'I2::"BAR<PRINCIPLE::c,WHY::d,STATUS::IMPLEMENTED>"\n'
+            "§4::SCOPE_BOUNDARIES\n"
+            "IS::[\n"
+            '  "thing one",\n'
+            '  "thing two"\n'
+            "]\n"
+            "IS_NOT::[\n"
+            '  "not this",\n'
+            '  "not that"\n'
+            "]\n"
+            "===END===\n"
+        )
+
+        result = clock_in(role="test-role", working_dir=str(tmp_path))
+        constraints = result["context"]["product_north_star_constraints"]
+        assert "is" in constraints["scope_boundaries"]
+        assert "is_not" in constraints["scope_boundaries"]
+        assert any("thing one" in item for item in constraints["scope_boundaries"]["is"])
+        assert any("not this" in item for item in constraints["scope_boundaries"]["is_not"])
+        assert len(constraints["immutables"]) == 2
+        assert constraints["immutables"][0].startswith("I1::")
+        assert constraints["immutables"][1].startswith("I2::")
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_raw_north_star_field_unchanged_when_constraints_added(self, mock_branch, tmp_path):
+        """Backward compat: raw product_north_star still carries full file text."""
+        ns_dir = tmp_path / ".hestai" / "north-star"
+        ns_dir.mkdir(parents=True)
+        ns_text = (
+            "===NORTH_STAR===\n"
+            "§2::IMMUTABLES\n"
+            'I1::"X<PRINCIPLE::a,WHY::b,STATUS::IMPLEMENTED>"\n'
+            "===END===\n"
+        )
+        (ns_dir / "000-TEST-NORTH-STAR.oct.md").write_text(ns_text)
+
+        result = clock_in(role="test-role", working_dir=str(tmp_path))
+        ctx = result["context"]
+        # Raw blob — exact bytes-on-disk
+        assert ctx["product_north_star"] == ns_text
+        # Structured sibling present and populated
+        assert ctx["product_north_star_constraints"]["immutables"][0].startswith("I1::")
+
+
 class TestClockInValidation:
     """Test input validation."""
 

--- a/tests/unit/core/test_north_star_parser.py
+++ b/tests/unit/core/test_north_star_parser.py
@@ -1,0 +1,268 @@
+"""Behavioural tests for North Star structured constraint extraction.
+
+Issue #6: Harvest SCOPE_BOUNDARIES and IMMUTABLES from the Product North Star
+so the Payload Compiler can extract architectural constraints programmatically
+(PROD::I4 STRUCTURED_RETURN_SHAPES) without re-implementing parsing.
+
+The parser MUST be a pure function — no side effects, no I/O beyond DEBUG
+logging for malformed content. Tests exercise the REAL repository North Star
+summary file in place (not synthetic stubs) per the issue acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.core.north_star_parser import (
+    NorthStarConstraints,
+    extract_constraints,
+)
+
+# Repository root: tests/unit/core/test_north_star_parser.py -> parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REAL_NS_SUMMARY = (
+    REPO_ROOT / ".hestai" / "north-star" / "000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md"
+)
+
+
+class TestEmptyOrMissingInput:
+    """Graceful handling of empty / missing input (no exceptions)."""
+
+    def test_empty_string_returns_empty_structured_result(self):
+        """Empty string → empty structured result, no exception."""
+        result = extract_constraints("")
+        assert result == {"scope_boundaries": {}, "immutables": []}
+
+    def test_none_input_returns_empty_structured_result(self):
+        """None input → empty structured result, no exception."""
+        # A None is an explicit contract option: clock_in may pass None when
+        # no North Star file exists.
+        result = extract_constraints(None)
+        assert result == {"scope_boundaries": {}, "immutables": []}
+
+    def test_whitespace_only_returns_empty_structured_result(self):
+        """Whitespace-only input → empty structured result."""
+        result = extract_constraints("   \n\n\t  \n")
+        assert result == {"scope_boundaries": {}, "immutables": []}
+
+    def test_document_without_sections_returns_empty_structured_result(self):
+        """Document with no SCOPE_BOUNDARIES or IMMUTABLES → empty result."""
+        result = extract_constraints("===NORTH_STAR===\nPURPOSE::foo\nROLE::bar\n===END===\n")
+        assert result == {"scope_boundaries": {}, "immutables": []}
+
+
+class TestMalformedContent:
+    """Best-effort parse of malformed content with DEBUG logging."""
+
+    def test_malformed_scope_boundaries_returns_empty_scope(self, caplog):
+        """Unterminated/malformed SCOPE_BOUNDARIES → empty scope, no exception."""
+        # Truncated mid-list — parser must not raise.
+        malformed = '§4::SCOPE_BOUNDARIES\nIS::[\n  "incomplete'
+        with caplog.at_level(logging.DEBUG, logger="hestai_context_mcp.core.north_star_parser"):
+            result = extract_constraints(malformed)
+        assert isinstance(result, dict)
+        assert "scope_boundaries" in result
+        assert "immutables" in result
+        # Either partial or empty, but MUST be a dict/list shape, never an exception.
+        assert isinstance(result["scope_boundaries"], dict)
+        assert isinstance(result["immutables"], list)
+
+    def test_malformed_does_not_raise(self):
+        """Arbitrary garbage must not raise."""
+        garbage = "\x00\x01random bytes [[{{ I1:: SCOPE_BOUNDARIES incomplete"
+        # Must complete without raising.
+        result = extract_constraints(garbage)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"scope_boundaries", "immutables"}
+
+
+class TestRealNorthStarSummary:
+    """Behavioural tests against the REAL repository North Star summary file.
+
+    Issue #6 acceptance: synthetic stubs do NOT satisfy this gate.
+
+    Maintenance note: these tests are intentionally coupled to the live
+    repo North Star summary (``.hestai/north-star/…-SUMMARY.oct.md``). If
+    the NS format evolves (new immutables added, scope items changed), the
+    assertions below will need updating in the same PR that updates the NS
+    — that coupling is the point. A failure here means "the NS changed
+    without a corresponding parser-gate update", which is exactly the
+    signal the Payload Compiler depends on.
+    """
+
+    @pytest.fixture
+    def real_ns_content(self) -> str:
+        assert REAL_NS_SUMMARY.exists(), (
+            f"Real North Star summary fixture missing: {REAL_NS_SUMMARY}. "
+            "This test MUST exercise the live repo file in-place."
+        )
+        return REAL_NS_SUMMARY.read_text()
+
+    def test_returns_typeddict_shape(self, real_ns_content: str):
+        """Return value conforms to NorthStarConstraints TypedDict shape."""
+        result = extract_constraints(real_ns_content)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"scope_boundaries", "immutables"}
+        assert isinstance(result["scope_boundaries"], dict)
+        assert isinstance(result["immutables"], list)
+
+    def test_scope_boundaries_has_is_and_is_not(self, real_ns_content: str):
+        """§4 SCOPE_BOUNDARIES parses into 'is' and 'is_not' keys."""
+        result = extract_constraints(real_ns_content)
+        scope = result["scope_boundaries"]
+        assert "is" in scope, f"Expected 'is' key, got: {list(scope.keys())}"
+        assert "is_not" in scope, f"Expected 'is_not' key, got: {list(scope.keys())}"
+        assert isinstance(scope["is"], list)
+        assert isinstance(scope["is_not"], list)
+        assert len(scope["is"]) >= 1
+        assert len(scope["is_not"]) >= 1
+
+    def test_scope_is_contains_expected_items(self, real_ns_content: str):
+        """Real §4 IS list contains known substrings from the repo NS."""
+        result = extract_constraints(real_ns_content)
+        is_items = result["scope_boundaries"]["is"]
+        joined = "\n".join(is_items)
+        # From .hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md §4
+        assert "session lifecycle management" in joined
+        assert "context synthesis engine" in joined
+
+    def test_scope_is_not_contains_expected_items(self, real_ns_content: str):
+        """Real §4 IS_NOT list contains known substrings."""
+        result = extract_constraints(real_ns_content)
+        is_not_items = result["scope_boundaries"]["is_not"]
+        joined = "\n".join(is_not_items)
+        assert "agent identity or governance (Vault owns)" in joined
+        assert "UI or dispatch system (Workbench owns)" in joined
+
+    def test_immutables_extracted_in_order(self, real_ns_content: str):
+        """Real §2 IMMUTABLES yields I1..I6 entries in declared order."""
+        result = extract_constraints(real_ns_content)
+        immutables = result["immutables"]
+        # Real NS declares I1..I6 (six immutables)
+        assert len(immutables) == 6, f"Expected 6 immutables, got {len(immutables)}: {immutables}"
+        # Order preserved and each entry starts with its I# token
+        for i, expected_prefix in enumerate(["I1::", "I2::", "I3::", "I4::", "I5::", "I6::"]):
+            assert immutables[i].startswith(expected_prefix), (
+                f"Immutable index {i} does not start with {expected_prefix!r}: "
+                f"{immutables[i]!r}"
+            )
+
+    def test_immutables_preserve_declared_content(self, real_ns_content: str):
+        """Known immutable bodies from real NS are present verbatim."""
+        result = extract_constraints(real_ns_content)
+        immutables = result["immutables"]
+        joined = "\n".join(immutables)
+        # Anchored substrings from NS summary §2
+        assert "SESSION_LIFECYCLE_INTEGRITY" in joined
+        assert "PROVIDER_AGNOSTIC_CONTEXT" in joined
+        assert "STRUCTURED_RETURN_SHAPES" in joined
+        assert "LEGACY_INDEPENDENCE" in joined
+
+
+class TestPurity:
+    """PROD::I5 — parser is a pure function with no side effects."""
+
+    def test_does_not_mutate_input(self):
+        """Parser does not mutate its string argument (strings are immutable
+        in Python; we also check that repeated calls yield identical results).
+        """
+        content = REAL_NS_SUMMARY.read_text() if REAL_NS_SUMMARY.exists() else ""
+        first = extract_constraints(content)
+        second = extract_constraints(content)
+        assert first == second
+
+    def test_no_filesystem_access(self, tmp_path, monkeypatch):
+        """Parser is text-in → dict-out; it must not touch the filesystem.
+
+        We verify indirectly: calling the parser with non-existent 'paths'
+        embedded in the text does not create files and does not raise.
+        """
+        text = (
+            "§4::SCOPE_BOUNDARIES\n"
+            'IS::[\n  "/nonexistent/path/should/not/be/opened"\n]\n'
+            'IS_NOT::[\n  "other"\n]\n'
+        )
+        before = set(tmp_path.iterdir())
+        _ = extract_constraints(text)
+        after = set(tmp_path.iterdir())
+        assert before == after
+
+
+class TestTypedDictExport:
+    """PROD::I4 — schema is exported as a TypedDict for static consumers."""
+
+    def test_typeddict_schema_is_resolvable_by_typing_api(self):
+        """The TypedDict exposes a schema via ``typing.get_type_hints``.
+
+        This is the external contract static type checkers (mypy, pyright)
+        use to validate producers and consumers — it does NOT depend on the
+        TypedDict implementation's ``__annotations__`` attribute.
+        """
+        from typing import get_type_hints
+
+        from hestai_context_mcp.core.north_star_parser import NorthStarConstraints
+
+        hints = get_type_hints(NorthStarConstraints)
+        assert "scope_boundaries" in hints
+        assert "immutables" in hints
+
+    def test_result_assigns_to_typeddict_variable(self):
+        """Return value is assignable to the TypedDict type at runtime."""
+        result: NorthStarConstraints = extract_constraints("")
+        assert result == {"scope_boundaries": {}, "immutables": []}
+
+
+class TestUnicodeAndBoundaryShapes:
+    """Encoding boundaries and partial-section shape consistency (PROD::I4)."""
+
+    def test_unicode_content_in_scope_boundaries(self):
+        """Non-ASCII content in IS/IS_NOT items is preserved verbatim."""
+        text = (
+            "§4::SCOPE_BOUNDARIES\n"
+            "IS::[\n"
+            '  "日本語 context synthesis",\n'
+            '  "émoji 🚀 handling"\n'
+            "]\n"
+            "IS_NOT::[\n"
+            '  "漢字 governance"\n'
+            "]\n"
+        )
+        result = extract_constraints(text)
+        is_items = result["scope_boundaries"]["is"]
+        is_not_items = result["scope_boundaries"]["is_not"]
+        joined_is = "\n".join(is_items)
+        assert "日本語 context synthesis" in joined_is
+        assert "émoji 🚀 handling" in joined_is
+        assert any("漢字 governance" in item for item in is_not_items)
+
+    def test_unicode_content_in_immutables(self):
+        """Non-ASCII body content in I# lines is preserved verbatim."""
+        text = "§2::IMMUTABLES\n" 'I1::"CTX_日本<PRINCIPLE::a,WHY::b,STATUS::IMPLEMENTED>"\n'
+        result = extract_constraints(text)
+        immutables = result["immutables"]
+        assert len(immutables) == 1
+        assert "CTX_日本" in immutables[0]
+
+    def test_scope_with_only_is_present(self):
+        """PROD::I4 shape consistency: IS present, IS_NOT absent → both keys
+        present with IS_NOT=[]."""
+        text = "§4::SCOPE_BOUNDARIES\n" "IS::[\n" '  "only one"\n' "]\n"
+        result = extract_constraints(text)
+        scope = result["scope_boundaries"]
+        assert "is" in scope
+        assert "is_not" in scope
+        assert scope["is_not"] == []
+        assert any("only one" in item for item in scope["is"])
+
+    def test_scope_with_only_is_not_present(self):
+        """IS_NOT present, IS absent → both keys present with IS=[]."""
+        text = "§4::SCOPE_BOUNDARIES\n" "IS_NOT::[\n" '  "excluded item"\n' "]\n"
+        result = extract_constraints(text)
+        scope = result["scope_boundaries"]
+        assert "is" in scope
+        assert "is_not" in scope
+        assert scope["is"] == []
+        assert any("excluded item" in item for item in scope["is_not"])

--- a/tests/unit/core/test_north_star_parser.py
+++ b/tests/unit/core/test_north_star_parser.py
@@ -266,3 +266,179 @@ class TestUnicodeAndBoundaryShapes:
         assert "is_not" in scope
         assert scope["is"] == []
         assert any("excluded item" in item for item in scope["is_not"])
+
+
+class TestSectionAnchoring:
+    """PR #10 cubic P2 regression guard: section tokens must be matched as
+    OCTAVE headers (``TOKEN::``), never as bare-substring occurrences inside
+    free-text bullet bodies. Otherwise a scope-boundary description such as
+    ``"cross-reference IMMUTABLES section"`` would be mistaken for a section
+    header and corrupt the slice (silently truncating SCOPE_BOUNDARIES at
+    the spurious match, and shifting IMMUTABLES to start mid-bullet).
+    """
+
+    @pytest.mark.parametrize(
+        "free_text_token",
+        [
+            "IMMUTABLES",
+            "SCOPE_BOUNDARIES",
+            "ASSUMPTIONS",
+            "CONSTRAINED_VARIABLES",
+            "GATES",
+            "ESCALATION",
+            "TRIGGERS",
+            "PROTECTION",
+            "IDENTITY",
+        ],
+    )
+    def test_free_text_section_token_does_not_shift_section_slice(self, free_text_token: str):
+        """A bare section-token word inside a bullet body must not be treated
+        as a header. SCOPE_BOUNDARIES must continue to capture both bullets
+        and IMMUTABLES must still parse to a single I1 line, regardless of
+        which token appears as free text inside the IS list.
+        """
+        text = (
+            "§4::SCOPE_BOUNDARIES\n"
+            "IS::[\n"
+            f'  "documentation must cross-reference the {free_text_token} section",\n'
+            '  "second legitimate boundary item"\n'
+            "]\n"
+            "IS_NOT::[\n"
+            '  "out of scope"\n'
+            "]\n"
+            "§2::IMMUTABLES\n"
+            'I1::"REAL<PRINCIPLE::p,WHY::w,STATUS::IMPLEMENTED>"\n'
+            "===END===\n"
+        )
+        result = extract_constraints(text)
+
+        # SCOPE_BOUNDARIES bullets are intact (not truncated at the spurious
+        # token occurrence, and not corrupted by re-anchoring on it).
+        is_items = result["scope_boundaries"]["is"]
+        assert len(is_items) == 2, (
+            f"Expected both IS bullets to parse; free-text {free_text_token!r} "
+            f"shifted the slice. Got: {is_items!r}"
+        )
+        assert any("second legitimate boundary item" in item for item in is_items)
+        assert any("out of scope" in item for item in result["scope_boundaries"]["is_not"])
+
+        # IMMUTABLES still resolves to exactly one I1 declaration (not pulled
+        # forward by a spurious in-body match).
+        immutables = result["immutables"]
+        assert (
+            len(immutables) == 1
+        ), f"Expected exactly one immutable; got {len(immutables)}: {immutables!r}"
+        assert immutables[0].startswith('I1::"REAL')
+
+    @pytest.mark.parametrize(
+        "adversarial_token",
+        ["IMMUTABLES", "SCOPE_BOUNDARIES", "ASSUMPTIONS", "GATES"],
+    )
+    def test_inline_double_colon_token_does_not_anchor(self, adversarial_token: str):
+        """CRS delta P1: an inline ``::TOKEN`` reference inside a quoted body
+        (e.g. ``"depends on ::IMMUTABLES section"``) must NOT match as a
+        section header — the OCTAVE header form requires the TOKEN to occupy
+        its own line (``\\n§N::TOKEN`` or ``\\nTOKEN::``).
+        """
+        text = (
+            "§4::SCOPE_BOUNDARIES\n"
+            "IS::[\n"
+            f'  "downstream code depends on ::{adversarial_token} parsing",\n'
+            '  "second legitimate boundary item"\n'
+            "]\n"
+            "§2::IMMUTABLES\n"
+            'I1::"REAL<PRINCIPLE::p,WHY::w,STATUS::IMPLEMENTED>"\n'
+        )
+        result = extract_constraints(text)
+        # Both bullets present — slice was not truncated by the inline ::TOKEN.
+        is_items = result["scope_boundaries"]["is"]
+        assert (
+            len(is_items) == 2
+        ), f"Inline ::{adversarial_token} corrupted slice. Got: {is_items!r}"
+        assert any("second legitimate boundary item" in item for item in is_items)
+        # IMMUTABLES still parses to exactly the one declaration.
+        assert len(result["immutables"]) == 1
+        assert result["immutables"][0].startswith('I1::"REAL')
+
+    @pytest.mark.parametrize(
+        "sentence_token",
+        ["IMMUTABLES", "SCOPE_BOUNDARIES", "ASSUMPTIONS", "GATES"],
+    )
+    def test_line_start_token_without_double_colon_does_not_anchor(self, sentence_token: str):
+        """CRS delta P2: a sentence opener at line start whose first word
+        happens to be a section TOKEN (``\\nIMMUTABLES are essential ...``)
+        must NOT match as a header. The OCTAVE header form requires the
+        ``::`` separator immediately after the TOKEN.
+        """
+        text = (
+            "§4::SCOPE_BOUNDARIES\n"
+            "IS::[\n"
+            '  "first item",\n'
+            '  "second item"\n'
+            "]\n"
+            f"\n{sentence_token} are essential to this design but not a section.\n"
+            "\n"
+            "§2::IMMUTABLES\n"
+            'I1::"REAL<PRINCIPLE::p,WHY::w,STATUS::IMPLEMENTED>"\n'
+        )
+        result = extract_constraints(text)
+        is_items = result["scope_boundaries"]["is"]
+        assert (
+            len(is_items) == 2
+        ), f"Line-start '{sentence_token} are ...' corrupted slice. Got: {is_items!r}"
+        assert len(result["immutables"]) == 1
+
+    def test_crlf_line_endings_do_not_falsely_anchor(self):
+        """CRS delta P3: CRLF (``\\r\\n``) inputs must not produce false
+        anchors via the trailing ``\\n`` of the CRLF pair followed by an
+        otherwise-bare TOKEN. The header form still requires ``::`` after.
+        """
+        text = (
+            "§4::SCOPE_BOUNDARIES\r\n"
+            "IS::[\r\n"
+            '  "first item",\r\n'
+            '  "second item"\r\n'
+            "]\r\n"
+            "\r\n"
+            "IMMUTABLES are referenced but not headed here.\r\n"
+            "\r\n"
+            "§2::IMMUTABLES\r\n"
+            'I1::"REAL<PRINCIPLE::p,WHY::w,STATUS::IMPLEMENTED>"\r\n'
+        )
+        result = extract_constraints(text)
+        is_items = result["scope_boundaries"]["is"]
+        assert len(is_items) == 2, f"CRLF false anchor; got: {is_items!r}"
+        assert len(result["immutables"]) == 1
+
+    def test_bare_line_start_token_with_double_colon_does_anchor(self):
+        """Positive sanity: ``\\nTOKEN::`` (no ``§N`` prefix) IS still a
+        valid OCTAVE header and MUST anchor — the fix must not over-tighten.
+        """
+        text = (
+            "IMMUTABLES::\n"
+            'I1::"FIRST<PRINCIPLE::a,WHY::b,STATUS::IMPLEMENTED>"\n'
+            'I2::"SECOND<PRINCIPLE::c,WHY::d,STATUS::IMPLEMENTED>"\n'
+            "SCOPE_BOUNDARIES::\n"
+            'IS::["only one"]\n'
+        )
+        result = extract_constraints(text)
+        assert len(result["immutables"]) == 2
+        assert any("only one" in item for item in result["scope_boundaries"]["is"])
+
+    def test_real_repo_north_star_still_parses_after_anchoring(self):
+        """Belt-and-braces: anchoring fix must not regress the live repo NS.
+
+        Equivalent to the TestRealNorthStarSummary suite but co-located with
+        the cubic regression tests so a single targeted run covers both.
+        """
+        if not REAL_NS_SUMMARY.exists():
+            pytest.skip(f"Live North Star summary fixture missing: {REAL_NS_SUMMARY}")
+        result = extract_constraints(REAL_NS_SUMMARY.read_text())
+        # Same anchors as TestRealNorthStarSummary — duplicated intentionally
+        # so this regression class is self-contained.
+        assert len(result["immutables"]) == 6
+        assert "is" in result["scope_boundaries"]
+        assert "is_not" in result["scope_boundaries"]
+        assert any(
+            "session lifecycle management" in item for item in result["scope_boundaries"]["is"]
+        )


### PR DESCRIPTION
Closes #6

## Summary

Add a pure parser `core/north_star_parser.py` that extracts `SCOPE_BOUNDARIES` (dict of `is` / `is_not` lists) and `IMMUTABLES` (ordered list of `I<n>::…` lines) from the OCTAVE Product North Star summary format, and wire it additively into `clock_in` so the response now carries `context.product_north_star_constraints` alongside the existing raw `context.product_north_star` blob. The structured key is the substrate Workbench Payload Compiler needs at KVAEPH Position 3 (workbench #126 System Architecture Blindness) so architectural constraints can be extracted programmatically without each consumer re-implementing parsing.

## Deliverables

- `src/hestai_context_mcp/core/north_star_parser.py` — pure function `extract_constraints(text: str | None) -> NorthStarConstraints` (TypedDict). Section-token-keyed (resilient to OCTAVE `§N` renumbering). Graceful on empty / `None` / whitespace-only / malformed input — returns empty structured result, DEBUG-logs on parse failure, never raises.
- `src/hestai_context_mcp/tools/clock_in.py` — additive key `context.product_north_star_constraints`. Raw `context.product_north_star` field unchanged (backward compat verified by a dedicated test that asserts byte-identical content).
- `tests/unit/core/test_north_star_parser.py` — 20 behavioural tests across five classes: empty/missing input, malformed content, real-NS summary (reads `.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md` in place), purity (idempotence + no-filesystem), TypedDict + Unicode/boundary shapes.
- `tests/tools/test_clock_in.py` — `TestClockInNorthStarConstraints` (3 integration tests: key always present, real-shape parsing, backward-compat byte identity).

## Contract invariants held

- PROD::I3 provider-agnostic — parser has no provider coupling.
- PROD::I4 structured return shape — `NorthStarConstraints` TypedDict, stable top-level keys; resolvable via `typing.get_type_hints`.
- PROD::I5 pure function — no filesystem, no env, no side effects beyond `logger.debug(...)` on defensive parse failures. Tests assert idempotence and no tmpdir writes.
- PROD::I6 legacy independence — no runtime import of `hestai_mcp`; the legacy 60-line regex at `/Volumes/HestAI-MCP/.../modules/tools/clock_in.py:525-583` was read-only design-time reference and the new implementation is re-derived.

## Gate evidence (T2: TMG ⊕ CRS ⊕ CE — all APPROVED)

- **TMG** (goose, test-methodology-guardian): APPROVED. `continuation_id: 1c441bdb-6db4-4e8c-91fd-94a91d72c8cb`. Five pre-GREEN actions applied: stub module added first (RED became right-reason assertion failure, not import-error); `__annotations__` assertion replaced with `typing.get_type_hints` (avoids testing Python internals); Unicode test class added; IS/IS_NOT partial-presence tests added; live-file coupling docstring added to `TestRealNorthStarSummary`.
- **CRS** (gemini, code-review-specialist): APPROVED. Security/performance clean (no ReDoS, no quadratic scans). Architecture sound: `extract_constraints` cleanly decoupled, degrades gracefully. Non-blocking advisory: `scope_boundaries` is `{}` when section missing and `{"is": [...], "is_not": [...]}` when present — documented contract, tested, Payload Compiler is expected to treat as Mapping and use `.get(...)`.
- **CE** (codex, critical-engineer): APPROVED. `continuation_id: 87cf9a10-db3a-47ef-a25d-da87b2d5e826`. No production blockers. Purity verified (no hidden I/O, no module-level mutation, only DEBUG on defensive paths). Legacy semantic note (informational): the new parser returns the full immutable list rather than the legacy cap of 4, which is the goal of issue #6. State-layer omission (PROJECT-CONTEXT below) accepted as correct per repo gitignore convention.

## Quality gates

| Gate | Result |
|---|---|
| `.venv/bin/python -m ruff check src tests` | All checks passed |
| `.venv/bin/python -m black --check src tests` | 71 files would be left unchanged |
| `.venv/bin/python -m mypy src` | Success: no issues in 28 source files |
| `.venv/bin/python -m pytest --cov-fail-under=85 -q` | **538 passed**; coverage **90.48%** |

### Coverage / test-count delta

- Baseline on `main@d0c7e09`: 512 tests, 90% coverage.
- This PR: 538 tests (+26: 20 parser unit + 3 clock_in integration + 3 boundary/unicode), coverage 90.48% (baseline floor 89% held — no regression).
- Parser module itself: 98% line coverage (two uncovered lines are defensive `except Exception` bodies marked `# pragma: no cover`).

## Backward compatibility

- `context.product_north_star` raw blob: byte-identical to pre-PR behaviour. Verified by `TestClockInNorthStarConstraints::test_raw_north_star_field_unchanged_when_constraints_added`.
- No existing test assertion on the raw field was modified.
- `get_context` tool intentionally left untouched (side-effect scope per task directive).

## Note on `PROJECT-CONTEXT.oct.md` (Issue #6 AC #5)

The authoritative `PROJECT-CONTEXT.oct.md` lives in the state layer (`.hestai-state/context/PROJECT-CONTEXT.oct.md`, symlinked as `.hestai/state/context/`) which is **gitignored** by repo convention (`.gitignore` lines 43-44). The file has been updated locally via `mcp__octave__octave_write` to record that structured extraction now ships — test count bumped to 538, coverage to 90%, `STRUCTURED_EXTRACTION` key added under `§1::CURRENT_STATE`, `NorthStarConstraintsParser` added to `§2::WHAT_THIS_SERVICE_OWNS`, `§3::PHASE_1` updated to note issue #6 harvest completion. Because the file is gitignored, it is not in this PR's diff; this note documents the state-layer update per CE §6 approval. If we later want PROJECT-CONTEXT to be a tracked artefact, that is a separate governance decision.

## Test plan

- [x] Full gate chain green locally (ruff / black / mypy / pytest).
- [x] Coverage ≥ 89% (actual 90.48%).
- [x] Real-NS behavioural tests pass against the live repo `.hestai/north-star/…-SUMMARY.oct.md`.
- [x] Backward-compat test confirms raw `product_north_star` field byte-identical.
- [x] Purity test confirms no filesystem writes during parsing.
- [ ] CI green on PR (awaits GitHub Actions run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pure parser to extract structured North Star constraints and exposes them in `clock_in` as `context.product_north_star_constraints`, while keeping the raw `context.product_north_star` unchanged. Also anchors section matching to real headers to prevent misparsing when tokens appear in free text. Addresses #6.

- **New Features**
  - Added `src/hestai_context_mcp/core/north_star_parser.py` with `extract_constraints(text) -> NorthStarConstraints` to parse `IMMUTABLES` and `SCOPE_BOUNDARIES` (`IS` / `IS_NOT`), keyed by literal section tokens; pure, provider-agnostic, never raises (debug-logs on failure).
  - Updated `src/hestai_context_mcp/tools/clock_in.py` to include `context.product_north_star_constraints` alongside the raw blob; always present with `scope_boundaries` dict and `immutables` list.

- **Bug Fixes**
  - Anchored section token matching to actual headers in `_section_slice` via `_find_section_header`, rejecting free-text, inline `::TOKEN`, and line-start sentence false positives; CRLF-safe.
  - Added tests covering adversarial cases and positive sanity; total tests now 558, coverage 90.45%.

<sup>Written for commit 26868cdf1f6e5c8b1076b09d28b1a177d3cb5c2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

