### PR TITLE
feat: ADR-0013 B1 — Portable Session State via Storage Adapters (LocalFilesystem)

### DIFF
--- a/src/hestai_context_mcp/core/redaction.py
+++ b/src/hestai_context_mcp/core/redaction.py
@@ -16,6 +16,21 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from re import Pattern
 
+#: Canonical engine identifier for provenance metadata (RISK_004 / G6).
+#: Used by storage.provenance.build_provenance to populate
+#: RedactionProvenance.engine_name on every published Portable Memory
+#: Artifact (ADR-0013 R6). Must remain stable across refactors so older
+#: artifacts can identify the engine that produced them.
+REDACTION_ENGINE_NAME: str = "hestai-context-mcp.redaction"
+
+#: Engine version embedded in artifact metadata (RISK_004 + G6 + A4).
+#: Bump this constant whenever PATTERNS or redaction semantics change so
+#: downstream readers can detect stale provenance and refuse to treat
+#: older redactor output as safe (PROD::I2 fail-closed). The B1
+#: arbitration record locks the value at '1' for the LocalFilesystem
+#: adapter ship.
+REDACTION_ENGINE_VERSION: str = "1"
+
 
 @dataclass(frozen=True)
 class RedactionResult:

--- a/src/hestai_context_mcp/core/session.py
+++ b/src/hestai_context_mcp/core/session.py
@@ -283,11 +283,20 @@ class SessionManager:
 
         Args:
             state_real: Path to the .hestai-state/ directory.
+
+        ADR-0013 §MIGRATION_PLAN FIRST_RUN_DIRECTORY_CREATION: clock_in
+        also creates the PSS portable subtree (outbox + snapshots) so
+        the LocalFilesystemAdapter has somewhere to write. get_context
+        is forbidden from creating these directories (purity invariant
+        in test_get_context_purity.py).
         """
         (state_real / "sessions" / "active").mkdir(parents=True, exist_ok=True)
         (state_real / "sessions" / "archive").mkdir(parents=True, exist_ok=True)
         (state_real / "context").mkdir(parents=True, exist_ok=True)
         (state_real / "context" / "state").mkdir(parents=True, exist_ok=True)
+        # PSS portable directories (R5 + R7). Created at clock_in time.
+        (state_real / "portable" / "outbox").mkdir(parents=True, exist_ok=True)
+        (state_real / "portable" / "snapshots").mkdir(parents=True, exist_ok=True)
 
     def _ensure_state_symlink(self, state_link: Path, state_real: Path) -> None:
         """Create .hestai/state symlink pointing to ../.hestai-state.

--- a/src/hestai_context_mcp/storage/__init__.py
+++ b/src/hestai_context_mcp/storage/__init__.py
@@ -1,0 +1,44 @@
+"""Portable Session State (PSS) storage package — ADR-0013 B1 foundation.
+
+Re-exports the stable type and protocol contract for ADR-0013 Portable
+Session State. Concrete adapters (currently only LocalFilesystemAdapter)
+land alongside; remote carriers are explicitly out of scope per R12 and
+the B2_START_BLOCKERS in the B1 BUILD-PLAN.
+
+Per CRS C1 the signatures here MUST match BUILD-PLAN §PROTOCOL_SIGNATURES
+verbatim. Any drift requires CE re-consult per the B1→B2 arbitration record.
+"""
+
+from __future__ import annotations
+
+from hestai_context_mcp.storage.types import (
+    ArtifactKind,
+    ArtifactRef,
+    IdentityTuple,
+    PortableArtifact,
+    PortableMemoryArtifact,
+    PortableNamespace,
+    PublishAck,
+    PublishStatus,
+    RedactionProvenance,
+    StateClassification,
+    StorageCapabilities,
+    TombstoneArtifact,
+    WritePrecondition,
+)
+
+__all__ = [
+    "ArtifactKind",
+    "ArtifactRef",
+    "IdentityTuple",
+    "PortableArtifact",
+    "PortableMemoryArtifact",
+    "PortableNamespace",
+    "PublishAck",
+    "PublishStatus",
+    "RedactionProvenance",
+    "StateClassification",
+    "StorageCapabilities",
+    "TombstoneArtifact",
+    "WritePrecondition",
+]

--- a/src/hestai_context_mcp/storage/__init__.py
+++ b/src/hestai_context_mcp/storage/__init__.py
@@ -11,6 +11,8 @@ verbatim. Any drift requires CE re-consult per the B1→B2 arbitration record.
 
 from __future__ import annotations
 
+from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+from hestai_context_mcp.storage.protocol import StorageAdapter
 from hestai_context_mcp.storage.types import (
     ArtifactKind,
     ArtifactRef,
@@ -31,6 +33,7 @@ __all__ = [
     "ArtifactKind",
     "ArtifactRef",
     "IdentityTuple",
+    "LocalFilesystemAdapter",
     "PortableArtifact",
     "PortableMemoryArtifact",
     "PortableNamespace",
@@ -38,6 +41,7 @@ __all__ = [
     "PublishStatus",
     "RedactionProvenance",
     "StateClassification",
+    "StorageAdapter",
     "StorageCapabilities",
     "TombstoneArtifact",
     "WritePrecondition",

--- a/src/hestai_context_mcp/storage/__init__.py
+++ b/src/hestai_context_mcp/storage/__init__.py
@@ -29,9 +29,19 @@ from hestai_context_mcp.storage.types import (
     WritePrecondition,
 )
 
+#: G1 (CIV) — canonical positive marker that the B1 layering chain is
+#: sealed. The post-B2 quality gate chain (TMG -> CRS -> CE -> CIV)
+#: introspects this constant to confirm B1's structural invariants are
+#: in force. Future B2 work that adds adapters MUST flip this flag (or
+#: replace it with a version-tagged equivalent) so the chain catches
+#: layering changes instead of silently accepting drift.
+B1_LAYERING_FROZEN: bool = True
+
+
 __all__ = [
     "ArtifactKind",
     "ArtifactRef",
+    "B1_LAYERING_FROZEN",
     "IdentityTuple",
     "LocalFilesystemAdapter",
     "PortableArtifact",

--- a/src/hestai_context_mcp/storage/classification.py
+++ b/src/hestai_context_mcp/storage/classification.py
@@ -52,11 +52,17 @@ def classify_state_path(target: Path, *, working_dir: Path) -> StateClassificati
     if not parts:
         return StateClassification.LOCAL_MUTABLE
 
-    # PORTABLE_MEMORY: artifacts and tombstones carrier files.
     if parts[:1] == ("portable",) and len(parts) > 1:
         sub = parts[1]
-        if sub in ("artifacts", "tombstones"):
-            return StateClassification.PORTABLE_MEMORY
+        # PORTABLE_MEMORY: ADR-0013 abstract path (CE rework RISK_006).
+        # Layout: portable/pss/{ns}/{proj}/{ws}/{user}/{leaf}/{id}.json
+        # where {leaf} is 'artifacts' or 'tombstones'. We classify by the
+        # second-from-last segment so the path geometry is the basis (R1).
+        if sub == "pss" and len(parts) >= 4:
+            leaf = parts[-2]
+            if leaf in ("artifacts", "tombstones"):
+                return StateClassification.PORTABLE_MEMORY
+            return StateClassification.LOCAL_MUTABLE
         if sub == "snapshots":
             return StateClassification.DERIVED_PROJECTION
         if sub in ("outbox", "tmp"):

--- a/src/hestai_context_mcp/storage/classification.py
+++ b/src/hestai_context_mcp/storage/classification.py
@@ -1,0 +1,100 @@
+"""ADR-0013 PSS state classification helpers — R1 + §MIGRATION_PLAN.
+
+Maps known ``.hestai/state/`` paths to ``StateClassification`` per the
+authoritative EXISTING_STATE_CLASSIFICATION_MAP in BUILD-PLAN
+§MIGRATION_PLAN. Unknown paths fail closed to ``LOCAL_MUTABLE`` (R1).
+
+The helpers here are pure: they perform no filesystem mutation and never
+require the target file to exist. They classify by *path shape*, which is
+the only safe basis when the migration runner does not yet know whether a
+given file has been written.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hestai_context_mcp.storage.types import StateClassification
+
+
+def _relative_state_path(target: Path, *, working_dir: Path) -> tuple[str, ...]:
+    """Return the path components of ``target`` relative to ``working_dir/.hestai/state``.
+
+    Returns an empty tuple when ``target`` is not inside the state tree.
+    Comparison uses absolute, resolved paths and tolerates the
+    ``.hestai/state`` -> ``.hestai-state`` symlink convention.
+    """
+
+    state_root = working_dir / ".hestai" / "state"
+    try:
+        rel = target.resolve().relative_to(state_root.resolve())
+    except (FileNotFoundError, ValueError):
+        try:
+            rel = target.relative_to(state_root)
+        except ValueError:
+            return ()
+    return rel.parts
+
+
+def classify_state_path(target: Path, *, working_dir: Path) -> StateClassification:
+    """Classify ``target`` per ADR-0013 R1.
+
+    Args:
+        target: A path *under* ``working_dir/.hestai/state``. Paths outside
+            the state tree default to ``LOCAL_MUTABLE`` (R1 fail-closed).
+        working_dir: Project root.
+
+    Returns:
+        ``StateClassification`` for the path shape.
+    """
+
+    parts = _relative_state_path(target, working_dir=working_dir)
+    if not parts:
+        return StateClassification.LOCAL_MUTABLE
+
+    # PORTABLE_MEMORY: artifacts and tombstones carrier files.
+    if parts[:1] == ("portable",) and len(parts) > 1:
+        sub = parts[1]
+        if sub in ("artifacts", "tombstones"):
+            return StateClassification.PORTABLE_MEMORY
+        if sub == "snapshots":
+            return StateClassification.DERIVED_PROJECTION
+        if sub in ("outbox", "tmp"):
+            return StateClassification.LOCAL_MUTABLE
+        # Unknown subtree under portable/ → fail-closed.
+        return StateClassification.LOCAL_MUTABLE
+
+    # All non-portable paths under .hestai/state/ default to LOCAL_MUTABLE.
+    return StateClassification.LOCAL_MUTABLE
+
+
+def classify_materialized_context(
+    target: Path, *, derived_from_portable_memory: bool
+) -> StateClassification:
+    """Classify a materialized PROJECT-CONTEXT.oct.md file (MAP_008).
+
+    The same on-disk path can be either ``DERIVED_PROJECTION`` (when
+    rebuilt from Portable Memory Artifacts) or ``LOCAL_MUTABLE`` (when
+    authored locally). Callers MUST signal the provenance explicitly;
+    when in doubt, pass ``derived_from_portable_memory=False`` to
+    fail-closed under R1.
+
+    Args:
+        target: Path to the materialized context file (e.g.,
+            ``.hestai/state/context/PROJECT-CONTEXT.oct.md``). Not opened.
+        derived_from_portable_memory: True iff the migration / rebuilder
+            produced this file from Portable Memory Artifacts.
+    """
+
+    # ``target`` is reserved for future shape-based dispatch; current
+    # behavior depends only on the explicit derivation flag (MAP_008).
+    del target
+    if derived_from_portable_memory:
+        return StateClassification.DERIVED_PROJECTION
+    return StateClassification.LOCAL_MUTABLE
+
+
+__all__ = [
+    "classify_materialized_context",
+    "classify_state_path",
+]

--- a/src/hestai_context_mcp/storage/classification.py
+++ b/src/hestai_context_mcp/storage/classification.py
@@ -56,11 +56,17 @@ def classify_state_path(target: Path, *, working_dir: Path) -> StateClassificati
         sub = parts[1]
         # PORTABLE_MEMORY: ADR-0013 abstract path (CE rework RISK_006).
         # Layout: portable/pss/{ns}/{proj}/{ws}/{user}/{leaf}/{id}.json
-        # where {leaf} is 'artifacts' or 'tombstones'. We classify by the
-        # second-from-last segment so the path geometry is the basis (R1).
-        if sub == "pss" and len(parts) >= 4:
-            leaf = parts[-2]
-            if leaf in ("artifacts", "tombstones"):
+        # where {leaf} is 'artifacts' or 'tombstones'.
+        #
+        # Cubic P2 #7: enforce EXACT segment count (8 parts relative to
+        # ``.hestai/state/``). The previous ``len(parts) >= 4`` guard was
+        # too permissive — paths like ``portable/pss/ns/artifacts/x.json``
+        # (5 segments) matched because parts[-2] == "artifacts" and were
+        # misclassified as PORTABLE_MEMORY. Per ADR-0013 R1 path geometry
+        # is authoritative, and per RULE_005 of BUILD-PLAN §SCOPE_DISCIPLINE
+        # malformed shapes fall through to LOCAL_MUTABLE.
+        if sub == "pss":
+            if len(parts) == 8 and parts[-2] in ("artifacts", "tombstones"):
                 return StateClassification.PORTABLE_MEMORY
             return StateClassification.LOCAL_MUTABLE
         if sub == "snapshots":

--- a/src/hestai_context_mcp/storage/identity.py
+++ b/src/hestai_context_mcp/storage/identity.py
@@ -68,8 +68,26 @@ class RestoreError(Exception):
         Exception.__init__(self, self.message)
 
 
-def _check_string_component(value: str, *, field: str) -> None:
-    """Validate a single identity string component (R3)."""
+def _check_string_component(value: object, *, field: str) -> None:
+    """Validate a single identity string component (R3).
+
+    Cubic P1 #2: explicitly reject non-string types BEFORE any string
+    method is called. Without this gate, a non-string truthy value
+    (e.g., int, list, dict) would reach ``value.strip()`` and raise
+    an unstructured ``AttributeError``. Per PROD::I2 fail-closed
+    identity validation and RISK_001, the structured error code is
+    ``invalid_identity_component_type``.
+    """
+
+    if not isinstance(value, str):
+        raise IdentityValidationError(
+            code="invalid_identity_component_type",
+            message=(
+                f"identity component {field!r} must be a string, "
+                f"got {type(value).__name__}"
+            ),
+            field=field,
+        )
 
     if not value or not value.strip():
         raise IdentityValidationError(

--- a/src/hestai_context_mcp/storage/identity.py
+++ b/src/hestai_context_mcp/storage/identity.py
@@ -134,8 +134,13 @@ def validate_identity_tuple(identity: IdentityTuple) -> IdentityTuple:
     for field in ("project_id", "workspace_id", "user_id", "carrier_namespace"):
         _check_string_component(getattr(identity, field), field=field)
 
+    # Cubic P1 #5: bool subclasses int, so ``isinstance(int)`` would
+    # silently accept True/False (True → 1 passes the supported-version
+    # membership check). Reject bool explicitly before the int check so
+    # PROD::I2 fail-closed identity validation rejects all non-int types.
     if (
-        not isinstance(identity.state_schema_version, int)
+        isinstance(identity.state_schema_version, bool)
+        or not isinstance(identity.state_schema_version, int)
         or identity.state_schema_version <= 0
         or identity.state_schema_version not in SUPPORTED_SCHEMA_VERSIONS
     ):

--- a/src/hestai_context_mcp/storage/identity.py
+++ b/src/hestai_context_mcp/storage/identity.py
@@ -83,8 +83,7 @@ def _check_string_component(value: object, *, field: str) -> None:
         raise IdentityValidationError(
             code="invalid_identity_component_type",
             message=(
-                f"identity component {field!r} must be a string, "
-                f"got {type(value).__name__}"
+                f"identity component {field!r} must be a string, " f"got {type(value).__name__}"
             ),
             field=field,
         )

--- a/src/hestai_context_mcp/storage/identity.py
+++ b/src/hestai_context_mcp/storage/identity.py
@@ -1,0 +1,167 @@
+"""ADR-0013 PSS identity validation — R3 + RISK_001 fail-closed observability.
+
+Pure validation helpers for IdentityTuple and PortableNamespace. Performs
+no filesystem I/O. Returns structured errors so callers (clock_in restore
+path, clock_out publish path) can route them into observable
+``portable_state.error`` payloads without inventing auth or first-run UX
+(B2_START_BLOCKER_001).
+
+Binding rulings:
+- R3: project_id/workspace_id/user_id/carrier_namespace must be non-blank
+  strings free of path separators, traversal sequences, and control chars.
+  state_schema_version must be a positive int in SUPPORTED_SCHEMA_VERSIONS.
+- R10: namespace/identity mismatch is a structured ValidationError, not a
+  silent empty-restore fallback.
+- RISK_001 + A1: ``RestoreError`` carries a code + optional cause for
+  fail-closed observability when identity/schema/IO problems occur during
+  the restore lifecycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hestai_context_mcp.storage.types import IdentityTuple, PortableNamespace
+
+#: Supported state-schema-version set. Currently single-version (R4 + B1
+#: scope: NO compaction, NO v2 content). Expanding this set requires CE
+#: re-consult per the B1→B2 arbitration record.
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+
+_PATH_SEPARATORS: tuple[str, ...] = ("/", "\\")
+_TRAVERSAL_TOKENS: tuple[str, ...] = ("..",)
+_CONTROL_CHARS: tuple[str, ...] = ("\n", "\r", "\t", "\x00")
+
+
+class IdentityValidationError(ValueError):
+    """Structured validation error for identity inputs.
+
+    Attributes:
+        code: Stable error code (machine-readable; safe for logging).
+        field: Identity field that failed validation, when applicable.
+        message: Human-readable description.
+    """
+
+    def __init__(self, code: str, message: str, *, field: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.field = field
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreError(Exception):
+    """Structured restore error (RISK_001 + A1).
+
+    Used by the clock_in restore pipeline to surface identity-mismatch,
+    schema_too_new, or local-adapter IO failures in a machine-readable
+    shape. Inherits from Exception so callers can ``raise`` and ``catch``
+    normally; the attributes (code, message, cause) form the wire shape
+    that lands in ``clock_in`` response ``portable_state.error``.
+    """
+
+    code: str
+    message: str
+    cause: BaseException | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover — Exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def _check_string_component(value: str, *, field: str) -> None:
+    """Validate a single identity string component (R3)."""
+
+    if not value or not value.strip():
+        raise IdentityValidationError(
+            code="blank_identity_component",
+            message=f"identity component {field!r} must be a non-blank string",
+            field=field,
+        )
+
+    for sep in _PATH_SEPARATORS:
+        if sep in value:
+            raise IdentityValidationError(
+                code="path_separator",
+                message=f"identity component {field!r} must not contain path separator {sep!r}",
+                field=field,
+            )
+
+    for token in _TRAVERSAL_TOKENS:
+        if token in value:
+            raise IdentityValidationError(
+                code="path_traversal",
+                message=f"identity component {field!r} must not contain traversal token {token!r}",
+                field=field,
+            )
+
+    for ctrl in _CONTROL_CHARS:
+        if ctrl in value:
+            raise IdentityValidationError(
+                code="control_character",
+                message=f"identity component {field!r} must not contain control characters",
+                field=field,
+            )
+
+
+def validate_identity_tuple(identity: IdentityTuple) -> IdentityTuple:
+    """Validate an IdentityTuple before any path construction or adapter call.
+
+    Returns the same identity unchanged on success so callers can chain
+    e.g. ``adapter.list_artifacts(validate_identity_tuple(identity))``.
+
+    Raises:
+        IdentityValidationError: with a stable ``code`` field on failure.
+    """
+
+    for field in ("project_id", "workspace_id", "user_id", "carrier_namespace"):
+        _check_string_component(getattr(identity, field), field=field)
+
+    if (
+        not isinstance(identity.state_schema_version, int)
+        or identity.state_schema_version <= 0
+        or identity.state_schema_version not in SUPPORTED_SCHEMA_VERSIONS
+    ):
+        raise IdentityValidationError(
+            code="unsupported_schema_version",
+            message=(
+                f"state_schema_version={identity.state_schema_version!r} not in "
+                f"supported set {sorted(SUPPORTED_SCHEMA_VERSIONS)!r}"
+            ),
+            field="state_schema_version",
+        )
+
+    return identity
+
+
+def validate_namespace_matches_identity(
+    *, namespace: PortableNamespace, identity: IdentityTuple
+) -> None:
+    """Assert PortableNamespace == IdentityTuple component-wise (NOTE_007 / R3)."""
+
+    mismatches: list[str] = []
+    for field in (
+        "project_id",
+        "workspace_id",
+        "user_id",
+        "state_schema_version",
+        "carrier_namespace",
+    ):
+        if getattr(namespace, field) != getattr(identity, field):
+            mismatches.append(field)
+
+    if mismatches:
+        raise IdentityValidationError(
+            code="namespace_identity_mismatch",
+            message=(
+                "PortableNamespace does not match IdentityTuple in fields: " + ", ".join(mismatches)
+            ),
+        )
+
+
+__all__ = [
+    "IdentityValidationError",
+    "RestoreError",
+    "SUPPORTED_SCHEMA_VERSIONS",
+    "validate_identity_tuple",
+    "validate_namespace_matches_identity",
+]

--- a/src/hestai_context_mcp/storage/identity_resolver.py
+++ b/src/hestai_context_mcp/storage/identity_resolver.py
@@ -63,13 +63,30 @@ def resolve_identity(working_dir: str | Path) -> IdentityTuple | None:
             code="identity_config_shape",
             message=f"PSS identity config at {cfg_path} must be a JSON object",
         )
+
+    # Cubic P2 #6: do NOT silently coerce non-string identity fields via
+    # str(...). Per RISK_001 fail-closed default and PROD::I2 fail-closed
+    # identity safety, a malformed identity.json (string fields that are
+    # actually int/list/dict) must surface as "no identity configured"
+    # rather than a fabricated IdentityTuple. Return None so callers
+    # (clock_in restore path, clock_out publish path) treat the situation
+    # exactly as if the file were missing.
+    for string_field in ("project_id", "workspace_id", "user_id", "carrier_namespace"):
+        value = raw.get(string_field)
+        if not isinstance(value, str):
+            return None
+    if not isinstance(raw.get("state_schema_version"), int) or isinstance(
+        raw.get("state_schema_version"), bool
+    ):
+        return None
+
     try:
         identity = IdentityTuple(
-            project_id=str(raw["project_id"]),
-            workspace_id=str(raw["workspace_id"]),
-            user_id=str(raw["user_id"]),
-            state_schema_version=int(raw["state_schema_version"]),
-            carrier_namespace=str(raw["carrier_namespace"]),
+            project_id=raw["project_id"],
+            workspace_id=raw["workspace_id"],
+            user_id=raw["user_id"],
+            state_schema_version=raw["state_schema_version"],
+            carrier_namespace=raw["carrier_namespace"],
         )
     except (KeyError, TypeError, ValueError) as e:
         raise IdentityValidationError(

--- a/src/hestai_context_mcp/storage/identity_resolver.py
+++ b/src/hestai_context_mcp/storage/identity_resolver.py
@@ -1,0 +1,82 @@
+"""ADR-0013 PSS identity resolver — RISK_001 + B2_START_BLOCKER_001.
+
+Resolves the PSS IdentityTuple from on-disk project configuration.
+Per the BUILD-PLAN B2_START_BLOCKER_001, B1 must NOT invent auth or
+first-run UX. The resolver looks for a single configuration file at::
+
+    .hestai/state/portable/identity.json
+
+If the file is absent, the resolver returns ``None``. Callers (clock_in
+restore path, clock_out publish path) treat ``None`` as a fail-closed
+"no identity configured" state — no exception, no fallback identity.
+This preserves PROD::I6 (local-first, optional remote) and avoids
+breaching B2_START_BLOCKER_001.
+
+The configuration file shape is one JSON object containing exactly the
+five IdentityTuple fields. Schema version negotiation is handled by
+storage.identity.validate_identity_tuple.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hestai_context_mcp.storage.identity import (
+    IdentityValidationError,
+    validate_identity_tuple,
+)
+from hestai_context_mcp.storage.types import IdentityTuple
+
+
+def _identity_config_path(working_dir: Path) -> Path:
+    return working_dir / ".hestai" / "state" / "portable" / "identity.json"
+
+
+def resolve_identity(working_dir: str | Path) -> IdentityTuple | None:
+    """Return the configured PSS IdentityTuple or ``None`` if absent.
+
+    Args:
+        working_dir: Project root.
+
+    Returns:
+        Validated ``IdentityTuple`` when configuration exists; ``None``
+        when the configuration file is missing.
+
+    Raises:
+        IdentityValidationError: when the configuration file exists but
+            its contents fail R3 validation.
+    """
+
+    cfg_path = _identity_config_path(Path(working_dir))
+    if not cfg_path.exists():
+        return None
+    try:
+        raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise IdentityValidationError(
+            code="identity_config_unreadable",
+            message=f"failed to read PSS identity config at {cfg_path}: {e}",
+        ) from e
+    if not isinstance(raw, dict):
+        raise IdentityValidationError(
+            code="identity_config_shape",
+            message=f"PSS identity config at {cfg_path} must be a JSON object",
+        )
+    try:
+        identity = IdentityTuple(
+            project_id=str(raw["project_id"]),
+            workspace_id=str(raw["workspace_id"]),
+            user_id=str(raw["user_id"]),
+            state_schema_version=int(raw["state_schema_version"]),
+            carrier_namespace=str(raw["carrier_namespace"]),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise IdentityValidationError(
+            code="identity_config_fields",
+            message=f"PSS identity config at {cfg_path} is missing required fields: {e}",
+        ) from e
+    return validate_identity_tuple(identity)
+
+
+__all__ = ["resolve_identity"]

--- a/src/hestai_context_mcp/storage/local_filesystem.py
+++ b/src/hestai_context_mcp/storage/local_filesystem.py
@@ -26,14 +26,20 @@ Binding rulings enforced here:
 - R11: no git CLI shell-out, no custom Git refs.
 - R12: no network imports, no remote SDKs.
 
-Local carrier path layout (RISK_006):
+Local carrier path layout (RISK_006, post-CE-rework):
 
     .hestai/state/portable/
-      artifacts/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/v{schema_version}/{artifact_id}.json
-      tombstones/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/v{schema_version}/{artifact_id}.json
+      pss/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/artifacts/{artifact_id}.json
+      pss/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/tombstones/{artifact_id}.json
       tmp/                # atomic-write staging
       outbox/             # owned by storage.outbox (R7)
       snapshots/          # owned by storage.snapshots (R5)
+
+CE Stage C ruling (RISK_006 APPROVE_MIRROR): the on-disk path MUST
+match the ADR-0013 abstract path. The 'pss' top segment, the END-
+position 'artifacts/' segment, and the absence of any v{schema_version}
+segment are all binding. schema_version is a field inside the artifact
+and namespace records — embedding it in the path is over-specification.
 """
 
 from __future__ import annotations
@@ -304,18 +310,29 @@ class LocalFilesystemAdapter:
         return True
 
     @property
-    def _artifacts_root(self) -> Path:
-        return self.portable_root / "artifacts"
+    def _pss_root(self) -> Path:
+        """Root for the ADR-0013 abstract-path layout: ``portable/pss/``."""
 
-    @property
-    def _tombstones_root(self) -> Path:
-        return self.portable_root / "tombstones"
+        return self.portable_root / "pss"
 
     @property
     def _tmp_root(self) -> Path:
         return self.portable_root / "tmp"
 
     def _namespace_dir(self, namespace: PortableNamespace, *, kind: ArtifactKind) -> Path:
+        """Per-identity namespace dir for ``kind``.
+
+        Layout (CE rework RISK_006 APPROVE_MIRROR — ADR-0013 abstract path)::
+
+            pss/{ns}/{proj}/{ws}/{user}/artifacts
+            pss/{ns}/{proj}/{ws}/{user}/tombstones
+
+        The 'artifacts'/'tombstones' segment lives at the END so the
+        identity-keyed subtree is shared and the kind segment terminates
+        the directory. No ``v{schema_version}`` segment — schema_version
+        is a field inside the artifact/namespace records.
+        """
+
         # Validate identity-shaped fields before any path construction (R3).
         identity = IdentityTuple(
             project_id=namespace.project_id,
@@ -326,32 +343,28 @@ class LocalFilesystemAdapter:
         )
         validate_identity_tuple(identity)
 
-        root = (
-            self._artifacts_root if kind is ArtifactKind.PORTABLE_MEMORY else self._tombstones_root
-        )
+        leaf = "artifacts" if kind is ArtifactKind.PORTABLE_MEMORY else "tombstones"
         return (
-            root
+            self._pss_root
             / namespace.carrier_namespace
             / namespace.project_id
             / namespace.workspace_id
             / namespace.user_id
-            / f"v{namespace.state_schema_version}"
+            / leaf
         )
 
     def _artifact_path(self, ref: ArtifactRef) -> Path:
         # Validate identity before path construction (R3).
         validate_identity_tuple(ref.identity)
         kind = ref.artifact_kind
-        root = (
-            self._artifacts_root if kind is ArtifactKind.PORTABLE_MEMORY else self._tombstones_root
-        )
+        leaf = "artifacts" if kind is ArtifactKind.PORTABLE_MEMORY else "tombstones"
         return (
-            root
+            self._pss_root
             / ref.identity.carrier_namespace
             / ref.identity.project_id
             / ref.identity.workspace_id
             / ref.identity.user_id
-            / f"v{ref.identity.state_schema_version}"
+            / leaf
             / f"{ref.artifact_id}.json"
         )
 

--- a/src/hestai_context_mcp/storage/local_filesystem.py
+++ b/src/hestai_context_mcp/storage/local_filesystem.py
@@ -1,0 +1,568 @@
+"""ADR-0013 PSS LocalFilesystemAdapter — default B1 storage carrier.
+
+Implements the StorageAdapter protocol against the local filesystem rooted
+at ``{working_dir}/.hestai/state/portable/``. This is the only adapter that
+ships in B1 per ADR-0013 R12 and the BUILD-PLAN scope discipline.
+
+Binding rulings enforced here:
+
+- INVARIANT_003 (R6 + R10) + G4: ``write_artifact`` validates redaction
+  provenance via :func:`storage.provenance.validate_provenance_complete`
+  BEFORE any filesystem write. Incomplete provenance raises
+  ``ProvenanceIncompleteError`` with no on-disk side-effects.
+- R2 + R9: writes are conditional create-only by default
+  (``WritePrecondition.if_absent``). Same artifact_id with the same
+  payload_hash returns ``PublishStatus.DUPLICATE`` (idempotent). Same
+  artifact_id with a *different* payload_hash returns
+  ``PublishStatus.FAILED`` and never overwrites.
+- R3: ``PortableNamespace`` and ``IdentityTuple`` are validated through
+  :func:`storage.identity.validate_identity_tuple` BEFORE path
+  construction, preventing traversal/path-separator components from
+  reaching the filesystem.
+- R8: tombstones append into ``portable/tombstones/{namespace}`` and never
+  delete the target artifact. Tombstones whose ``reason`` indicates
+  post-hoc redaction failure require non-null
+  ``redaction_provenance`` (validated complete).
+- R11: no git CLI shell-out, no custom Git refs.
+- R12: no network imports, no remote SDKs.
+
+Local carrier path layout (RISK_006):
+
+    .hestai/state/portable/
+      artifacts/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/v{schema_version}/{artifact_id}.json
+      tombstones/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/v{schema_version}/{artifact_id}.json
+      tmp/                # atomic-write staging
+      outbox/             # owned by storage.outbox (R7)
+      snapshots/          # owned by storage.snapshots (R5)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from hestai_context_mcp.storage.identity import (
+    validate_identity_tuple,
+    validate_namespace_matches_identity,
+)
+from hestai_context_mcp.storage.provenance import validate_provenance_complete
+from hestai_context_mcp.storage.types import (
+    ArtifactKind,
+    ArtifactRef,
+    IdentityTuple,
+    PortableArtifact,
+    PortableMemoryArtifact,
+    PortableNamespace,
+    PublishAck,
+    PublishStatus,
+    RedactionProvenance,
+    StorageCapabilities,
+    TombstoneArtifact,
+    WritePrecondition,
+)
+
+# Reasons that indicate post-hoc redaction failure — these tombstones MUST
+# carry non-null redaction_provenance per ADR-0013 R8.
+_REDACTION_FAILURE_REASONS: frozenset[str] = frozenset(
+    {"redaction_failure", "post_hoc_redaction_failure"}
+)
+
+_LOCAL_CAPABILITIES = StorageCapabilities(
+    strong_list_consistency=True,
+    atomic_compare_and_swap=True,
+    conditional_writes=True,
+    advisory_locking=False,
+    streaming_writes=False,
+    encryption_at_rest=False,
+    encryption_in_transit=False,
+    hard_delete=False,
+    read_only=False,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadHashMismatchError(Exception):
+    """Raised when an on-disk artifact payload no longer matches its hash (R4)."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+@dataclass(frozen=True, slots=True)
+class TombstoneProvenanceRequiredError(Exception):
+    """Raised when a redaction-failure tombstone lacks redaction_provenance (R8)."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def _serialize_identity(identity: IdentityTuple) -> dict[str, Any]:
+    return {
+        "project_id": identity.project_id,
+        "workspace_id": identity.workspace_id,
+        "user_id": identity.user_id,
+        "state_schema_version": identity.state_schema_version,
+        "carrier_namespace": identity.carrier_namespace,
+    }
+
+
+def _serialize_provenance(p: RedactionProvenance) -> dict[str, Any]:
+    return {
+        "engine_name": p.engine_name,
+        "engine_version": p.engine_version,
+        "ruleset_hash": p.ruleset_hash,
+        "input_artifact_hash": p.input_artifact_hash,
+        "output_artifact_hash": p.output_artifact_hash,
+        "redacted_at": p.redacted_at.isoformat(),
+        "classification_label": p.classification_label,
+        "redacted_credential_categories": list(p.redacted_credential_categories),
+    }
+
+
+def _serialize_memory_artifact(artifact: PortableMemoryArtifact) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact.artifact_id,
+        "artifact_kind": artifact.artifact_kind.value,
+        "identity": _serialize_identity(artifact.identity),
+        "schema_version": artifact.schema_version,
+        "producer_version": artifact.producer_version,
+        "minimum_reader_version": artifact.minimum_reader_version,
+        "created_at": artifact.created_at.isoformat(),
+        "sequence_id": artifact.sequence_id,
+        "parent_ids": list(artifact.parent_ids),
+        "redaction_provenance": _serialize_provenance(artifact.redaction_provenance),
+        "classification_label": artifact.classification_label,
+        "payload_hash": artifact.payload_hash,
+        "payload": dict(artifact.payload),
+    }
+
+
+def _serialize_tombstone(tomb: TombstoneArtifact) -> dict[str, Any]:
+    return {
+        "artifact_id": tomb.artifact_id,
+        "artifact_kind": tomb.artifact_kind.value,
+        "identity": _serialize_identity(tomb.identity),
+        "schema_version": tomb.schema_version,
+        "producer_version": tomb.producer_version,
+        "minimum_reader_version": tomb.minimum_reader_version,
+        "created_at": tomb.created_at.isoformat(),
+        "sequence_id": tomb.sequence_id,
+        "parent_ids": list(tomb.parent_ids),
+        "target_artifact_id": tomb.target_artifact_id,
+        "reason": tomb.reason,
+        "publisher_identity": _serialize_identity(tomb.publisher_identity),
+        "redaction_provenance": (
+            _serialize_provenance(tomb.redaction_provenance)
+            if tomb.redaction_provenance is not None
+            else None
+        ),
+        "classification_label": tomb.classification_label,
+        "payload_hash": tomb.payload_hash,
+    }
+
+
+def _parse_identity(raw: dict[str, Any]) -> IdentityTuple:
+    return IdentityTuple(
+        project_id=str(raw["project_id"]),
+        workspace_id=str(raw["workspace_id"]),
+        user_id=str(raw["user_id"]),
+        state_schema_version=int(raw["state_schema_version"]),
+        carrier_namespace=str(raw["carrier_namespace"]),
+    )
+
+
+def _parse_provenance(raw: dict[str, Any]) -> RedactionProvenance:
+    redacted_at = raw["redacted_at"]
+    if isinstance(redacted_at, str):
+        redacted_at = datetime.fromisoformat(redacted_at)
+    return RedactionProvenance(
+        engine_name=str(raw["engine_name"]),
+        engine_version=str(raw["engine_version"]),
+        ruleset_hash=str(raw["ruleset_hash"]),
+        input_artifact_hash=str(raw["input_artifact_hash"]),
+        output_artifact_hash=str(raw["output_artifact_hash"]),
+        redacted_at=redacted_at,
+        classification_label="PORTABLE_MEMORY",
+        redacted_credential_categories=tuple(raw.get("redacted_credential_categories", ())),
+    )
+
+
+def _parse_memory_artifact(raw: dict[str, Any]) -> PortableMemoryArtifact:
+    created_at = raw["created_at"]
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+    return PortableMemoryArtifact(
+        artifact_id=str(raw["artifact_id"]),
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=_parse_identity(raw["identity"]),
+        schema_version=int(raw["schema_version"]),
+        producer_version=str(raw["producer_version"]),
+        minimum_reader_version=int(raw["minimum_reader_version"]),
+        created_at=created_at,
+        sequence_id=int(raw["sequence_id"]),
+        parent_ids=tuple(raw.get("parent_ids", ())),
+        redaction_provenance=_parse_provenance(raw["redaction_provenance"]),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=str(raw["payload_hash"]),
+        payload=dict(raw["payload"]),
+    )
+
+
+def _parse_tombstone(raw: dict[str, Any]) -> TombstoneArtifact:
+    created_at = raw["created_at"]
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+    prov_raw = raw.get("redaction_provenance")
+    prov = _parse_provenance(prov_raw) if prov_raw is not None else None
+    return TombstoneArtifact(
+        artifact_id=str(raw["artifact_id"]),
+        artifact_kind=ArtifactKind.TOMBSTONE,
+        identity=_parse_identity(raw["identity"]),
+        schema_version=int(raw["schema_version"]),
+        producer_version=str(raw["producer_version"]),
+        minimum_reader_version=int(raw["minimum_reader_version"]),
+        created_at=created_at,
+        sequence_id=int(raw["sequence_id"]),
+        parent_ids=tuple(raw.get("parent_ids", ())),
+        target_artifact_id=str(raw["target_artifact_id"]),
+        reason=str(raw["reason"]),
+        publisher_identity=_parse_identity(raw["publisher_identity"]),
+        redaction_provenance=prov,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=str(raw["payload_hash"]),
+    )
+
+
+def _atomic_write_json(target: Path, data: dict[str, Any], *, tmp_root: Path) -> None:
+    """Write ``data`` as JSON to ``target`` atomically.
+
+    Writes to a temp file under ``tmp_root`` then renames into place. The
+    temp directory is created on demand. Caller is responsible for ensuring
+    ``target.parent`` exists.
+    """
+
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(tmp_root), suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp_name, target)
+    except BaseException:
+        # Cleanup partial tmp file on any error.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+class LocalFilesystemAdapter:
+    """Default B1 LocalFilesystemAdapter implementation (StorageAdapter Protocol).
+
+    Args:
+        working_dir: Project root containing ``.hestai/state/`` (or its
+            symlink). The adapter writes only under
+            ``working_dir/.hestai/state/portable/``.
+    """
+
+    capabilities: StorageCapabilities
+
+    def __init__(self, working_dir: str | Path) -> None:
+        self._working_dir = Path(working_dir).resolve()
+        self.capabilities = _LOCAL_CAPABILITIES
+
+    @property
+    def portable_root(self) -> Path:
+        """Root path for all PSS local-carrier state."""
+
+        return self._working_dir / ".hestai" / "state" / "portable"
+
+    @property
+    def _artifacts_root(self) -> Path:
+        return self.portable_root / "artifacts"
+
+    @property
+    def _tombstones_root(self) -> Path:
+        return self.portable_root / "tombstones"
+
+    @property
+    def _tmp_root(self) -> Path:
+        return self.portable_root / "tmp"
+
+    def _namespace_dir(self, namespace: PortableNamespace, *, kind: ArtifactKind) -> Path:
+        # Validate identity-shaped fields before any path construction (R3).
+        identity = IdentityTuple(
+            project_id=namespace.project_id,
+            workspace_id=namespace.workspace_id,
+            user_id=namespace.user_id,
+            state_schema_version=namespace.state_schema_version,
+            carrier_namespace=namespace.carrier_namespace,
+        )
+        validate_identity_tuple(identity)
+
+        root = (
+            self._artifacts_root if kind is ArtifactKind.PORTABLE_MEMORY else self._tombstones_root
+        )
+        return (
+            root
+            / namespace.carrier_namespace
+            / namespace.project_id
+            / namespace.workspace_id
+            / namespace.user_id
+            / f"v{namespace.state_schema_version}"
+        )
+
+    def _artifact_path(self, ref: ArtifactRef) -> Path:
+        # Validate identity before path construction (R3).
+        validate_identity_tuple(ref.identity)
+        kind = ref.artifact_kind
+        root = (
+            self._artifacts_root if kind is ArtifactKind.PORTABLE_MEMORY else self._tombstones_root
+        )
+        return (
+            root
+            / ref.identity.carrier_namespace
+            / ref.identity.project_id
+            / ref.identity.workspace_id
+            / ref.identity.user_id
+            / f"v{ref.identity.state_schema_version}"
+            / f"{ref.artifact_id}.json"
+        )
+
+    # ---- StorageAdapter API ----------------------------------------------
+
+    def list_artifacts(
+        self,
+        namespace: PortableNamespace,
+        after_id: str | None = None,
+    ) -> list[ArtifactRef]:
+        """List artifacts in deterministic monotonic (sequence_id, artifact_id) order."""
+
+        # Validate namespace before path construction (R3).
+        ns_dir = self._namespace_dir(namespace, kind=ArtifactKind.PORTABLE_MEMORY)
+        if not ns_dir.exists():
+            return []
+
+        refs: list[ArtifactRef] = []
+        for json_path in ns_dir.glob("*.json"):
+            try:
+                raw = json.loads(json_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            artifact = _parse_memory_artifact(raw)
+            if artifact.identity != IdentityTuple(
+                project_id=namespace.project_id,
+                workspace_id=namespace.workspace_id,
+                user_id=namespace.user_id,
+                state_schema_version=namespace.state_schema_version,
+                carrier_namespace=namespace.carrier_namespace,
+            ):
+                continue
+            refs.append(
+                ArtifactRef(
+                    artifact_id=artifact.artifact_id,
+                    identity=artifact.identity,
+                    artifact_kind=artifact.artifact_kind,
+                    sequence_id=artifact.sequence_id,
+                    created_at=artifact.created_at,
+                    payload_hash=artifact.payload_hash,
+                    carrier_path=str(json_path),
+                )
+            )
+
+        refs.sort(key=lambda r: (r.sequence_id, r.artifact_id))
+        if after_id is not None:
+            refs = [r for r in refs if r.artifact_id > after_id]
+        return refs
+
+    def read_artifact(self, ref: ArtifactRef) -> PortableArtifact:
+        """Read the artifact identified by ``ref`` and validate payload_hash (R4)."""
+
+        path = self._artifact_path(ref)
+        if not path.exists():
+            raise FileNotFoundError(f"Portable artifact not found: {path}")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        kind = raw.get("artifact_kind")
+        if kind == ArtifactKind.PORTABLE_MEMORY.value:
+            artifact = _parse_memory_artifact(raw)
+            # Identity match check (R3).
+            if artifact.identity != ref.identity:
+                from hestai_context_mcp.storage.identity import IdentityValidationError
+
+                raise IdentityValidationError(
+                    code="ref_identity_mismatch",
+                    message="ArtifactRef.identity does not match on-disk artifact identity",
+                )
+            # Payload hash validation (R4).
+            recomputed = hashlib.sha256(
+                json.dumps(artifact.payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if recomputed != artifact.payload_hash:
+                raise PayloadHashMismatchError(
+                    code="payload_hash_mismatch",
+                    message=(
+                        f"on-disk payload hash {recomputed!r} does not match stored "
+                        f"payload_hash {artifact.payload_hash!r}"
+                    ),
+                )
+            return artifact
+        if kind == ArtifactKind.TOMBSTONE.value:
+            tomb = _parse_tombstone(raw)
+            if tomb.identity != ref.identity:
+                from hestai_context_mcp.storage.identity import IdentityValidationError
+
+                raise IdentityValidationError(
+                    code="ref_identity_mismatch",
+                    message="ArtifactRef.identity does not match on-disk tombstone identity",
+                )
+            return tomb
+        raise PayloadHashMismatchError(
+            code="unknown_artifact_kind",
+            message=f"unsupported artifact_kind {kind!r}",
+        )
+
+    def write_artifact(
+        self,
+        ref: ArtifactRef,
+        artifact: PortableMemoryArtifact,
+        precondition: WritePrecondition,
+    ) -> PublishAck:
+        """Write a provenance-validated PortableMemoryArtifact (G4 atomic guard)."""
+
+        # G4: provenance gate runs BEFORE any filesystem side-effect.
+        validate_provenance_complete(artifact.redaction_provenance)
+        # R3: identity validation BEFORE path construction.
+        validate_identity_tuple(artifact.identity)
+        # NOTE_007: namespace == identity.
+        validate_namespace_matches_identity(
+            namespace=PortableNamespace(
+                project_id=artifact.identity.project_id,
+                workspace_id=artifact.identity.workspace_id,
+                user_id=artifact.identity.user_id,
+                state_schema_version=artifact.identity.state_schema_version,
+                carrier_namespace=artifact.identity.carrier_namespace,
+            ),
+            identity=artifact.identity,
+        )
+
+        target = self._artifact_path(ref)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        if target.exists() and precondition.if_absent:
+            existing_raw = json.loads(target.read_text(encoding="utf-8"))
+            existing_hash = str(existing_raw.get("payload_hash"))
+            if existing_hash == artifact.payload_hash:
+                return PublishAck(
+                    artifact_id=artifact.artifact_id,
+                    identity=artifact.identity,
+                    carrier_namespace=artifact.identity.carrier_namespace,
+                    sequence_id=artifact.sequence_id,
+                    status=PublishStatus.DUPLICATE,
+                    durable_carrier_receipt=str(target),
+                    queued_path=None,
+                    published_at=datetime.now(UTC),
+                    error_code=None,
+                    error_message=None,
+                )
+            return PublishAck(
+                artifact_id=artifact.artifact_id,
+                identity=artifact.identity,
+                carrier_namespace=artifact.identity.carrier_namespace,
+                sequence_id=artifact.sequence_id,
+                status=PublishStatus.FAILED,
+                durable_carrier_receipt=None,
+                queued_path=None,
+                published_at=None,
+                error_code="precondition_conflicting_payload",
+                error_message=(
+                    f"artifact_id {artifact.artifact_id!r} already exists with a different "
+                    "payload_hash; refusing to overwrite (R9 append-first)"
+                ),
+            )
+
+        _atomic_write_json(target, _serialize_memory_artifact(artifact), tmp_root=self._tmp_root)
+        return PublishAck(
+            artifact_id=artifact.artifact_id,
+            identity=artifact.identity,
+            carrier_namespace=artifact.identity.carrier_namespace,
+            sequence_id=artifact.sequence_id,
+            status=PublishStatus.PUBLISHED,
+            durable_carrier_receipt=str(target),
+            queued_path=None,
+            published_at=datetime.now(UTC),
+            error_code=None,
+            error_message=None,
+        )
+
+    def write_tombstone(
+        self,
+        ref: ArtifactRef,
+        tombstone: TombstoneArtifact,
+        precondition: WritePrecondition,
+    ) -> PublishAck:
+        """Append a tombstone artifact (R8)."""
+
+        # If the reason represents post-hoc redaction failure, provenance is required.
+        if tombstone.reason in _REDACTION_FAILURE_REASONS:
+            if tombstone.redaction_provenance is None:
+                raise TombstoneProvenanceRequiredError(
+                    code="tombstone_provenance_required",
+                    message=(
+                        f"tombstone reason {tombstone.reason!r} indicates post-hoc redaction "
+                        "failure; redaction_provenance is required"
+                    ),
+                )
+            validate_provenance_complete(tombstone.redaction_provenance)
+
+        # Identity validation BEFORE path construction (R3).
+        validate_identity_tuple(tombstone.identity)
+        validate_identity_tuple(tombstone.publisher_identity)
+
+        target = self._artifact_path(ref)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        if target.exists() and precondition.if_absent:
+            return PublishAck(
+                artifact_id=tombstone.artifact_id,
+                identity=tombstone.identity,
+                carrier_namespace=tombstone.identity.carrier_namespace,
+                sequence_id=tombstone.sequence_id,
+                status=PublishStatus.DUPLICATE,
+                durable_carrier_receipt=str(target),
+                queued_path=None,
+                published_at=datetime.now(UTC),
+                error_code=None,
+                error_message=None,
+            )
+
+        _atomic_write_json(target, _serialize_tombstone(tombstone), tmp_root=self._tmp_root)
+        return PublishAck(
+            artifact_id=tombstone.artifact_id,
+            identity=tombstone.identity,
+            carrier_namespace=tombstone.identity.carrier_namespace,
+            sequence_id=tombstone.sequence_id,
+            status=PublishStatus.PUBLISHED,
+            durable_carrier_receipt=str(target),
+            queued_path=None,
+            published_at=datetime.now(UTC),
+            error_code=None,
+            error_message=None,
+        )
+
+
+__all__ = [
+    "LocalFilesystemAdapter",
+    "PayloadHashMismatchError",
+    "TombstoneProvenanceRequiredError",
+]

--- a/src/hestai_context_mcp/storage/local_filesystem.py
+++ b/src/hestai_context_mcp/storage/local_filesystem.py
@@ -288,6 +288,21 @@ class LocalFilesystemAdapter:
 
         return self._working_dir / ".hestai" / "state" / "portable"
 
+    @staticmethod
+    def is_local_only() -> bool:
+        """Canonical structural marker: this adapter is local-only (B1, R12).
+
+        Returns:
+            ``True`` for ``LocalFilesystemAdapter``. The post-B2 quality
+            gate chain uses this method to mechanically confirm that B1
+            ships only the local carrier per B2_START_BLOCKER_003. Future
+            non-local adapters MUST return ``False`` from their override
+            so PSS lifecycle code can short-circuit appropriately when
+            local-only constraints apply.
+        """
+
+        return True
+
     @property
     def _artifacts_root(self) -> Path:
         return self.portable_root / "artifacts"

--- a/src/hestai_context_mcp/storage/local_filesystem.py
+++ b/src/hestai_context_mcp/storage/local_filesystem.py
@@ -411,7 +411,23 @@ class LocalFilesystemAdapter:
 
         refs.sort(key=lambda r: (r.sequence_id, r.artifact_id))
         if after_id is not None:
-            refs = [r for r in refs if r.artifact_id > after_id]
+            # Cubic P1 #4: pagination MUST use the same key as the sort,
+            # ``(sequence_id, artifact_id)``. Lexicographic comparison on
+            # ``artifact_id`` alone breaks the cursor when artifact_ids do
+            # not increase monotonically with sequence_ids (PROD::I1
+            # SESSION_LIFECYCLE_INTEGRITY: restore-time listing depends on
+            # a stable cursor). Locate the ref whose artifact_id == after_id
+            # in the already-sorted list and slice everything after it.
+            cursor_index: int | None = None
+            for idx, ref in enumerate(refs):
+                if ref.artifact_id == after_id:
+                    cursor_index = idx
+                    break
+            if cursor_index is None:
+                # Cursor does not match any known ref: return empty rather
+                # than the full list, preserving fail-closed semantics.
+                return []
+            refs = refs[cursor_index + 1 :]
         return refs
 
     def read_artifact(self, ref: ArtifactRef) -> PortableArtifact:

--- a/src/hestai_context_mcp/storage/outbox.py
+++ b/src/hestai_context_mcp/storage/outbox.py
@@ -1,0 +1,207 @@
+"""ADR-0013 PSS Durable Outbound Queue — R7 status-only B1 implementation.
+
+Owns ``.hestai/state/portable/outbox/{artifact_id}.json``: when an adapter
+publish fails after a successful local archive, clock_out enqueues a
+durable status record so the unpublished-memory state is visible to
+operators and to subsequent ``clock_out`` / ``clock_in`` calls.
+
+Binding rulings enforced here:
+
+- RISK_008 + G7: B1 ships **status only** — no retry/drain orchestration.
+  Future ADR may add a Publish Portable State tool. ``retry_count`` is
+  recorded so a future driver can advance it; B1 never bumps it.
+- A2 (CIV): clock_out emits a ``portable_publication`` status block even
+  when publish is skipped. The store exposes
+  :meth:`unpublished_memory_exists` for that surface.
+- R7: queue path is one JSON-per-artifact under
+  ``.hestai/state/portable/outbox/``. The queue is LOCAL_MUTABLE.
+- R10: parse errors raise :class:`OutboxParseError` instead of silently
+  skipping malformed entries.
+- get_context purity: the store performs filesystem writes only via
+  :meth:`enqueue`. Pure read APIs (``list_entries``,
+  ``unpublished_memory_exists``) never create the outbox directory.
+
+PROD::I5: ``get_context`` never imports this module. The clock_in /
+clock_out tools are the only callers that may write here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from hestai_context_mcp.storage.types import (
+    PublishAck,
+    PublishStatus,
+    StateClassification,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxParseError(Exception):
+    """Raised when an outbox JSON entry cannot be parsed (R10 fail-closed)."""
+
+    code: str
+    message: str
+    path: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def _serialize_ack(ack: PublishAck) -> dict[str, Any]:
+    return {
+        "artifact_id": ack.artifact_id,
+        "identity": {
+            "project_id": ack.identity.project_id,
+            "workspace_id": ack.identity.workspace_id,
+            "user_id": ack.identity.user_id,
+            "state_schema_version": ack.identity.state_schema_version,
+            "carrier_namespace": ack.identity.carrier_namespace,
+        },
+        "carrier_namespace": ack.carrier_namespace,
+        "sequence_id": ack.sequence_id,
+        "status": ack.status.value,
+        "durable_carrier_receipt": ack.durable_carrier_receipt,
+        "queued_path": ack.queued_path,
+        "published_at": ack.published_at.isoformat() if ack.published_at else None,
+    }
+
+
+class OutboxStore:
+    """Durable outbound queue for unpublished Portable Memory Artifacts.
+
+    Args:
+        working_dir: Project root containing ``.hestai/state/`` (or its
+            symlink). The store writes only under
+            ``working_dir/.hestai/state/portable/outbox/``.
+    """
+
+    classification: StateClassification = StateClassification.LOCAL_MUTABLE
+
+    def __init__(self, working_dir: str | Path) -> None:
+        self._working_dir = Path(working_dir).resolve()
+
+    @property
+    def root(self) -> Path:
+        """Outbox root: ``.hestai/state/portable/outbox/`` (R7)."""
+
+        return self._working_dir / ".hestai" / "state" / "portable" / "outbox"
+
+    # ---- Write API -------------------------------------------------------
+
+    def enqueue(
+        self,
+        *,
+        ack: PublishAck,
+        error_code: str,
+        error_message: str,
+    ) -> Path:
+        """Enqueue a durable status record for an unpublished artifact.
+
+        The on-disk shape is the union of the PublishAck payload, the
+        original error reason, and B1 retry metadata
+        (``retry_count``=0). Writes are atomic (tempfile + os.replace).
+
+        Args:
+            ack: Adapter PublishAck; ``status`` should be FAILED for the
+                outbox path. Other statuses are still recorded so
+                operators have an observable trail.
+            error_code: Stable code from the failing adapter call.
+            error_message: Human-readable failure description.
+
+        Returns:
+            Final on-disk path of the enqueued JSON entry.
+        """
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        target = self.root / f"{ack.artifact_id}.json"
+        entry: dict[str, Any] = {
+            **_serialize_ack(ack),
+            "error_code": error_code,
+            "error_message": error_message,
+            "enqueued_at": datetime.now(UTC).isoformat(),
+            "retry_count": 0,  # B1 never advances; future ADR owns retries.
+        }
+
+        fd, tmp_name = tempfile.mkstemp(dir=str(self.root), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(entry, f, sort_keys=True, separators=(",", ":"))
+            os.replace(tmp_name, target)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            raise
+        return target
+
+    # ---- Read API (no side-effects) --------------------------------------
+
+    def unpublished_memory_exists(self) -> bool:
+        """True iff at least one entry remains in the outbox.
+
+        Pure read: does not create the outbox directory.
+        """
+
+        if not self.root.exists():
+            return False
+        return any(entry.is_file() and entry.suffix == ".json" for entry in self.root.iterdir())
+
+    def list_entries(self) -> list[dict[str, Any]]:
+        """List outbox entries deterministically by artifact_id.
+
+        Raises:
+            OutboxParseError: when any on-disk entry cannot be parsed.
+        """
+
+        if not self.root.exists():
+            return []
+        entries: list[dict[str, Any]] = []
+        for path in sorted(self.root.glob("*.json")):
+            try:
+                entries.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as e:
+                raise OutboxParseError(
+                    code="outbox_entry_parse_failed",
+                    message=f"failed to parse outbox entry {path}: {e}",
+                    path=str(path),
+                ) from e
+        entries.sort(key=lambda d: str(d.get("artifact_id", "")))
+        return entries
+
+    # ---- Convenience for clock_out (A2) ----------------------------------
+
+    @staticmethod
+    def skipped_publish_status(
+        *, reason: str, error_code: str = "publish_skipped"
+    ) -> dict[str, Any]:
+        """Build the structured A2 skip-publish status record.
+
+        Used by clock_out when publication is intentionally skipped (e.g.,
+        no transcript / provenance unavailable). The record carries no
+        artifact id because nothing was built; ``status`` is ``failed``
+        from the adapter point of view but the message reason explains
+        it was a skip rather than an I/O failure.
+        """
+
+        return {
+            "status": PublishStatus.FAILED.value,
+            "artifact_id": None,
+            "sequence_id": None,
+            "carrier_namespace": None,
+            "queued_path": None,
+            "error_code": error_code,
+            "error_message": reason,
+        }
+
+
+__all__ = [
+    "OutboxParseError",
+    "OutboxStore",
+]

--- a/src/hestai_context_mcp/storage/outbox.py
+++ b/src/hestai_context_mcp/storage/outbox.py
@@ -166,7 +166,14 @@ class OutboxStore:
         for path in sorted(self.root.glob("*.json")):
             try:
                 entries.append(json.loads(path.read_text(encoding="utf-8")))
-            except (OSError, json.JSONDecodeError) as e:
+            except (OSError, ValueError) as e:
+                # Cubic P2 #9: ``ValueError`` is the structural superset:
+                # ``json.JSONDecodeError`` is a ValueError subclass, and
+                # ``UnicodeDecodeError`` (raised by read_text on non-UTF-8
+                # bytes) is also a ValueError subclass. Catching ValueError
+                # ensures every decode failure is wrapped as a structured
+                # OutboxParseError per R10 fail-closed and PROD::I4
+                # STRUCTURED_RETURN_SHAPES.
                 raise OutboxParseError(
                     code="outbox_entry_parse_failed",
                     message=f"failed to parse outbox entry {path}: {e}",

--- a/src/hestai_context_mcp/storage/projection.py
+++ b/src/hestai_context_mcp/storage/projection.py
@@ -1,0 +1,149 @@
+"""ADR-0013 PSS deterministic projection builder — R3, R8, R9, R10.
+
+Pure projection over already-loaded Portable Memory Artifacts and
+TombstoneArtifacts. Produces a JSON-compatible read model that
+``clock_in`` writes into the named session snapshot.
+
+Binding rulings enforced here:
+
+- R3: all artifacts must share the same identity tuple as the projection
+  caller; mismatch raises ``IdentityValidationError`` (no silent
+  contamination from forks/clones).
+- R8 + A3: tombstones are applied BEFORE merge, so the resulting
+  ``artifact_refs`` never contains a tombstoned artifact. Tombstones
+  themselves are recorded under ``tombstoned_artifact_ids`` so the
+  projection round-trips through clock_in -> snapshot -> get_context
+  without losing revocation evidence.
+- R9: same artifact_id + same payload_hash is idempotent; same
+  artifact_id + different payload_hash raises ``ProjectionError``.
+- R10 / INVARIANT_004: deterministic — same inputs produce identical
+  output. INVARIANT_005: structured failure, never silent empty.
+
+This module performs no filesystem I/O and never imports adapters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from hestai_context_mcp.storage.identity import (
+    IdentityValidationError,
+    validate_identity_tuple,
+)
+from hestai_context_mcp.storage.types import (
+    IdentityTuple,
+    PortableMemoryArtifact,
+    TombstoneArtifact,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionError(Exception):
+    """Structured projection failure (R9 conflicts, R10 fail-closed)."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def _identity_dict(identity: IdentityTuple) -> dict[str, Any]:
+    return {
+        "project_id": identity.project_id,
+        "workspace_id": identity.workspace_id,
+        "user_id": identity.user_id,
+        "state_schema_version": identity.state_schema_version,
+        "carrier_namespace": identity.carrier_namespace,
+    }
+
+
+def build_projection(
+    *,
+    identity: IdentityTuple,
+    artifacts: tuple[PortableMemoryArtifact, ...],
+    tombstones: tuple[TombstoneArtifact, ...],
+) -> dict[str, Any]:
+    """Build a deterministic projection over ``artifacts`` minus ``tombstones``.
+
+    Args:
+        identity: Snapshot identity tuple.
+        artifacts: Portable memory artifacts to merge.
+        tombstones: Tombstone artifacts whose targets must be excluded.
+
+    Returns:
+        ``{"identity": <id>, "tombstoned_artifact_ids": [...],
+        "artifact_refs": [{"artifact_id": ..., "sequence_id": ...,
+        "payload_hash": ..., "payload": {...}}, ...]}``.
+
+    Raises:
+        IdentityValidationError: when ``identity`` is invalid or any
+            artifact / tombstone disagrees with ``identity``.
+        ProjectionError: when same artifact_id has conflicting payload
+            hashes (R9).
+    """
+
+    validate_identity_tuple(identity)
+
+    # R3: identity match for every input.
+    for a in artifacts:
+        if a.identity != identity:
+            raise IdentityValidationError(
+                code="projection_artifact_identity_mismatch",
+                message=(
+                    f"artifact {a.artifact_id!r} identity {a.identity!r} does not match "
+                    f"projection identity {identity!r}"
+                ),
+            )
+    for t in tombstones:
+        if t.identity != identity:
+            raise IdentityValidationError(
+                code="projection_tombstone_identity_mismatch",
+                message=(
+                    f"tombstone {t.artifact_id!r} identity does not match projection identity"
+                ),
+            )
+
+    # R8: tombstoned target ids are excluded BEFORE merge.
+    tombstoned_ids = sorted({t.target_artifact_id for t in tombstones})
+    tombstoned_set = set(tombstoned_ids)
+
+    # R9: deduplicate same artifact_id; conflicting hashes raise.
+    by_id: dict[str, PortableMemoryArtifact] = {}
+    for a in artifacts:
+        if a.artifact_id in tombstoned_set:
+            continue
+        prior = by_id.get(a.artifact_id)
+        if prior is None:
+            by_id[a.artifact_id] = a
+            continue
+        if prior.payload_hash != a.payload_hash:
+            raise ProjectionError(
+                code="conflicting_artifact_payload",
+                message=(
+                    f"artifact_id {a.artifact_id!r} has conflicting payload_hash "
+                    f"{prior.payload_hash!r} vs {a.payload_hash!r}"
+                ),
+            )
+        # Same id + same hash: idempotent — keep first.
+
+    ordered = sorted(by_id.values(), key=lambda a: (a.sequence_id, a.artifact_id))
+    artifact_refs: list[dict[str, Any]] = [
+        {
+            "artifact_id": a.artifact_id,
+            "sequence_id": a.sequence_id,
+            "payload_hash": a.payload_hash,
+            "payload": dict(a.payload),
+        }
+        for a in ordered
+    ]
+
+    return {
+        "identity": _identity_dict(identity),
+        "tombstoned_artifact_ids": tombstoned_ids,
+        "artifact_refs": artifact_refs,
+    }
+
+
+__all__ = ["ProjectionError", "build_projection"]

--- a/src/hestai_context_mcp/storage/protocol.py
+++ b/src/hestai_context_mcp/storage/protocol.py
@@ -1,0 +1,80 @@
+"""ADR-0013 PSS StorageAdapter Protocol — verbatim from §PROTOCOL_SIGNATURES.
+
+This module defines the storage boundary @runtime_checkable Protocol used by
+hestai-context-mcp during clock_in (restore) and clock_out (publish).
+
+CRS C1: signatures match BUILD-PLAN §PROTOCOL_SIGNATURES exactly. Any drift
+requires CE re-consult per the B1→B2 arbitration record.
+
+CRS C2: @runtime_checkable provides attribute-presence checks only — it does
+NOT validate method signatures or parameter types at runtime. Implementations
+must still satisfy the type contract; mypy strict is the binding type gate.
+
+Concrete remote carriers (RemoteHTTP, S3, Git) are explicitly out of scope
+for B1 per ADR-0013 R12 and B2_START_BLOCKER_003. Custom Git refs are
+prohibited by R11 and the phantom-substrate evidence cited in the ADR.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from hestai_context_mcp.storage.types import (
+    ArtifactRef,
+    PortableArtifact,
+    PortableMemoryArtifact,
+    PortableNamespace,
+    PublishAck,
+    StorageCapabilities,
+    TombstoneArtifact,
+    WritePrecondition,
+)
+
+
+@runtime_checkable
+class StorageAdapter(Protocol):
+    """Storage boundary used by clock_in/clock_out for PSS artifacts.
+
+    Adapters implement append-first writes with conditional/atomic create
+    semantics. ``read_artifact`` returns the discriminated PortableArtifact
+    union (RISK_002) so tombstones round-trip without a separate method.
+
+    Note (CRS C2): runtime_checkable enables ``isinstance()`` attribute
+    checks only; mypy strict + the explicit ``write_artifact``/
+    ``write_tombstone`` split is the load-bearing type contract.
+    """
+
+    capabilities: StorageCapabilities
+
+    def list_artifacts(
+        self,
+        namespace: PortableNamespace,
+        after_id: str | None = None,
+    ) -> list[ArtifactRef]:
+        """List artifacts in deterministic monotonic order."""
+        ...
+
+    def read_artifact(self, ref: ArtifactRef) -> PortableArtifact:
+        """Read the artifact identified by ref."""
+        ...
+
+    def write_artifact(
+        self,
+        ref: ArtifactRef,
+        artifact: PortableMemoryArtifact,
+        precondition: WritePrecondition,
+    ) -> PublishAck:
+        """Write a provenance-validated Portable Memory Artifact."""
+        ...
+
+    def write_tombstone(
+        self,
+        ref: ArtifactRef,
+        tombstone: TombstoneArtifact,
+        precondition: WritePrecondition,
+    ) -> PublishAck:
+        """Append a tombstone artifact without overwriting the target."""
+        ...
+
+
+__all__ = ["StorageAdapter"]

--- a/src/hestai_context_mcp/storage/provenance.py
+++ b/src/hestai_context_mcp/storage/provenance.py
@@ -1,0 +1,251 @@
+"""ADR-0013 PSS redaction provenance — R6 + R10 fail-closed publication gate.
+
+This module is the publication-gate enforcer:
+
+- ``compute_ruleset_hash`` derives a deterministic SHA-256 over the named
+  RedactionEngine.PATTERNS regex set so readers can detect stale
+  provenance after rules change (PROD::I2).
+- ``build_provenance`` constructs a complete RedactionProvenance, hashing
+  input/output text and stamping the engine name + version constants from
+  ``core.redaction``. ``build_provenance_from_result`` accepts the
+  RedactionEngine.redact() result so callers don't need to redact twice.
+- ``validate_provenance_complete`` rejects partial provenance with stable
+  ``ProvenanceIncompleteError(code='provenance_incomplete',
+  missing_field=...)`` codes for clock_out / adapter integration.
+- ``assert_ruleset_hash_current`` rejects stale provenance whose ruleset
+  hash no longer matches the live PATTERNS digest.
+- ``build_provenance_or_raise`` is the **G4 atomic guard**: it raises
+  BEFORE any side-effecting work begins. Storage adapters and clock_out
+  MUST call this *before* opening a target file so a partial-state write
+  cannot occur.
+
+CRS C3 (B1→B2 arbitration): JSON payloads are mutable nested types; the
+redaction provenance contract here treats input_text/output_text as bytes
+inputs to a hash function and never persists them, which preserves
+effective immutability for the provenance record itself (frozen+slots
+RedactionProvenance dataclass).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from hestai_context_mcp.core.redaction import (
+    REDACTION_ENGINE_NAME,
+    REDACTION_ENGINE_VERSION,
+    RedactionEngine,
+    RedactionResult,
+)
+from hestai_context_mcp.storage.types import RedactionProvenance
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceIncompleteError(Exception):
+    """Provenance metadata missing a required field for publication (R6 + RISK_010)."""
+
+    code: str
+    missing_field: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover — Exception side-effect
+        Exception.__init__(self, self.message)
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceStaleError(Exception):
+    """Ruleset hash on the provenance record no longer matches live PATTERNS."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover — Exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def compute_ruleset_hash() -> str:
+    """Deterministic digest over RedactionEngine.PATTERNS (R6).
+
+    Combines pattern names + compiled regex source + replacement strings
+    in sorted order so the hash is stable across runs and changes
+    deterministically when PATTERNS changes (A4 contract test).
+    """
+
+    parts: list[str] = []
+    for name in sorted(RedactionEngine.PATTERNS):
+        pattern, replacement = RedactionEngine.PATTERNS[name]
+        parts.append(f"{name}|{pattern.pattern}|{replacement}")
+    digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+    return digest
+
+
+def _hash_text(text: str) -> str:
+    """SHA-256 of text content for provenance input/output_artifact_hash."""
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_provenance(
+    *,
+    input_text: str,
+    output_text: str,
+    redacted_credential_categories: tuple[str, ...],
+    engine_name_override: str | None = None,
+    engine_version_override: str | None = None,
+    redacted_at: datetime | None = None,
+) -> RedactionProvenance:
+    """Construct a complete RedactionProvenance for a redacted artifact (R6).
+
+    Args:
+        input_text: Pre-redaction text content.
+        output_text: Post-redaction text content.
+        redacted_credential_categories: Categories detected by the engine
+            (may be empty per NOTE_009; never None).
+        engine_name_override: Test-only seam to inject a different engine
+            identifier; production code uses REDACTION_ENGINE_NAME.
+        engine_version_override: Test-only seam to inject a different
+            version (used by the G4 atomic-guard test to simulate a
+            mis-configured caller).
+        redacted_at: Optional timezone-aware datetime; defaults to now(UTC).
+    """
+
+    return RedactionProvenance(
+        engine_name=(
+            engine_name_override if engine_name_override is not None else REDACTION_ENGINE_NAME
+        ),
+        engine_version=(
+            engine_version_override
+            if engine_version_override is not None
+            else REDACTION_ENGINE_VERSION
+        ),
+        ruleset_hash=compute_ruleset_hash(),
+        input_artifact_hash=_hash_text(input_text),
+        output_artifact_hash=_hash_text(output_text),
+        redacted_at=redacted_at if redacted_at is not None else datetime.now(UTC),
+        classification_label="PORTABLE_MEMORY",
+        redacted_credential_categories=tuple(redacted_credential_categories),
+    )
+
+
+def build_provenance_from_result(
+    *,
+    input_text: str,
+    result: RedactionResult,
+    redacted_at: datetime | None = None,
+) -> RedactionProvenance:
+    """Construct provenance directly from a RedactionEngine.redact() result.
+
+    Avoids re-redacting in callers and keeps the redacted_credential_categories
+    aligned with the engine's actual detection output (TEST_056).
+    """
+
+    return build_provenance(
+        input_text=input_text,
+        output_text=result.redacted_text,
+        redacted_credential_categories=tuple(result.redacted_types),
+        redacted_at=redacted_at,
+    )
+
+
+_REQUIRED_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "engine_name",
+    "engine_version",
+    "ruleset_hash",
+    "input_artifact_hash",
+    "output_artifact_hash",
+)
+
+
+def validate_provenance_complete(provenance: RedactionProvenance) -> RedactionProvenance:
+    """Reject incomplete provenance with a stable error code (R6 + RISK_010).
+
+    Raises:
+        ProvenanceIncompleteError: with ``missing_field`` indicating which
+            required string field is empty/blank.
+    """
+
+    for field in _REQUIRED_PROVENANCE_FIELDS:
+        value = getattr(provenance, field)
+        if not isinstance(value, str) or not value:
+            raise ProvenanceIncompleteError(
+                code="provenance_incomplete",
+                missing_field=field,
+                message=f"RedactionProvenance.{field} must be a non-empty string",
+            )
+    if provenance.classification_label != "PORTABLE_MEMORY":
+        raise ProvenanceIncompleteError(
+            code="provenance_incomplete",
+            missing_field="classification_label",
+            message=(
+                "classification_label must be 'PORTABLE_MEMORY'; "
+                "any other value violates R1 + R6"
+            ),
+        )
+    if provenance.redacted_at.tzinfo is None:
+        raise ProvenanceIncompleteError(
+            code="provenance_incomplete",
+            missing_field="redacted_at",
+            message="redacted_at must be timezone-aware",
+        )
+    return provenance
+
+
+def assert_ruleset_hash_current(provenance: RedactionProvenance) -> None:
+    """Refuse provenance whose ruleset_hash does not match live PATTERNS (TEST_055).
+
+    Used at publish time to prevent treating older redactor output as safe
+    after rules change (PROD::I2 fail-closed).
+    """
+
+    current = compute_ruleset_hash()
+    if provenance.ruleset_hash != current:
+        raise ProvenanceStaleError(
+            code="ruleset_hash_stale",
+            message=(
+                "RedactionProvenance.ruleset_hash does not match current "
+                "RedactionEngine.PATTERNS digest — bump REDACTION_ENGINE_VERSION "
+                "or re-redact before publishing"
+            ),
+        )
+
+
+def build_provenance_or_raise(
+    *,
+    input_text: str,
+    output_text: str,
+    redacted_credential_categories: tuple[str, ...],
+    engine_name_override: str | None = None,
+    engine_version_override: str | None = None,
+    redacted_at: datetime | None = None,
+) -> RedactionProvenance:
+    """G4 atomic guard: build + validate provenance in a single non-side-effecting call.
+
+    Storage adapters and clock_out MUST call this BEFORE opening a target
+    file so partial-state writes cannot occur. The function raises
+    ``ProvenanceIncompleteError`` synchronously when any required field is
+    empty (e.g., ``engine_version_override=''``), preserving R10 + RISK_010
+    fail-closed publication semantics.
+    """
+
+    provenance = build_provenance(
+        input_text=input_text,
+        output_text=output_text,
+        redacted_credential_categories=redacted_credential_categories,
+        engine_name_override=engine_name_override,
+        engine_version_override=engine_version_override,
+        redacted_at=redacted_at,
+    )
+    return validate_provenance_complete(provenance)
+
+
+__all__ = [
+    "ProvenanceIncompleteError",
+    "ProvenanceStaleError",
+    "assert_ruleset_hash_current",
+    "build_provenance",
+    "build_provenance_from_result",
+    "build_provenance_or_raise",
+    "compute_ruleset_hash",
+    "validate_provenance_complete",
+]

--- a/src/hestai_context_mcp/storage/schema.py
+++ b/src/hestai_context_mcp/storage/schema.py
@@ -1,0 +1,240 @@
+"""ADR-0013 PSS portable artifact schema versioning + migration framework.
+
+Implements R4 (versioning + migration) and R10 (fail-closed hydration):
+
+- ``CURRENT_SCHEMA_VERSION`` and ``SUPPORTED_SCHEMA_VERSIONS`` define the
+  reader's compatibility envelope. B1 ships only v1 to honor R12 (no
+  invented v2 content) and the B1 scope discipline (RISK_007 NO compaction).
+- ``MIGRATION_REGISTRY`` is keyed by source schema version. Each entry is a
+  callable that takes a PortableMemoryArtifact and returns a v-current
+  projection artifact. Migration NEVER rewrites the source on disk
+  (CONTEXT_PROJECTION_EDIT_PLAN EDIT_004).
+- ``parse_artifact_dict`` deserializes a dict into a PortableMemoryArtifact,
+  silently dropping forward-compatible fields when the reader can support
+  the artifact (R4 last bullet).
+- ``validate_artifact`` enforces structural integrity (identity/schema
+  alignment, payload_hash present, sequence_id >= 0, classification ==
+  PORTABLE_MEMORY). Failures raise SchemaValidationError with a stable
+  ``code`` field.
+- ``SchemaTooNewError`` is the structured error raised when an artifact's
+  minimum_reader_version exceeds the reader's support envelope. This is
+  the wire shape that lands in clock_in restore_error / clock_out
+  publish-skip status (RISK_001 + A1).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any
+
+from hestai_context_mcp.storage.types import (
+    ArtifactKind,
+    IdentityTuple,
+    PortableMemoryArtifact,
+    RedactionProvenance,
+)
+
+CURRENT_SCHEMA_VERSION: int = 1
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaValidationError(Exception):
+    """Structural validation failure for a portable artifact."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover — Exception side-effect
+        Exception.__init__(self, self.message)
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaTooNewError(Exception):
+    """Reader cannot hydrate an artifact whose minimum_reader_version is too high."""
+
+    code: str
+    message: str
+    minimum_reader_version: int
+
+    def __post_init__(self) -> None:  # pragma: no cover — Exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def is_artifact_supported(artifact: PortableMemoryArtifact) -> bool:
+    """True iff the reader can hydrate this artifact (R4)."""
+
+    return (
+        artifact.minimum_reader_version <= CURRENT_SCHEMA_VERSION
+        and artifact.schema_version in SUPPORTED_SCHEMA_VERSIONS
+    )
+
+
+def validate_artifact(artifact: PortableMemoryArtifact) -> PortableMemoryArtifact:
+    """Validate structural integrity of a portable memory artifact (R4 + R10).
+
+    Returns the artifact unchanged on success so callers can chain.
+
+    Raises:
+        SchemaTooNewError: when minimum_reader_version exceeds support.
+        SchemaValidationError: with a stable ``code`` for any other
+            structural issue.
+    """
+
+    if not is_artifact_supported(artifact):
+        raise SchemaTooNewError(
+            code="schema_too_new",
+            message=(
+                f"artifact minimum_reader_version={artifact.minimum_reader_version} "
+                f"exceeds reader CURRENT_SCHEMA_VERSION={CURRENT_SCHEMA_VERSION}"
+            ),
+            minimum_reader_version=artifact.minimum_reader_version,
+        )
+
+    if artifact.identity.state_schema_version != artifact.schema_version:
+        raise SchemaValidationError(
+            code="identity_schema_mismatch",
+            message=(
+                f"identity.state_schema_version={artifact.identity.state_schema_version} "
+                f"!= artifact.schema_version={artifact.schema_version}"
+            ),
+        )
+
+    if not artifact.payload_hash:
+        raise SchemaValidationError(
+            code="missing_payload_hash",
+            message="artifact.payload_hash must be a non-empty string",
+        )
+
+    if artifact.sequence_id < 0:
+        raise SchemaValidationError(
+            code="non_monotonic_sequence_id",
+            message=f"sequence_id must be >= 0, got {artifact.sequence_id}",
+        )
+
+    if artifact.classification_label != "PORTABLE_MEMORY":
+        raise SchemaValidationError(
+            code="non_portable_classification",
+            message=(
+                "classification_label must be 'PORTABLE_MEMORY', got "
+                f"{artifact.classification_label!r}"
+            ),
+        )
+
+    return artifact
+
+
+def _identity_migration(artifact: PortableMemoryArtifact) -> PortableMemoryArtifact:
+    """v1 identity migration — returns the artifact unchanged.
+
+    R4: migration produces a projection artifact and never rewrites the
+    source on disk; the v1 identity migration is the simplest case.
+    """
+
+    return artifact
+
+
+MIGRATION_REGISTRY: Mapping[int, Callable[[PortableMemoryArtifact], PortableMemoryArtifact]] = {
+    1: _identity_migration,
+}
+
+
+def migrate_into_projection(artifact: PortableMemoryArtifact) -> PortableMemoryArtifact:
+    """Apply the registered migration for ``artifact.schema_version``.
+
+    Used by the projection builder (storage.projection) and clock_in
+    restore. Source is never mutated on disk; this returns a (possibly
+    new) PortableMemoryArtifact instance suitable for projection input.
+
+    Raises:
+        SchemaTooNewError: when the artifact is forward-incompatible.
+        SchemaValidationError: when no migration is registered.
+    """
+
+    validate_artifact(artifact)
+    migrator = MIGRATION_REGISTRY.get(artifact.schema_version)
+    if migrator is None:
+        raise SchemaValidationError(
+            code="no_migration_registered",
+            message=f"no migration registered for schema_version={artifact.schema_version}",
+        )
+    return migrator(artifact)
+
+
+def _parse_identity(raw: Mapping[str, Any]) -> IdentityTuple:
+    return IdentityTuple(
+        project_id=str(raw["project_id"]),
+        workspace_id=str(raw["workspace_id"]),
+        user_id=str(raw["user_id"]),
+        state_schema_version=int(raw["state_schema_version"]),
+        carrier_namespace=str(raw["carrier_namespace"]),
+    )
+
+
+def _parse_provenance(raw: Mapping[str, Any]) -> RedactionProvenance:
+    redacted_at = raw["redacted_at"]
+    if isinstance(redacted_at, str):
+        redacted_at = datetime.fromisoformat(redacted_at)
+    return RedactionProvenance(
+        engine_name=str(raw["engine_name"]),
+        engine_version=str(raw["engine_version"]),
+        ruleset_hash=str(raw["ruleset_hash"]),
+        input_artifact_hash=str(raw["input_artifact_hash"]),
+        output_artifact_hash=str(raw["output_artifact_hash"]),
+        redacted_at=redacted_at,
+        classification_label="PORTABLE_MEMORY",
+        redacted_credential_categories=tuple(raw.get("redacted_credential_categories", ())),
+    )
+
+
+def parse_artifact_dict(raw: Mapping[str, Any]) -> PortableMemoryArtifact:
+    """Deserialize a dict into PortableMemoryArtifact.
+
+    Forward-compatible: silently drops keys outside the v-current schema
+    when ``minimum_reader_version <= CURRENT_SCHEMA_VERSION`` (R4 last
+    bullet). For too-new artifacts, ``validate_artifact`` raises
+    ``SchemaTooNewError`` after construction.
+    """
+
+    created_at = raw["created_at"]
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+
+    artifact = PortableMemoryArtifact(
+        artifact_id=str(raw["artifact_id"]),
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=_parse_identity(raw["identity"]),
+        schema_version=int(raw["schema_version"]),
+        producer_version=str(raw["producer_version"]),
+        minimum_reader_version=int(raw["minimum_reader_version"]),
+        created_at=created_at,
+        sequence_id=int(raw["sequence_id"]),
+        parent_ids=tuple(raw.get("parent_ids", ())),
+        redaction_provenance=_parse_provenance(raw["redaction_provenance"]),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=str(raw["payload_hash"]),
+        payload=dict(raw["payload"]),
+    )
+    # Note: forward-compat unknown fields (e.g., 'future_only_field') are
+    # not consumed above and are silently ignored when supported.
+    if not is_artifact_supported(artifact):
+        # Keep the structured fail-closed path even when constructed via
+        # parse_artifact_dict — caller relies on this to distinguish
+        # too-new artifacts from structurally-invalid ones.
+        return artifact  # validate_artifact will raise downstream
+    return replace(artifact)
+
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "MIGRATION_REGISTRY",
+    "SUPPORTED_SCHEMA_VERSIONS",
+    "SchemaTooNewError",
+    "SchemaValidationError",
+    "is_artifact_supported",
+    "migrate_into_projection",
+    "parse_artifact_dict",
+    "validate_artifact",
+]

--- a/src/hestai_context_mcp/storage/snapshots.py
+++ b/src/hestai_context_mcp/storage/snapshots.py
@@ -1,0 +1,239 @@
+"""ADR-0013 PSS named-session snapshots — R5 + R10 implementation.
+
+Owns ``.hestai/state/portable/snapshots/{session_id}/`` with two files:
+
+- ``context-projection.json``: derived read-model payload for ``get_context``.
+- ``metadata.json``: identity tuple, artifact refs (sequence_id +
+  artifact_id + payload_hash), created_at.
+
+Binding rulings enforced here:
+
+- R5: snapshots are written by ``clock_in`` only. ``read_session_snapshot``
+  is a pure read — no directory creation, no mutation. The snapshot is
+  the *frozen* view that ``get_context`` should see for the session,
+  preventing intra-session context drift.
+- R3: artifact refs whose identity differs from the snapshot identity are
+  refused at write time (``IdentityValidationError``).
+- R10: snapshot does not drift mid-session — projection bytes on disk
+  are the only source of truth for that session.
+- Path traversal: ``session_id`` is validated to be a non-empty token free
+  of path separators, traversal sequences, and control characters.
+
+PROD::I5: ``read_session_snapshot`` performs zero writes. Tools using it
+in ``get_context`` must not call any other adapter API.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from hestai_context_mcp.storage.identity import (
+    IdentityValidationError,
+    validate_identity_tuple,
+)
+from hestai_context_mcp.storage.types import (
+    ArtifactRef,
+    IdentityTuple,
+    JsonObject,
+    StateClassification,
+)
+
+#: Snapshots are derived projection state per ADR-0013 R1.
+SNAPSHOT_CLASSIFICATION: StateClassification = StateClassification.DERIVED_PROJECTION
+
+_PATH_TRAVERSAL_TOKENS: tuple[str, ...] = ("/", "\\", "..")
+_CONTROL_CHARS: tuple[str, ...] = ("\n", "\r", "\t", "\x00")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotIdValidationError(ValueError):
+    """Session-id failed structural validation (path traversal / blank)."""
+
+    code: str
+    message: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotNotFoundError(Exception):
+    """Snapshot directory or files missing for the requested session_id."""
+
+    code: str
+    message: str
+    session_id: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - exception side-effect
+        Exception.__init__(self, self.message)
+
+
+def _validate_session_id(session_id: str) -> str:
+    if not isinstance(session_id, str) or not session_id or not session_id.strip():
+        raise SnapshotIdValidationError(
+            code="blank_session_id",
+            message="session_id must be a non-blank string",
+        )
+    for token in _PATH_TRAVERSAL_TOKENS:
+        if token in session_id:
+            raise SnapshotIdValidationError(
+                code="path_traversal_session_id",
+                message=f"session_id must not contain {token!r}",
+            )
+    for ctrl in _CONTROL_CHARS:
+        if ctrl in session_id:
+            raise SnapshotIdValidationError(
+                code="control_char_session_id",
+                message="session_id must not contain control characters",
+            )
+    return session_id
+
+
+def _snapshot_dir(working_dir: Path, session_id: str) -> Path:
+    return Path(working_dir).resolve() / ".hestai" / "state" / "portable" / "snapshots" / session_id
+
+
+def _serialize_ref(ref: ArtifactRef) -> dict[str, Any]:
+    return {
+        "artifact_id": ref.artifact_id,
+        "identity": {
+            "project_id": ref.identity.project_id,
+            "workspace_id": ref.identity.workspace_id,
+            "user_id": ref.identity.user_id,
+            "state_schema_version": ref.identity.state_schema_version,
+            "carrier_namespace": ref.identity.carrier_namespace,
+        },
+        "artifact_kind": ref.artifact_kind.value,
+        "sequence_id": ref.sequence_id,
+        "created_at": ref.created_at.isoformat(),
+        "payload_hash": ref.payload_hash,
+        "carrier_path": ref.carrier_path,
+    }
+
+
+def _serialize_identity(identity: IdentityTuple) -> dict[str, Any]:
+    return {
+        "project_id": identity.project_id,
+        "workspace_id": identity.workspace_id,
+        "user_id": identity.user_id,
+        "state_schema_version": identity.state_schema_version,
+        "carrier_namespace": identity.carrier_namespace,
+    }
+
+
+def _atomic_write_json(target: Path, data: dict[str, Any]) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp_name, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def create_session_snapshot(
+    *,
+    working_dir: str | Path,
+    session_id: str,
+    identity: IdentityTuple,
+    artifact_refs: tuple[ArtifactRef, ...],
+    projection_payload: JsonObject,
+) -> Path:
+    """Write a frozen context projection for ``session_id``.
+
+    Args:
+        working_dir: Project root.
+        session_id: Logical session identifier (validated structurally).
+        identity: PSS identity tuple bound to this snapshot.
+        artifact_refs: Artifact refs included in the projection. All refs
+            must share ``identity`` (R3).
+        projection_payload: JSON-compatible read-model payload.
+
+    Returns:
+        Final path of ``context-projection.json``.
+
+    Raises:
+        SnapshotIdValidationError: when ``session_id`` is structurally invalid.
+        IdentityValidationError: when ``identity`` is invalid or any ref
+            disagrees with ``identity``.
+    """
+
+    sid = _validate_session_id(session_id)
+    validate_identity_tuple(identity)
+
+    for ref in artifact_refs:
+        if ref.identity != identity:
+            raise IdentityValidationError(
+                code="snapshot_artifact_identity_mismatch",
+                message=(
+                    f"artifact_ref {ref.artifact_id!r} identity does not match "
+                    "snapshot identity (R3)"
+                ),
+            )
+
+    target_dir = _snapshot_dir(Path(working_dir), sid)
+    projection_path = target_dir / "context-projection.json"
+    metadata_path = target_dir / "metadata.json"
+
+    _atomic_write_json(projection_path, dict(projection_payload))
+    metadata: dict[str, Any] = {
+        "session_id": sid,
+        "identity": _serialize_identity(identity),
+        "artifact_refs": [_serialize_ref(r) for r in artifact_refs],
+        "created_at": datetime.now(UTC).isoformat(),
+        "classification_label": SNAPSHOT_CLASSIFICATION.value,
+    }
+    _atomic_write_json(metadata_path, metadata)
+    return projection_path
+
+
+def read_session_snapshot(
+    *,
+    working_dir: str | Path,
+    session_id: str,
+) -> dict[str, Any]:
+    """Read the named snapshot for ``session_id`` as a pure local read.
+
+    Returns:
+        ``{"projection": <projection-json>, "metadata": <metadata-json>}``.
+
+    Raises:
+        SnapshotIdValidationError: when ``session_id`` is structurally invalid.
+        SnapshotNotFoundError: when the snapshot does not exist.
+    """
+
+    sid = _validate_session_id(session_id)
+    target_dir = _snapshot_dir(Path(working_dir), sid)
+    projection_path = target_dir / "context-projection.json"
+    metadata_path = target_dir / "metadata.json"
+
+    if not projection_path.exists() or not metadata_path.exists():
+        raise SnapshotNotFoundError(
+            code="snapshot_not_found",
+            message=f"snapshot for session_id={sid!r} not found at {target_dir}",
+            session_id=sid,
+        )
+
+    return {
+        "projection": json.loads(projection_path.read_text(encoding="utf-8")),
+        "metadata": json.loads(metadata_path.read_text(encoding="utf-8")),
+    }
+
+
+__all__ = [
+    "SNAPSHOT_CLASSIFICATION",
+    "SnapshotIdValidationError",
+    "SnapshotNotFoundError",
+    "create_session_snapshot",
+    "read_session_snapshot",
+]

--- a/src/hestai_context_mcp/storage/types.py
+++ b/src/hestai_context_mcp/storage/types.py
@@ -1,0 +1,207 @@
+"""ADR-0013 PSS storage type contract — verbatim from BUILD-PLAN §PROTOCOL_SIGNATURES.
+
+This module contains pure type definitions for Portable Session State (PSS)
+artifacts, identity, refs, capabilities, and acks. It performs:
+- NO filesystem I/O.
+- NO environment reads.
+- NO adapter imports.
+- NO remote-carrier fields.
+
+CRS C1 (B1→B2 arbitration): signatures MUST be implemented verbatim.
+CRS C3: frozen+slots dataclasses preserve effective immutability of leaf
+fields; nested JSON payload immutability is enforced at the *construction
+site* (e.g., clock_out artifact build) — see provenance/clock_out groups.
+
+R-trace: R1 (classification), R2 (capabilities/refs), R3 (identity),
+R4 (schema), R6 (redaction provenance), R7 (publish ack),
+R8 (tombstone), R9 (sequence + precondition).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal, TypeAlias
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = Mapping[str, JsonValue]
+
+
+class StateClassification(StrEnum):
+    LOCAL_MUTABLE = "LOCAL_MUTABLE"
+    PORTABLE_MEMORY = "PORTABLE_MEMORY"
+    DERIVED_PROJECTION = "DERIVED_PROJECTION"
+
+
+class ArtifactKind(StrEnum):
+    PORTABLE_MEMORY = "portable_memory"
+    TOMBSTONE = "tombstone"
+
+
+class PublishStatus(StrEnum):
+    PUBLISHED = "published"
+    QUEUED = "queued"
+    DUPLICATE = "duplicate"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class StorageCapabilities:
+    strong_list_consistency: bool
+    atomic_compare_and_swap: bool
+    conditional_writes: bool
+    advisory_locking: bool
+    streaming_writes: bool
+    encryption_at_rest: bool
+    encryption_in_transit: bool
+    hard_delete: bool
+    read_only: bool
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityTuple:
+    project_id: str
+    workspace_id: str
+    user_id: str
+    state_schema_version: int
+    carrier_namespace: str
+
+
+@dataclass(frozen=True, slots=True)
+class PortableNamespace:
+    project_id: str
+    workspace_id: str
+    user_id: str
+    state_schema_version: int
+    carrier_namespace: str
+
+
+@dataclass(frozen=True, slots=True)
+class RedactionProvenance:
+    engine_name: str
+    engine_version: str
+    ruleset_hash: str
+    input_artifact_hash: str
+    output_artifact_hash: str
+    redacted_at: datetime
+    classification_label: Literal["PORTABLE_MEMORY"]
+    redacted_credential_categories: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRef:
+    artifact_id: str
+    identity: IdentityTuple
+    artifact_kind: ArtifactKind
+    sequence_id: int
+    created_at: datetime
+    payload_hash: str
+    carrier_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class PortableMemoryArtifact:
+    artifact_id: str
+    artifact_kind: Literal[ArtifactKind.PORTABLE_MEMORY]
+    identity: IdentityTuple
+    schema_version: int
+    producer_version: str
+    minimum_reader_version: int
+    created_at: datetime
+    sequence_id: int
+    parent_ids: tuple[str, ...]
+    redaction_provenance: RedactionProvenance
+    classification_label: Literal["PORTABLE_MEMORY"]
+    payload_hash: str
+    payload: JsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class TombstoneArtifact:
+    artifact_id: str
+    artifact_kind: Literal[ArtifactKind.TOMBSTONE]
+    identity: IdentityTuple
+    schema_version: int
+    producer_version: str
+    minimum_reader_version: int
+    created_at: datetime
+    sequence_id: int
+    parent_ids: tuple[str, ...]
+    target_artifact_id: str
+    reason: str
+    publisher_identity: IdentityTuple
+    redaction_provenance: RedactionProvenance | None
+    classification_label: Literal["PORTABLE_MEMORY"]
+    payload_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class WritePrecondition:
+    if_absent: bool = True
+    expected_current_hash: str | None = None
+    expected_parent_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PublishAck:
+    artifact_id: str
+    identity: IdentityTuple
+    carrier_namespace: str
+    sequence_id: int
+    status: PublishStatus
+    durable_carrier_receipt: str | None
+    queued_path: str | None
+    published_at: datetime | None
+    error_code: str | None
+    error_message: str | None
+
+
+PortableArtifact: TypeAlias = PortableMemoryArtifact | TombstoneArtifact
+
+
+def is_portable_memory(artifact: PortableArtifact) -> bool:
+    """Discriminator helper for PortableArtifact union (G5).
+
+    Returns True when the artifact is a PortableMemoryArtifact. Together
+    with :func:`is_tombstone` this provides predicate access for callers
+    that prefer not to use match/case (e.g., older Python compatibility
+    in tests). The canonical narrowing path is match-statement on
+    ``artifact_kind`` Literal narrowing — see RISK_002 / G5.
+    """
+
+    return isinstance(artifact, PortableMemoryArtifact)
+
+
+def is_tombstone(artifact: PortableArtifact) -> bool:
+    """Discriminator helper for PortableArtifact union (G5).
+
+    Returns True when the artifact is a TombstoneArtifact. See
+    :func:`is_portable_memory` for the paired predicate.
+    """
+
+    return isinstance(artifact, TombstoneArtifact)
+
+
+__all__ = [
+    "ArtifactKind",
+    "ArtifactRef",
+    "IdentityTuple",
+    "JsonObject",
+    "JsonScalar",
+    "JsonValue",
+    "PortableArtifact",
+    "PortableMemoryArtifact",
+    "PortableNamespace",
+    "PublishAck",
+    "PublishStatus",
+    "RedactionProvenance",
+    "StateClassification",
+    "StorageCapabilities",
+    "TombstoneArtifact",
+    "WritePrecondition",
+    "is_portable_memory",
+    "is_tombstone",
+]

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -378,19 +378,21 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
         elif isinstance(obj, TombstoneArtifact):
             tombstones.append(obj)
 
-    # Tombstones live in a separate tree; list_artifacts(namespace) only
-    # returned PORTABLE_MEMORY refs above. Surface tombstones explicitly.
+    # Tombstones live in a separate leaf under the per-identity subtree
+    # (CE rework RISK_006: pss/{ns}/{proj}/{ws}/{user}/tombstones/ — no
+    # v{schema_version} segment). list_artifacts(namespace) only returned
+    # PORTABLE_MEMORY refs above. Surface tombstones explicitly.
     tomb_namespace_dir = (
         working_dir_path
         / ".hestai"
         / "state"
         / "portable"
-        / "tombstones"
+        / "pss"
         / identity.carrier_namespace
         / identity.project_id
         / identity.workspace_id
         / identity.user_id
-        / f"v{identity.state_schema_version}"
+        / "tombstones"
     )
     if tomb_namespace_dir.exists():
         from hestai_context_mcp.storage.types import ArtifactRef

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -2,6 +2,12 @@
 
 Returns the structured response per ADR-0353 interface contract.
 Harvested from legacy hestai-mcp clock_in.py.
+
+ADR-0013 PSS extension: clock_in resolves the PSS IdentityTuple, restores
+Portable Memory Artifacts via LocalFilesystemAdapter, and writes a named
+session snapshot. The response is extended with a structured
+``portable_state`` block. All existing top-level fields are preserved
+(G2 backward compatibility).
 """
 
 import logging
@@ -231,6 +237,16 @@ def clock_in(
         context_summary=context_summary,
     )
 
+    # ADR-0013 PSS: restore Portable Memory Artifacts and write a named
+    # snapshot bound to session_id. The block is ALWAYS present (G2 +
+    # PROD::I4 STRUCTURED_RETURN_SHAPES). When no identity is configured
+    # the block reports restore_status="no_identity_configured" — never
+    # an exception, never a network call.
+    portable_state = _restore_portable_state(
+        working_dir_path=working_dir_path,
+        session_id=session_id,
+    )
+
     return {
         "session_id": session_id,
         "role": role,
@@ -250,6 +266,205 @@ def clock_in(
             "active_sessions": active_sessions,
             "conflicts": conflicts,
         },
+        "portable_state": portable_state,
+    }
+
+
+def _empty_portable_state(
+    *, restore_status: str, error: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    return {
+        "restore_status": restore_status,
+        "identity": None,
+        "artifact_count": 0,
+        "tombstone_count": 0,
+        "snapshot_path": None,
+        "error": error,
+    }
+
+
+def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[str, Any]:
+    """Restore PSS state and write a named snapshot bound to ``session_id``.
+
+    This function is the integration boundary between ``clock_in`` and
+    the storage adapter / projection / snapshot pipeline. It NEVER
+    raises: every error path returns a structured ``portable_state``
+    block so the caller's response shape is stable. Network calls are
+    impossible by construction (LocalFilesystemAdapter only).
+    """
+
+    # Lazy imports keep PSS coupling out of module-load time and allow
+    # get_context to import this module without dragging in the
+    # storage subtree.
+    from hestai_context_mcp.storage.identity import IdentityValidationError
+    from hestai_context_mcp.storage.identity_resolver import resolve_identity
+    from hestai_context_mcp.storage.local_filesystem import (
+        LocalFilesystemAdapter,
+        PayloadHashMismatchError,
+    )
+    from hestai_context_mcp.storage.projection import (
+        ProjectionError,
+        build_projection,
+    )
+    from hestai_context_mcp.storage.schema import (
+        SchemaTooNewError,
+        SchemaValidationError,
+        validate_artifact,
+    )
+    from hestai_context_mcp.storage.snapshots import create_session_snapshot
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        PortableMemoryArtifact,
+        PortableNamespace,
+        TombstoneArtifact,
+    )
+
+    try:
+        identity = resolve_identity(working_dir_path)
+    except IdentityValidationError as e:
+        return _empty_portable_state(
+            restore_status="identity_invalid",
+            error={"code": e.code, "message": e.message},
+        )
+
+    if identity is None:
+        return _empty_portable_state(restore_status="no_identity_configured")
+
+    namespace = PortableNamespace(
+        project_id=identity.project_id,
+        workspace_id=identity.workspace_id,
+        user_id=identity.user_id,
+        state_schema_version=identity.state_schema_version,
+        carrier_namespace=identity.carrier_namespace,
+    )
+
+    adapter = LocalFilesystemAdapter(working_dir=working_dir_path)
+    try:
+        memory_refs = adapter.list_artifacts(namespace)
+    except IdentityValidationError as e:
+        return _empty_portable_state(
+            restore_status="identity_mismatch",
+            error={"code": e.code, "message": e.message},
+        )
+
+    artifacts: list[PortableMemoryArtifact] = []
+    tombstones: list[TombstoneArtifact] = []
+    for ref in memory_refs:
+        try:
+            obj = adapter.read_artifact(ref)
+        except (
+            PayloadHashMismatchError,
+            IdentityValidationError,
+            FileNotFoundError,
+        ) as e:
+            return _empty_portable_state(
+                restore_status="restore_io_error",
+                error={"code": getattr(e, "code", "io_error"), "message": str(e)},
+            )
+        if isinstance(obj, PortableMemoryArtifact):
+            try:
+                validate_artifact(obj)
+            except SchemaTooNewError as e:
+                return _empty_portable_state(
+                    restore_status="schema_too_new",
+                    error={"code": e.code, "message": e.message},
+                )
+            except SchemaValidationError as e:
+                return _empty_portable_state(
+                    restore_status="schema_invalid",
+                    error={"code": e.code, "message": e.message},
+                )
+            artifacts.append(obj)
+        elif isinstance(obj, TombstoneArtifact):
+            tombstones.append(obj)
+
+    # Tombstones live in a separate tree; list_artifacts(namespace) only
+    # returned PORTABLE_MEMORY refs above. Surface tombstones explicitly.
+    tomb_namespace_dir = (
+        working_dir_path
+        / ".hestai"
+        / "state"
+        / "portable"
+        / "tombstones"
+        / identity.carrier_namespace
+        / identity.project_id
+        / identity.workspace_id
+        / identity.user_id
+        / f"v{identity.state_schema_version}"
+    )
+    if tomb_namespace_dir.exists():
+        from hestai_context_mcp.storage.types import ArtifactRef
+
+        for json_path in sorted(tomb_namespace_dir.glob("*.json")):
+            import json as _json
+
+            try:
+                raw = _json.loads(json_path.read_text(encoding="utf-8"))
+                if raw.get("artifact_kind") != ArtifactKind.TOMBSTONE.value:
+                    continue
+                # Build a ref then read through the adapter so identity
+                # checks apply.
+                from datetime import datetime as _dt
+
+                ref = ArtifactRef(
+                    artifact_id=str(raw["artifact_id"]),
+                    identity=identity,
+                    artifact_kind=ArtifactKind.TOMBSTONE,
+                    sequence_id=int(raw["sequence_id"]),
+                    created_at=_dt.fromisoformat(raw["created_at"]),
+                    payload_hash=str(raw["payload_hash"]),
+                    carrier_path=str(json_path),
+                )
+                obj = adapter.read_artifact(ref)
+                if isinstance(obj, TombstoneArtifact):
+                    tombstones.append(obj)
+            except (OSError, KeyError, ValueError, IdentityValidationError):
+                # A bad tombstone file should not destroy a valid
+                # restore; continue past it.
+                continue
+
+    try:
+        projection = build_projection(
+            identity=identity,
+            artifacts=tuple(artifacts),
+            tombstones=tuple(tombstones),
+        )
+    except IdentityValidationError as e:
+        return _empty_portable_state(
+            restore_status="identity_mismatch",
+            error={"code": e.code, "message": e.message},
+        )
+    except ProjectionError as e:
+        return _empty_portable_state(
+            restore_status="projection_error",
+            error={"code": e.code, "message": e.message},
+        )
+
+    # Refs included in the snapshot are the post-tombstone memory refs.
+    accepted_ids = {r["artifact_id"] for r in projection["artifact_refs"]}
+    accepted_refs = tuple(r for r in memory_refs if r.artifact_id in accepted_ids)
+
+    snapshot_path = create_session_snapshot(
+        working_dir=working_dir_path,
+        session_id=session_id,
+        identity=identity,
+        artifact_refs=accepted_refs,
+        projection_payload=projection,
+    )
+
+    return {
+        "restore_status": "ok",
+        "identity": {
+            "project_id": identity.project_id,
+            "workspace_id": identity.workspace_id,
+            "user_id": identity.user_id,
+            "state_schema_version": identity.state_schema_version,
+            "carrier_namespace": identity.carrier_namespace,
+        },
+        "artifact_count": len(accepted_refs),
+        "tombstone_count": len(tombstones),
+        "snapshot_path": str(snapshot_path),
+        "error": None,
     }
 
 

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -446,6 +446,13 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
             error={"code": e.code, "message": e.message},
         )
 
+    # Cubic P2 #2 (rework cycle 3): ``artifact_count`` is the post-tombstone
+    # count, which is authoritatively present in ``projection["artifact_refs"]``
+    # (the projection builder already applied tombstones per R8). Compute it
+    # BEFORE the snapshot try-block so the count is independent of snapshot
+    # success/failure and never falls back to pre-tombstone memory_refs.
+    artifact_count = len(projection["artifact_refs"])
+
     # Refs included in the snapshot are the post-tombstone memory refs.
     # Cubic P1 #1: both the dict comprehension and the create_session_snapshot
     # call can raise (KeyError, TypeError, OSError on disk-full / permission
@@ -455,7 +462,6 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
     # the A2 audit-on-skip pattern).
     snapshot_path: str | None = None
     snapshot_error: dict[str, Any] | None = None
-    accepted_refs: tuple[Any, ...] = ()
     try:
         accepted_ids = {r["artifact_id"] for r in projection["artifact_refs"]}
         accepted_refs = tuple(r for r in memory_refs if r.artifact_id in accepted_ids)
@@ -472,10 +478,6 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
             "code": "snapshot_write_failed",
             "message": f"failed to write session snapshot: {e}",
         }
-        # accepted_refs may be empty if the comprehension itself raised; the
-        # post-tombstone count below falls back to the memory_refs count.
-        if not accepted_refs:
-            accepted_refs = tuple(memory_refs)
 
     return {
         "restore_status": "ok",
@@ -486,7 +488,7 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
             "state_schema_version": identity.state_schema_version,
             "carrier_namespace": identity.carrier_namespace,
         },
-        "artifact_count": len(accepted_refs),
+        "artifact_count": artifact_count,
         "tombstone_count": len(tombstones),
         "snapshot_path": snapshot_path,
         "error": None,

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -271,7 +271,10 @@ def clock_in(
 
 
 def _empty_portable_state(
-    *, restore_status: str, error: dict[str, Any] | None = None
+    *,
+    restore_status: str,
+    error: dict[str, Any] | None = None,
+    snapshot_error: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "restore_status": restore_status,
@@ -280,6 +283,7 @@ def _empty_portable_state(
         "tombstone_count": 0,
         "snapshot_path": None,
         "error": error,
+        "snapshot_error": snapshot_error,
     }
 
 
@@ -443,16 +447,35 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
         )
 
     # Refs included in the snapshot are the post-tombstone memory refs.
-    accepted_ids = {r["artifact_id"] for r in projection["artifact_refs"]}
-    accepted_refs = tuple(r for r in memory_refs if r.artifact_id in accepted_ids)
-
-    snapshot_path = create_session_snapshot(
-        working_dir=working_dir_path,
-        session_id=session_id,
-        identity=identity,
-        artifact_refs=accepted_refs,
-        projection_payload=projection,
-    )
+    # Cubic P1 #1: both the dict comprehension and the create_session_snapshot
+    # call can raise (KeyError, TypeError, OSError on disk-full / permission
+    # errors). Local session creation already succeeded, so we surface
+    # snapshot-write failure via a structured ``snapshot_error`` field rather
+    # than letting it propagate (PROD::I4 STRUCTURED_RETURN_SHAPES; parallels
+    # the A2 audit-on-skip pattern).
+    snapshot_path: str | None = None
+    snapshot_error: dict[str, Any] | None = None
+    accepted_refs: tuple[Any, ...] = ()
+    try:
+        accepted_ids = {r["artifact_id"] for r in projection["artifact_refs"]}
+        accepted_refs = tuple(r for r in memory_refs if r.artifact_id in accepted_ids)
+        path = create_session_snapshot(
+            working_dir=working_dir_path,
+            session_id=session_id,
+            identity=identity,
+            artifact_refs=accepted_refs,
+            projection_payload=projection,
+        )
+        snapshot_path = str(path)
+    except (OSError, KeyError, TypeError, ValueError) as e:
+        snapshot_error = {
+            "code": "snapshot_write_failed",
+            "message": f"failed to write session snapshot: {e}",
+        }
+        # accepted_refs may be empty if the comprehension itself raised; the
+        # post-tombstone count below falls back to the memory_refs count.
+        if not accepted_refs:
+            accepted_refs = tuple(memory_refs)
 
     return {
         "restore_status": "ok",
@@ -465,8 +488,9 @@ def _restore_portable_state(*, working_dir_path: Path, session_id: str) -> dict[
         },
         "artifact_count": len(accepted_refs),
         "tombstone_count": len(tombstones),
-        "snapshot_path": str(snapshot_path),
+        "snapshot_path": snapshot_path,
         "error": None,
+        "snapshot_error": snapshot_error,
     }
 
 

--- a/src/hestai_context_mcp/tools/clock_out.py
+++ b/src/hestai_context_mcp/tools/clock_out.py
@@ -9,11 +9,20 @@ Archives an agent session by:
 6. Appending to learnings index
 7. Cleaning up the active session directory
 
+ADR-0013 PSS extension: after archive succeeds, clock_out builds a
+``PortableMemoryArtifact`` with v1 payload keys (RISK_005), validates
+redaction provenance fail-closed (RISK_010 / G4), and publishes via
+``LocalFilesystemAdapter``. Publish failures enqueue a status-only
+record in the durable outbox (R7 + A2 + G7). The response is extended
+with a ``portable_publication`` block and a ``unpublished_memory_exists``
+flag. All existing top-level fields are preserved (G2 backward-compat).
+
 Part of ADR-0353 Phase 1 harvest.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -25,6 +34,10 @@ from typing import Any
 from hestai_context_mcp.core.redaction import RedactionEngine
 from hestai_context_mcp.core.transcript.base import TranscriptMessage
 from hestai_context_mcp.core.transcript.registry import detect_parser
+from hestai_context_mcp.storage.provenance import (
+    ProvenanceIncompleteError,
+    build_provenance_or_raise,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +178,8 @@ def clock_out(
             "message_count": 0,
             "compression_status": "skipped",
             "extracted_learnings": {"decisions": [], "blockers": [], "learnings": []},
+            "portable_publication": _skipped_publication("invalid_session_id"),
+            "unpublished_memory_exists": False,
             "message": f"Invalid session_id: {session_id!r}",
         }
 
@@ -184,6 +199,8 @@ def clock_out(
             "message_count": 0,
             "compression_status": "skipped",
             "extracted_learnings": {"decisions": [], "blockers": [], "learnings": []},
+            "portable_publication": _skipped_publication("session_not_found"),
+            "unpublished_memory_exists": _outbox_has_entries(wd),
             "message": f"Session {session_id} not found in active sessions",
         }
 
@@ -198,6 +215,8 @@ def clock_out(
             "message_count": 0,
             "compression_status": "skipped",
             "extracted_learnings": {"decisions": [], "blockers": [], "learnings": []},
+            "portable_publication": _skipped_publication("session_metadata_missing"),
+            "unpublished_memory_exists": _outbox_has_entries(wd),
             "message": f"Session metadata not found: {session_file}",
         }
 
@@ -212,6 +231,8 @@ def clock_out(
             "message_count": 0,
             "compression_status": "skipped",
             "extracted_learnings": {"decisions": [], "blockers": [], "learnings": []},
+            "portable_publication": _skipped_publication("session_metadata_unreadable"),
+            "unpublished_memory_exists": _outbox_has_entries(wd),
             "message": f"Could not read session metadata: {e}",
         }
 
@@ -265,6 +286,20 @@ def clock_out(
         archive_path,
     )
 
+    # ADR-0013 PSS: build + publish the Portable Memory Artifact, then
+    # decide outbox enqueue vs success. The publication block is ALWAYS
+    # present (G2 backward-compat + PROD::I4 STRUCTURED_RETURN_SHAPES).
+    # Publication NEVER raises — every error path is captured into the
+    # structured publication block.
+    portable_publication, unpublished_memory_exists = _publish_portable_memory(
+        working_dir_path=wd,
+        session_id=session_id,
+        session_data=session_data,
+        archive_path=archive_path,
+        extracted_learnings=extracted_learnings,
+        description=description,
+    )
+
     # Remove active session directory
     try:
         shutil.rmtree(session_dir)
@@ -280,7 +315,311 @@ def clock_out(
         "message_count": len(messages),
         "compression_status": compression_status,
         "extracted_learnings": extracted_learnings,
+        "portable_publication": portable_publication,
+        "unpublished_memory_exists": unpublished_memory_exists,
     }
+
+
+def _skipped_publication(reason_code: str) -> dict[str, Any]:
+    """Build a structured 'skipped' portable_publication block (A2)."""
+
+    return {
+        "status": "failed",
+        "artifact_id": None,
+        "sequence_id": None,
+        "carrier_namespace": None,
+        "queued_path": None,
+        "durable_carrier_receipt": None,
+        "error_code": reason_code,
+        "error_message": f"clock_out skipped portable publication: {reason_code}",
+    }
+
+
+def _outbox_has_entries(working_dir: Path) -> bool:
+    """Pure read: True iff the durable outbox has any pending entries.
+
+    Imported lazily so the early-return paths don't drag in storage code
+    when there's nothing to publish.
+    """
+
+    try:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        return OutboxStore(working_dir=working_dir).unpublished_memory_exists()
+    except Exception:  # pragma: no cover - defensive: never raise from clock_out
+        return False
+
+
+def _build_v1_payload(
+    *,
+    session_id: str,
+    role: str,
+    focus: str,
+    archive_path: str | None,
+    extracted_learnings: dict[str, list[str]],
+    description: str,
+) -> dict[str, Any]:
+    """Build the RISK_005 v1 portable artifact payload.
+
+    Keys are exactly: ``session_id, role, focus, archive_path, decisions,
+    blockers, learnings, description``.
+    """
+
+    return {
+        "session_id": session_id,
+        "role": role,
+        "focus": focus,
+        "archive_path": archive_path,
+        "decisions": list(extracted_learnings.get("decisions", [])),
+        "blockers": list(extracted_learnings.get("blockers", [])),
+        "learnings": list(extracted_learnings.get("learnings", [])),
+        "description": description,
+    }
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    """Deterministic SHA-256 over a canonical JSON encoding."""
+
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _ack_to_publication(ack: Any) -> dict[str, Any]:
+    """Convert a PublishAck to the public portable_publication shape."""
+
+    return {
+        "status": ack.status.value,
+        "artifact_id": ack.artifact_id,
+        "sequence_id": ack.sequence_id,
+        "carrier_namespace": ack.carrier_namespace,
+        "queued_path": ack.queued_path,
+        "durable_carrier_receipt": ack.durable_carrier_receipt,
+        "error_code": ack.error_code,
+        "error_message": ack.error_message,
+    }
+
+
+def _publish_portable_memory(
+    *,
+    working_dir_path: Path,
+    session_id: str,
+    session_data: dict[str, Any],
+    archive_path: str | None,
+    extracted_learnings: dict[str, list[str]],
+    description: str,
+) -> tuple[dict[str, Any], bool]:
+    """Build, publish, and (on failure) enqueue the Portable Memory Artifact.
+
+    Returns a tuple of (portable_publication block, unpublished_memory_exists).
+    Never raises: every failure path is captured into the structured
+    publication block. Lazy imports keep storage coupling out of
+    module-load time.
+    """
+
+    # Lazy imports: keep storage subtree off clock_out's import-time
+    # surface. PROD::I5 — clock_out is the publish boundary, not get_context.
+    from hestai_context_mcp.storage.identity import IdentityValidationError
+    from hestai_context_mcp.storage.identity_resolver import resolve_identity
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.outbox import OutboxStore
+    from hestai_context_mcp.storage.snapshots import (
+        SnapshotNotFoundError,
+        read_session_snapshot,
+    )
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        PortableMemoryArtifact,
+        PublishAck,
+        PublishStatus,
+        WritePrecondition,
+    )
+
+    outbox = OutboxStore(working_dir=working_dir_path)
+
+    # Identity gate: B2_START_BLOCKER_001 — do not invent identity. If the
+    # config is absent, the publish path is a structured skip with an
+    # outbox status record (A2). The skip record is informational; we
+    # don't write a persistent outbox entry because there's nothing to
+    # publish. ``unpublished_memory_exists`` reflects the durable queue.
+    try:
+        identity = resolve_identity(working_dir_path)
+    except IdentityValidationError as e:
+        publication = _skipped_publication("identity_invalid")
+        publication["error_message"] = e.message
+        return publication, outbox.unpublished_memory_exists()
+
+    if identity is None:
+        publication = _skipped_publication("no_identity_configured")
+        return publication, outbox.unpublished_memory_exists()
+
+    # Provenance gate: G4 atomic guard. Build provenance from the redacted
+    # archive if available; else from the v1 payload itself so a complete
+    # provenance pair always exists before any adapter call (RISK_010).
+    payload_role = str(session_data.get("role", "unknown"))
+    payload_focus = str(session_data.get("focus", "unknown"))
+    payload = _build_v1_payload(
+        session_id=session_id,
+        role=payload_role,
+        focus=payload_focus,
+        archive_path=archive_path,
+        extracted_learnings=extracted_learnings,
+        description=description,
+    )
+    payload_canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    if archive_path is not None and Path(archive_path).exists():
+        try:
+            input_text = Path(archive_path).read_text(encoding="utf-8")
+        except OSError as e:
+            publication = _skipped_publication("archive_unreadable")
+            publication["error_message"] = str(e)
+            return publication, outbox.unpublished_memory_exists()
+    else:
+        # No transcript archived; still produce a complete provenance pair
+        # over the canonical payload so RISK_010 holds (no publish without
+        # a redacted input/output pair). Empty input is acceptable because
+        # the redaction engine has no secrets to redact.
+        input_text = payload_canonical
+
+    try:
+        provenance = build_provenance_or_raise(
+            input_text=input_text,
+            output_text=payload_canonical,
+            redacted_credential_categories=(),
+        )
+    except ProvenanceIncompleteError as e:
+        publication = _skipped_publication(e.code)
+        publication["error_message"] = e.message
+        # A2: the skip is observable. Outbox status reflects existing queue
+        # plus a synthetic record so unpublished_memory_exists flips True.
+        try:
+            synthetic_id = f"skip-{session_id}"
+            ack = PublishAck(
+                artifact_id=synthetic_id,
+                identity=identity,
+                carrier_namespace=identity.carrier_namespace,
+                sequence_id=0,
+                status=PublishStatus.FAILED,
+                durable_carrier_receipt=None,
+                queued_path=None,
+                published_at=None,
+                error_code=e.code,
+                error_message=e.message,
+            )
+            queued = outbox.enqueue(ack=ack, error_code=e.code, error_message=e.message)
+            publication["queued_path"] = str(queued)
+        except Exception as enqueue_err:  # pragma: no cover - defensive
+            logger.warning("outbox enqueue for provenance skip failed: %s", enqueue_err)
+        return publication, outbox.unpublished_memory_exists()
+
+    # Build the artifact. parent_ids reference the session snapshot's
+    # known artifact_refs (R5 + R9 monotonic chain).
+    parent_ids: tuple[str, ...] = ()
+    try:
+        snapshot = read_session_snapshot(
+            working_dir=working_dir_path,
+            session_id=session_id,
+        )
+        snapshot_refs = snapshot.get("metadata", {}).get("artifact_refs", [])
+        parent_ids = tuple(str(r["artifact_id"]) for r in snapshot_refs)
+    except SnapshotNotFoundError:
+        parent_ids = ()
+    except (OSError, KeyError, ValueError, TypeError):  # pragma: no cover - defensive
+        parent_ids = ()
+
+    # Stable artifact_id derived from session+payload so duplicate publish
+    # is idempotent (R9). The id is content-addressed on the canonical
+    # payload + identity, so identical sessions reproduce identical ids.
+    artifact_id_seed = (
+        f"{session_id}|{identity.project_id}|{identity.workspace_id}|"
+        f"{identity.user_id}|{identity.state_schema_version}|{identity.carrier_namespace}|"
+        f"{_payload_hash(payload)}"
+    )
+    artifact_id = "pss-" + hashlib.sha256(artifact_id_seed.encode("utf-8")).hexdigest()[:32]
+    sequence_id = int(datetime.now(UTC).timestamp() * 1000)
+    payload_hash = _payload_hash(payload)
+
+    artifact = PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=IdentityTuple(
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            user_id=identity.user_id,
+            state_schema_version=identity.state_schema_version,
+            carrier_namespace=identity.carrier_namespace,
+        ),
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=parent_ids,
+        redaction_provenance=provenance,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=payload_hash,
+        payload=payload,
+    )
+    ref = ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+
+    adapter = LocalFilesystemAdapter(working_dir=working_dir_path)
+    try:
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+    except Exception as e:  # noqa: BLE001 — adapter contract is broad; we
+        # capture every failure into the structured publication shape and
+        # enqueue an outbox entry so unpublished_memory_exists flips True.
+        logger.warning("LocalFilesystemAdapter publish failed: %s", e)
+        publication = _skipped_publication("adapter_write_failed")
+        publication["error_message"] = str(e)
+        try:
+            failed_ack = PublishAck(
+                artifact_id=artifact.artifact_id,
+                identity=artifact.identity,
+                carrier_namespace=artifact.identity.carrier_namespace,
+                sequence_id=artifact.sequence_id,
+                status=PublishStatus.FAILED,
+                durable_carrier_receipt=None,
+                queued_path=None,
+                published_at=None,
+                error_code="adapter_write_failed",
+                error_message=str(e),
+            )
+            queued = outbox.enqueue(
+                ack=failed_ack,
+                error_code="adapter_write_failed",
+                error_message=str(e),
+            )
+            publication["queued_path"] = str(queued)
+        except Exception as enqueue_err:  # pragma: no cover - defensive
+            logger.warning("outbox enqueue after adapter failure failed: %s", enqueue_err)
+        return publication, outbox.unpublished_memory_exists()
+
+    publication = _ack_to_publication(ack)
+    if ack.status == PublishStatus.FAILED:
+        # Adapter returned a structured failure (e.g. precondition
+        # conflicting payload). Enqueue and report unpublished memory.
+        try:
+            queued = outbox.enqueue(
+                ack=ack,
+                error_code=ack.error_code or "publish_failed",
+                error_message=ack.error_message or "publish failed",
+            )
+            publication["queued_path"] = str(queued)
+        except Exception as enqueue_err:  # pragma: no cover - defensive
+            logger.warning("outbox enqueue after FAILED ack failed: %s", enqueue_err)
+
+    return publication, outbox.unpublished_memory_exists()
 
 
 def _resolve_transcript_path(session_data: dict[str, Any]) -> Path | None:

--- a/src/hestai_context_mcp/tools/clock_out.py
+++ b/src/hestai_context_mcp/tools/clock_out.py
@@ -252,8 +252,14 @@ def clock_out(
     # Extract learnings from assistant messages
     extracted_learnings = _extract_learnings(messages)
 
-    # Archive: redact and save transcript
+    # Archive: redact and save transcript.
+    # RISK_010 fail-closed (CE rework): redaction failure is structurally
+    # distinct from "no transcript" — the former MUST block publish; the
+    # latter is a legitimate skip. We track the two outcomes separately so
+    # the publish path can decide deterministically.
     archive_path: str | None = None
+    redaction_failed: bool = False
+    redaction_failure_reason: str = ""
     archive_dir = wd / ".hestai" / "state" / "sessions" / "archive"
     archive_dir.mkdir(parents=True, exist_ok=True)
 
@@ -271,11 +277,31 @@ def clock_out(
             logger.info("Archived redacted transcript to %s", dest)
         except Exception as e:
             logger.error("Redaction/archival failed: %s", e)
-            # Continue without archive -- session cleanup still needed
+            # CE rework RISK_010: do NOT silently fall through to publish.
+            # The transcript existed but redaction failed — this is a
+            # structural credential-safety failure (PROD::I2 fail-closed).
+            redaction_failed = True
+            redaction_failure_reason = str(e)
+            # Best-effort cleanup of any partial dest file so no
+            # half-redacted content lingers on disk.
+            try:
+                if dest.exists():
+                    dest.unlink()
+            except OSError:  # pragma: no cover — defensive
+                pass
 
     # OCTAVE compression (Phase 1 simplification: skipped)
     octave_path: str | None = None
     compression_status = "skipped"
+
+    # CE rework RISK_010: when redaction fails, the in-memory
+    # extracted_learnings may carry unredacted credentials from the parsed
+    # transcript. PROD::I2 fail-closed forbids surfacing them in the
+    # response or the learnings index. Replace with empty lists so the
+    # caller gets the structured shape (PROD::I4 STRUCTURED_RETURN_SHAPES)
+    # without any credential exposure.
+    if redaction_failed:
+        extracted_learnings = {"decisions": [], "blockers": [], "learnings": []}
 
     # Append to learnings index
     _append_to_learnings_index(
@@ -298,6 +324,8 @@ def clock_out(
         archive_path=archive_path,
         extracted_learnings=extracted_learnings,
         description=description,
+        redaction_failed=redaction_failed,
+        redaction_failure_reason=redaction_failure_reason,
     )
 
     # Remove active session directory
@@ -333,6 +361,54 @@ def _skipped_publication(reason_code: str) -> dict[str, Any]:
         "error_code": reason_code,
         "error_message": f"clock_out skipped portable publication: {reason_code}",
     }
+
+
+def _record_skip_status(
+    working_dir: Path,
+    *,
+    session_id: str,
+    reason_code: str,
+    reason_message: str,
+) -> Path | None:
+    """Write a durable on-disk skip-status record under portable/outbox/.
+
+    CE rework ADDITIONAL CONCERN 1: any structured publish skip
+    (no_identity_configured, redaction_failure, provenance_incomplete,
+    archive_unreadable, identity_invalid) MUST leave an auditable on-disk
+    trace so PROD::I1 lifecycle integrity holds (no orphaned sessions).
+
+    The file shape is intentionally simple JSON keyed by
+    ``{session_id}-{reason_code}.json`` so operators can locate the
+    record directly without parsing the broader outbox queue. The
+    contents include the reason message and a UTC timestamp.
+
+    Returns:
+        The on-disk Path of the written record, or ``None`` if the write
+        failed (defensive: skip-status is best-effort and must never
+        propagate an exception out of clock_out).
+    """
+
+    target_dir = working_dir / ".hestai" / "state" / "portable" / "outbox"
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        # session_id is already validated upstream (no path traversal).
+        # reason_code is internal-controlled.
+        target = target_dir / f"{session_id}-{reason_code}.json"
+        record = {
+            "session_id": session_id,
+            "error_code": reason_code,
+            "error_message": reason_message,
+            "recorded_at": datetime.now(UTC).isoformat(),
+            "kind": "skip_status",
+        }
+        target.write_text(
+            json.dumps(record, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        return target
+    except OSError as e:  # pragma: no cover - defensive
+        logger.warning("skip-status record write failed: %s", e)
+        return None
 
 
 def _outbox_has_entries(working_dir: Path) -> bool:
@@ -400,6 +476,13 @@ def _ack_to_publication(ack: Any) -> dict[str, Any]:
     }
 
 
+#: Sentinel input used when there is *no* transcript content to hash.
+#: Distinct from any payload_canonical so input_artifact_hash and
+#: output_artifact_hash are never equal for non-empty payloads (RISK_010
+#: provenance integrity, CE rework).
+_EMPTY_TRANSCRIPT_SENTINEL: str = "<no_transcript_input>"
+
+
 def _publish_portable_memory(
     *,
     working_dir_path: Path,
@@ -408,6 +491,8 @@ def _publish_portable_memory(
     archive_path: str | None,
     extracted_learnings: dict[str, list[str]],
     description: str,
+    redaction_failed: bool = False,
+    redaction_failure_reason: str = "",
 ) -> tuple[dict[str, Any], bool]:
     """Build, publish, and (on failure) enqueue the Portable Memory Artifact.
 
@@ -415,6 +500,13 @@ def _publish_portable_memory(
     Never raises: every failure path is captured into the structured
     publication block. Lazy imports keep storage coupling out of
     module-load time.
+
+    Args:
+        redaction_failed: When True, the upstream redaction step raised; we
+            MUST fail-closed (RISK_010, CE rework) and never publish — even
+            if identity is configured and provenance can be re-computed.
+        redaction_failure_reason: Human-readable reason; surfaced in the
+            outbox status record so operators can correlate.
     """
 
     # Lazy imports: keep storage subtree off clock_out's import-time
@@ -439,25 +531,57 @@ def _publish_portable_memory(
 
     outbox = OutboxStore(working_dir=working_dir_path)
 
+    # CE rework BLOCKER 1 (RISK_010): if redaction failed upstream, the
+    # publish path is fail-closed regardless of identity / provenance.
+    # PROD::I2 forbids any publish that does not preserve fail-closed
+    # redaction. Emit a structured failure + durable outbox status record
+    # so the skip is auditable (A2 second-order concern).
+    if redaction_failed:
+        publication = _skipped_publication("redaction_failure")
+        publication["error_message"] = (
+            redaction_failure_reason or "redaction failed; publish blocked fail-closed"
+        )
+        _record_skip_status(
+            working_dir_path,
+            session_id=session_id,
+            reason_code="redaction_failure",
+            reason_message=publication["error_message"],
+        )
+        return publication, True
+
     # Identity gate: B2_START_BLOCKER_001 — do not invent identity. If the
     # config is absent, the publish path is a structured skip with an
-    # outbox status record (A2). The skip record is informational; we
-    # don't write a persistent outbox entry because there's nothing to
-    # publish. ``unpublished_memory_exists`` reflects the durable queue.
+    # outbox status record (A2 + CE rework ADDITIONAL CONCERN 1). Every
+    # structured skip leaves a durable on-disk trace so PROD::I1 lifecycle
+    # integrity is preserved (no orphaned sessions).
     try:
         identity = resolve_identity(working_dir_path)
     except IdentityValidationError as e:
         publication = _skipped_publication("identity_invalid")
         publication["error_message"] = e.message
-        return publication, outbox.unpublished_memory_exists()
+        _record_skip_status(
+            working_dir_path,
+            session_id=session_id,
+            reason_code="identity_invalid",
+            reason_message=e.message,
+        )
+        return publication, True
 
     if identity is None:
         publication = _skipped_publication("no_identity_configured")
-        return publication, outbox.unpublished_memory_exists()
+        _record_skip_status(
+            working_dir_path,
+            session_id=session_id,
+            reason_code="no_identity_configured",
+            reason_message="no identity configured; publish skipped",
+        )
+        return publication, True
 
     # Provenance gate: G4 atomic guard. Build provenance from the redacted
-    # archive if available; else from the v1 payload itself so a complete
-    # provenance pair always exists before any adapter call (RISK_010).
+    # archive if available; else use a deterministic empty-input sentinel
+    # distinct from the canonical payload so input_artifact_hash and
+    # output_artifact_hash are independently derived (RISK_010 provenance
+    # integrity — CE rework: same-source fallback is forbidden).
     payload_role = str(session_data.get("role", "unknown"))
     payload_focus = str(session_data.get("focus", "unknown"))
     payload = _build_v1_payload(
@@ -476,13 +600,20 @@ def _publish_portable_memory(
         except OSError as e:
             publication = _skipped_publication("archive_unreadable")
             publication["error_message"] = str(e)
-            return publication, outbox.unpublished_memory_exists()
+            _record_skip_status(
+                working_dir_path,
+                session_id=session_id,
+                reason_code="archive_unreadable",
+                reason_message=str(e),
+            )
+            return publication, True
     else:
-        # No transcript archived; still produce a complete provenance pair
-        # over the canonical payload so RISK_010 holds (no publish without
-        # a redacted input/output pair). Empty input is acceptable because
-        # the redaction engine has no secrets to redact.
-        input_text = payload_canonical
+        # No transcript archived (legitimate "no transcript" case). Use a
+        # constant sentinel as input_text so input_artifact_hash !=
+        # output_artifact_hash for any non-empty payload. This keeps
+        # provenance integrity structurally distinguishable from the
+        # forbidden "same source" pattern (CE rework RISK_010).
+        input_text = _EMPTY_TRANSCRIPT_SENTINEL
 
     try:
         provenance = build_provenance_or_raise(
@@ -493,8 +624,8 @@ def _publish_portable_memory(
     except ProvenanceIncompleteError as e:
         publication = _skipped_publication(e.code)
         publication["error_message"] = e.message
-        # A2: the skip is observable. Outbox status reflects existing queue
-        # plus a synthetic record so unpublished_memory_exists flips True.
+        # A2 + CE rework: the skip is observable on disk via the outbox
+        # entry AND a status record keyed by session+reason for operators.
         try:
             synthetic_id = f"skip-{session_id}"
             ack = PublishAck(
@@ -513,6 +644,12 @@ def _publish_portable_memory(
             publication["queued_path"] = str(queued)
         except Exception as enqueue_err:  # pragma: no cover - defensive
             logger.warning("outbox enqueue for provenance skip failed: %s", enqueue_err)
+        _record_skip_status(
+            working_dir_path,
+            session_id=session_id,
+            reason_code=e.code,
+            reason_message=e.message,
+        )
         return publication, outbox.unpublished_memory_exists()
 
     # Build the artifact. parent_ids reference the session snapshot's

--- a/src/hestai_context_mcp/tools/clock_out.py
+++ b/src/hestai_context_mcp/tools/clock_out.py
@@ -264,6 +264,14 @@ def clock_out(
     archive_dir.mkdir(parents=True, exist_ok=True)
 
     if transcript_path and transcript_path.exists():
+        # Cubic P1 #3: ``dest`` must be initialised BEFORE the try block so
+        # the cleanup handler does not raise UnboundLocalError when an
+        # earlier statement (e.g., focus.replace on a None focus) raises
+        # before the assignment ``dest = archive_dir / archive_filename``
+        # is reached. PROD::I1 SESSION_LIFECYCLE_INTEGRITY + PROD::I4
+        # STRUCTURED_RETURN_SHAPES require a structured response, not an
+        # unstructured UnboundLocalError leak.
+        dest: Path | None = None
         try:
             timestamp = datetime.now(UTC).strftime("%Y-%m-%d")
             focus = session_data.get("focus", "general")
@@ -285,7 +293,7 @@ def clock_out(
             # Best-effort cleanup of any partial dest file so no
             # half-redacted content lingers on disk.
             try:
-                if dest.exists():
+                if dest is not None and dest.exists():
                     dest.unlink()
             except OSError:  # pragma: no cover — defensive
                 pass

--- a/src/hestai_context_mcp/tools/get_context.py
+++ b/src/hestai_context_mcp/tools/get_context.py
@@ -10,6 +10,23 @@ Use cases:
 - Payload Compiler preview ("what would an agent see?")
 - CI pipeline context injection
 - Lightweight reads without session overhead
+
+PURITY_GUARD::G3 — DO NOT ADD STORAGE IMPORTS.
+================================================
+
+Per CE RISK_003 OPTION_C ratified in the B1->B2 arbitration record,
+this module's public contract is **frozen** at
+``get_context(working_dir: str)``. Session-bound snapshots are exposed
+exclusively via ``clock_in.portable_state.snapshot``; ``get_context``
+MUST NOT import any adapter module, MUST NOT reference adapter or
+outbox symbols, MUST NOT create portable subdirectories, MUST NOT
+mutate snapshot/outbox mtimes, MUST NOT drain or enqueue outbox
+entries, and MUST NOT surface hydration as a successful response key.
+
+Behavioral invariants are enforced by
+``tests/integration/test_get_context_purity.py`` and the source-level
+guard is enforced by ``tests/storage/test_source_invariants_pss.py``
+(PROD::I5 + R10 INVARIANT_001).
 """
 
 import logging

--- a/tests/integration/test_clock_in_portable_state.py
+++ b/tests/integration/test_clock_in_portable_state.py
@@ -1,0 +1,363 @@
+"""GROUP_011: CLOCK_IN_INTEGRATION — RED-first tests.
+
+Asserts the PSS restore + named snapshot integration in
+``tools.clock_in`` per BUILD-PLAN §INTEGRATION_PLAN
+CLOCK_IN_EDIT_PLAN and §TDD_TEST_LIST GROUP_011 (TEST_119..TEST_128).
+
+Binding rulings exercised here:
+- G2: existing top-level response fields remain (CIV backward-compat).
+  The PSS extension is additive: a new ``portable_state`` block.
+- B2_START_BLOCKER_001 + RISK_001: when no IdentityTuple is configured,
+  restore is skipped fail-closed; the response carries a structured
+  ``restore_status="no_identity_configured"`` rather than inventing
+  auth/UX.
+- R3: identity mismatch raises restore_status="identity_mismatch".
+- R4: schema_too_new -> restore_status="schema_too_new".
+- R5: a named snapshot is bound to the returned session_id.
+- R8: tombstoned artifacts are excluded from snapshot.
+- R12: never requires a remote adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path, *, override: dict[str, Any] | None = None) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(override or _identity_dict()))
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _seed_artifact(working_dir: Path, *, artifact_id: str, sequence_id: int) -> None:
+    """Seed a portable artifact via LocalFilesystemAdapter so the format is exact."""
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        PortableMemoryArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    payload = {"id": artifact_id, "seq": sequence_id}
+    artifact = PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=build_provenance_or_raise(
+            input_text="i", output_text="o", redacted_credential_categories=()
+        ),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_hash_payload(payload),
+        payload=payload,
+    )
+    ref = ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_artifact(
+        ref, artifact, WritePrecondition()
+    )
+
+
+def _seed_tombstone(working_dir: Path, *, target_artifact_id: str, sequence_id: int) -> None:
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        TombstoneArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    tomb = TombstoneArtifact(
+        artifact_id=f"tomb-{target_artifact_id}",
+        artifact_kind=ArtifactKind.TOMBSTONE,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(target_artifact_id,),
+        target_artifact_id=target_artifact_id,
+        reason="user-revoked",
+        publisher_identity=identity,
+        redaction_provenance=None,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=hashlib.sha256(target_artifact_id.encode()).hexdigest(),
+    )
+    ref = ArtifactRef(
+        artifact_id=tomb.artifact_id,
+        identity=tomb.identity,
+        artifact_kind=tomb.artifact_kind,
+        sequence_id=tomb.sequence_id,
+        created_at=tomb.created_at,
+        payload_hash=tomb.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_tombstone(ref, tomb, WritePrecondition())
+
+
+@pytest.mark.integration
+class TestPortableDirectories:
+    """TEST_119."""
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_creates_portable_dirs_via_session_structure(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        clock_in(role="impl", working_dir=str(tmp_path))
+        # SessionManager extension: portable/outbox + portable/snapshots present.
+        assert (tmp_path / ".hestai" / "state" / "portable" / "outbox").exists()
+        assert (tmp_path / ".hestai" / "state" / "portable" / "snapshots").exists()
+
+
+@pytest.mark.integration
+class TestRestore:
+    """TEST_120..TEST_122."""
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_restores_local_filesystem_artifacts_before_context_build(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
+        _seed_artifact(tmp_path, artifact_id="art-2", sequence_id=2)
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        assert ps["restore_status"] == "ok"
+        assert ps["artifact_count"] == 2
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_creates_named_snapshot_bound_to_returned_session_id(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        sid = result["session_id"]
+        snap_path = (
+            tmp_path
+            / ".hestai"
+            / "state"
+            / "portable"
+            / "snapshots"
+            / sid
+            / "context-projection.json"
+        )
+        assert snap_path.exists()
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_snapshot_excludes_tombstoned_artifacts(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
+        _seed_artifact(tmp_path, artifact_id="art-2", sequence_id=2)
+        _seed_tombstone(tmp_path, target_artifact_id="art-1", sequence_id=3)
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        assert ps["tombstone_count"] == 1
+        # Read the snapshot and confirm art-1 is gone.
+        sid = result["session_id"]
+        proj = json.loads(
+            (
+                tmp_path
+                / ".hestai"
+                / "state"
+                / "portable"
+                / "snapshots"
+                / sid
+                / "context-projection.json"
+            ).read_text()
+        )
+        ids = [r["artifact_id"] for r in proj["artifact_refs"]]
+        assert "art-1" not in ids
+        assert "art-2" in ids
+
+
+@pytest.mark.integration
+class TestRestoreErrors:
+    """TEST_123..TEST_124."""
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_identity_mismatch_returns_structured_restore_error(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        # Configured identity is project_id="proj-A".
+        _write_identity_config(tmp_path)
+        # Seed an artifact with project_id="proj-A" first to make the
+        # adapter happy, then write an artifact under a *different*
+        # carrier-path identity by overwriting the json file in place.
+        _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
+        json_path = next(
+            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+        )
+        raw = json.loads(json_path.read_text())
+        raw["identity"]["project_id"] = "proj-OTHER"
+        json_path.write_text(json.dumps(raw))
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        # Restore should refuse cleanly with a structured error code.
+        assert ps["restore_status"] in {"identity_mismatch", "ok"}
+        # Even if list_artifacts skipped the foreign artifact, the
+        # restore_status MUST surface the situation explicitly when
+        # mismatch is detected. Accept either:
+        #   - "identity_mismatch": detected and refused
+        #   - "ok" with artifact_count=0: silently filtered (still safe)
+        if ps["restore_status"] == "ok":
+            assert ps["artifact_count"] == 0
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_schema_too_new_returns_structured_restore_error(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
+        # Bump minimum_reader_version on disk to 99 (too new).
+        json_path = next(
+            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+        )
+        raw = json.loads(json_path.read_text())
+        raw["minimum_reader_version"] = 99
+        json_path.write_text(json.dumps(raw))
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        assert ps["restore_status"] == "schema_too_new"
+        # Error block carries the structured reason.
+        assert ps["error"]["code"] == "schema_too_new"
+
+
+@pytest.mark.integration
+class TestResponseShape:
+    """TEST_125..TEST_127 (G2 backward compat + portable_state shape)."""
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_return_shape_preserves_existing_top_level_fields(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        for k in (
+            "session_id",
+            "role",
+            "focus",
+            "focus_source",
+            "branch",
+            "working_dir",
+            "phase",
+            "context_paths",
+            "ai_synthesis",
+            "context",
+        ):
+            assert k in result, f"top-level field {k!r} disappeared (G2 violation)"
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_return_includes_portable_state_metadata(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        assert "portable_state" in result
+        ps = result["portable_state"]
+        for k in (
+            "restore_status",
+            "identity",
+            "artifact_count",
+            "tombstone_count",
+            "snapshot_path",
+            "error",
+        ):
+            assert k in ps, f"portable_state field {k!r} missing"
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_with_no_artifacts_succeeds_offline(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        assert ps["restore_status"] == "ok"
+        assert ps["artifact_count"] == 0
+        assert ps["tombstone_count"] == 0
+
+
+@pytest.mark.integration
+class TestNoRemoteRequired:
+    """TEST_128 — INVARIANT_002 (R10/R12)."""
+
+    @patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main")
+    def test_clock_in_does_not_require_remote_adapter_enabled(
+        self, _mock_branch: Any, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        # No identity, no artifacts — clock_in must still succeed.
+        result = clock_in(role="impl", working_dir=str(tmp_path))
+        # Backward compat preserved.
+        assert "session_id" in result
+        # PSS surface present even when not configured.
+        assert "portable_state" in result
+        # Status is the structured "no_identity_configured" — never an
+        # exception, never a network call.
+        assert result["portable_state"]["restore_status"] in {"no_identity_configured", "ok"}

--- a/tests/integration/test_clock_in_portable_state.py
+++ b/tests/integration/test_clock_in_portable_state.py
@@ -242,9 +242,7 @@ class TestRestoreErrors:
         # adapter happy, then write an artifact under a *different*
         # carrier-path identity by overwriting the json file in place.
         _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
-        json_path = next(
-            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
-        )
+        json_path = next((tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json"))
         raw = json.loads(json_path.read_text())
         raw["identity"]["project_id"] = "proj-OTHER"
         json_path.write_text(json.dumps(raw))
@@ -270,9 +268,7 @@ class TestRestoreErrors:
         _write_identity_config(tmp_path)
         _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
         # Bump minimum_reader_version on disk to 99 (too new).
-        json_path = next(
-            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
-        )
+        json_path = next((tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json"))
         raw = json.loads(json_path.read_text())
         raw["minimum_reader_version"] = 99
         json_path.write_text(json.dumps(raw))

--- a/tests/integration/test_clock_in_portable_state.py
+++ b/tests/integration/test_clock_in_portable_state.py
@@ -243,7 +243,7 @@ class TestRestoreErrors:
         # carrier-path identity by overwriting the json file in place.
         _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
         json_path = next(
-            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
         )
         raw = json.loads(json_path.read_text())
         raw["identity"]["project_id"] = "proj-OTHER"
@@ -271,7 +271,7 @@ class TestRestoreErrors:
         _seed_artifact(tmp_path, artifact_id="art-1", sequence_id=1)
         # Bump minimum_reader_version on disk to 99 (too new).
         json_path = next(
-            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
         )
         raw = json.loads(json_path.read_text())
         raw["minimum_reader_version"] = 99

--- a/tests/integration/test_clock_in_snapshot_error_count.py
+++ b/tests/integration/test_clock_in_snapshot_error_count.py
@@ -1,0 +1,256 @@
+"""Cubic rework cycle 3 — Finding (P2, clock_in.py:477).
+
+RED-first test: when the snapshot try-block raises (whether at the
+post-tombstone-id dict comprehension or at ``create_session_snapshot``),
+``portable_state.artifact_count`` MUST report the post-tombstone count
+authoritatively present in ``projection["artifact_refs"]`` — NOT the
+pre-tombstone ``memory_refs`` count.
+
+Cubic finding: the prior cubic #1 fix introduced a fallback
+``if not accepted_refs: accepted_refs = tuple(memory_refs)`` which
+overwrites the (correctly empty) post-tombstone refs with the
+pre-tombstone ``memory_refs`` whenever the dict comprehension raises
+(e.g., ``projection["artifact_refs"]`` malformed). This violates R8
+(tombstoned artifacts excluded from snapshot/state) and PROD::I4
+(STRUCTURED_RETURN_SHAPES — ``artifact_count`` must be a defined-field
+post-tombstone value).
+
+Correct fix (Option A): compute ``artifact_count`` from
+``projection["artifact_refs"]`` directly, independent of snapshot
+success/failure. The post-tombstone count is the projection's authority,
+not ``accepted_refs``.
+
+Setup: 3 memory artifacts seeded; 1 tombstoned. The PROJECTION'S
+authoritative post-tombstone count is 2. We force the snapshot try-block
+to raise via a malformed projection so the dict comprehension at
+``clock_in.py:460`` triggers KeyError (and so ``accepted_refs`` stays
+empty, exposing the buggy fallback). The test asserts
+``artifact_count == 2`` (post-tombstone), NOT 3 (pre-tombstone).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(_identity_dict()))
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _seed_artifact(working_dir: Path, *, artifact_id: str, sequence_id: int) -> None:
+    """Seed a portable artifact via LocalFilesystemAdapter so the format is exact."""
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        PortableMemoryArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    payload = {"id": artifact_id, "seq": sequence_id}
+    artifact = PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=build_provenance_or_raise(
+            input_text="i", output_text="o", redacted_credential_categories=()
+        ),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_hash_payload(payload),
+        payload=payload,
+    )
+    ref = ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_artifact(
+        ref, artifact, WritePrecondition()
+    )
+
+
+def _seed_tombstone(working_dir: Path, *, target_artifact_id: str, sequence_id: int) -> None:
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        TombstoneArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    tomb = TombstoneArtifact(
+        artifact_id=f"tomb-{target_artifact_id}",
+        artifact_kind=ArtifactKind.TOMBSTONE,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(target_artifact_id,),
+        target_artifact_id=target_artifact_id,
+        reason="user-revoked",
+        publisher_identity=identity,
+        redaction_provenance=None,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=hashlib.sha256(target_artifact_id.encode()).hexdigest(),
+    )
+    ref = ArtifactRef(
+        artifact_id=tomb.artifact_id,
+        identity=tomb.identity,
+        artifact_kind=tomb.artifact_kind,
+        sequence_id=tomb.sequence_id,
+        created_at=tomb.created_at,
+        payload_hash=tomb.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_tombstone(ref, tomb, WritePrecondition())
+
+
+@pytest.mark.integration
+class TestClockInArtifactCountPostTombstoneOnSnapshotError:
+    """Cubic P2 #2: artifact_count is post-tombstone authoritative regardless
+    of snapshot try-block outcome."""
+
+    def test_artifact_count_is_post_tombstone_when_snapshot_block_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """3 memory artifacts, 1 tombstoned -> projection has 2 artifact_refs.
+
+        We force the snapshot try-block to raise inside the dict
+        comprehension (via a malformed projection["artifact_refs"]) so
+        ``accepted_refs`` remains empty — exposing the buggy fallback. The
+        contract: ``portable_state.artifact_count`` MUST be 2 (the
+        post-tombstone projection count), NOT 3 (the pre-tombstone
+        memory_refs count).
+        """
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        # 3 memory artifacts; tombstone the second so projection has 2.
+        _seed_artifact(tmp_path, artifact_id="art-A", sequence_id=1)
+        _seed_artifact(tmp_path, artifact_id="art-B", sequence_id=2)
+        _seed_artifact(tmp_path, artifact_id="art-C", sequence_id=3)
+        _seed_tombstone(tmp_path, target_artifact_id="art-B", sequence_id=4)
+
+        # Real build_projection (we still want the genuine projection to
+        # construct correctly) — but we want the dict comprehension at
+        # clock_in.py:460 to raise. The comprehension iterates
+        # projection["artifact_refs"] and indexes r["artifact_id"]. We
+        # therefore wrap build_projection: keep the genuine
+        # tombstoned_artifact_ids + identity + length-2 artifact_refs, but
+        # replace each element with a dict missing the "artifact_id" key so
+        # the comprehension triggers KeyError. ``len(artifact_refs)`` is
+        # still 2 — the authoritative post-tombstone count Option A reads.
+        from hestai_context_mcp.storage import projection as _projection_mod
+
+        real_build = _projection_mod.build_projection
+
+        def _build_projection_with_malformed_refs(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            real = real_build(*args, **kwargs)
+            # Same length (post-tombstone count is 2), but each entry lacks
+            # "artifact_id" so the dict comprehension raises KeyError.
+            real["artifact_refs"] = [
+                {"sequence_id": entry["sequence_id"]} for entry in real["artifact_refs"]
+            ]
+            return real
+
+        with (
+            patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"),
+            patch(
+                "hestai_context_mcp.storage.projection.build_projection",
+                side_effect=_build_projection_with_malformed_refs,
+            ),
+        ):
+            result = clock_in(role="impl", working_dir=str(tmp_path), focus="task")
+
+        portable_state = result["portable_state"]
+
+        # Post-tombstone count is 2 (NOT pre-tombstone 3). This is the
+        # core regression assertion for cubic P2 #2.
+        assert portable_state["artifact_count"] == 2, (
+            "artifact_count must reflect post-tombstone projection count (2), "
+            "not pre-tombstone memory_refs count (3); cubic P2 fallback bug"
+        )
+
+        # Snapshot write did not succeed (the comprehension raised before
+        # snapshot creation), so error is structured and path is None.
+        snapshot_error = portable_state["snapshot_error"]
+        assert snapshot_error is not None
+        assert snapshot_error["code"] == "snapshot_write_failed"
+        assert portable_state["snapshot_path"] is None
+
+    def test_artifact_count_is_post_tombstone_when_snapshot_write_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Companion: when ``create_session_snapshot`` itself raises (after
+        the comprehension already populated ``accepted_refs`` correctly),
+        the count is still post-tombstone (2). Locks the contract along
+        the second branch of the try-block. Per cubic instruction wording.
+        """
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+        _seed_artifact(tmp_path, artifact_id="art-A", sequence_id=1)
+        _seed_artifact(tmp_path, artifact_id="art-B", sequence_id=2)
+        _seed_artifact(tmp_path, artifact_id="art-C", sequence_id=3)
+        _seed_tombstone(tmp_path, target_artifact_id="art-B", sequence_id=4)
+
+        def _raise(*args: Any, **kwargs: Any) -> Any:
+            raise OSError("simulated disk-full on snapshot write")
+
+        with (
+            patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"),
+            patch(
+                "hestai_context_mcp.storage.snapshots.create_session_snapshot",
+                side_effect=_raise,
+            ),
+        ):
+            result = clock_in(role="impl", working_dir=str(tmp_path), focus="task")
+
+        portable_state = result["portable_state"]
+        assert portable_state["artifact_count"] == 2
+        snapshot_error = portable_state["snapshot_error"]
+        assert snapshot_error is not None
+        assert snapshot_error["code"] == "snapshot_write_failed"
+        assert portable_state["snapshot_path"] is None

--- a/tests/integration/test_clock_in_snapshot_error_handling.py
+++ b/tests/integration/test_clock_in_snapshot_error_handling.py
@@ -1,0 +1,74 @@
+"""Cubic rework cycle 2 — Finding #1 (P1, clock_in.py:449).
+
+RED-first test: ``create_session_snapshot`` failure must be surfaced as
+``portable_state.snapshot_error`` (PROD::I4 STRUCTURED_RETURN_SHAPES);
+clock_in must NEVER raise even when snapshot write fails. This parallels
+the A2 audit-on-skip pattern: local session creation already succeeded,
+so portable-state snapshot failure is observable but not fatal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(_identity_dict()))
+
+
+@pytest.mark.integration
+class TestClockInSnapshotWriteFailure:
+    """Cubic P1 #1: snapshot construction must not break clock_in response shape."""
+
+    def test_clock_in_surfaces_snapshot_error_when_create_snapshot_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """Patching ``create_session_snapshot`` to raise OSError must yield
+        a structured ``portable_state.snapshot_error`` and a non-failing
+        clock_in response (PROD::I4 STRUCTURED_RETURN_SHAPES)."""
+
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        _write_identity_config(tmp_path)
+
+        def _raise(*args: Any, **kwargs: Any) -> Any:
+            raise OSError("simulated disk-full on snapshot write")
+
+        with patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"):
+            with patch(
+                "hestai_context_mcp.storage.snapshots.create_session_snapshot",
+                side_effect=_raise,
+            ):
+                result = clock_in(role="impl", working_dir=str(tmp_path), focus="task")
+
+        # Top-level shape preserved (G2 backward-compat).
+        assert "session_id" in result
+        assert "portable_state" in result
+
+        portable_state = result["portable_state"]
+        # Restore did succeed up to (but not including) snapshot write.
+        # Snapshot failure is observable via a dedicated structured field.
+        assert "snapshot_error" in portable_state
+        snapshot_error = portable_state["snapshot_error"]
+        assert snapshot_error is not None
+        assert snapshot_error["code"] == "snapshot_write_failed"
+        assert "simulated disk-full" in snapshot_error["message"]
+        # snapshot_path is None when the write fails (no half-written file).
+        assert portable_state["snapshot_path"] is None

--- a/tests/integration/test_clock_in_snapshot_error_handling.py
+++ b/tests/integration/test_clock_in_snapshot_error_handling.py
@@ -51,12 +51,14 @@ class TestClockInSnapshotWriteFailure:
         def _raise(*args: Any, **kwargs: Any) -> Any:
             raise OSError("simulated disk-full on snapshot write")
 
-        with patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"):
-            with patch(
+        with (
+            patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"),
+            patch(
                 "hestai_context_mcp.storage.snapshots.create_session_snapshot",
                 side_effect=_raise,
-            ):
-                result = clock_in(role="impl", working_dir=str(tmp_path), focus="task")
+            ),
+        ):
+            result = clock_in(role="impl", working_dir=str(tmp_path), focus="task")
 
         # Top-level shape preserved (G2 backward-compat).
         assert "session_id" in result

--- a/tests/integration/test_clock_out_dest_unbound.py
+++ b/tests/integration/test_clock_out_dest_unbound.py
@@ -54,9 +54,7 @@ def _write_session_with_focus_none(working_dir: Path, session_id: str) -> Path:
 class TestClockOutDestUnboundCleanup:
     """Cubic P1 #3: cleanup handler must not leak UnboundLocalError."""
 
-    def test_clock_out_focus_none_does_not_leak_unbound_local_error(
-        self, tmp_path: Path
-    ) -> None:
+    def test_clock_out_focus_none_does_not_leak_unbound_local_error(self, tmp_path: Path) -> None:
         """focus=None must not cause UnboundLocalError when dest is referenced
         in the cleanup handler. A structured response is required."""
 

--- a/tests/integration/test_clock_out_dest_unbound.py
+++ b/tests/integration/test_clock_out_dest_unbound.py
@@ -1,0 +1,77 @@
+"""Cubic rework cycle 2 — Finding #3 (P1, clock_out.py:288).
+
+RED-first test: when ``dest`` would not yet be assigned (e.g., focus is
+None and ``focus.replace("/", "-")`` raises AttributeError before the
+``dest = archive_dir / archive_filename`` line executes), the cleanup
+handler must NOT leak ``UnboundLocalError``. The expected behaviour is
+a structured response (PROD::I1 SESSION_LIFECYCLE_INTEGRITY +
+PROD::I4 STRUCTURED_RETURN_SHAPES) where redaction_failed records the
+underlying error and clock_out continues to the publish path without
+crashing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _write_session_with_focus_none(working_dir: Path, session_id: str) -> Path:
+    """Seed an active session whose session_data['focus'] is None.
+
+    A real transcript file is also created so the redaction branch is
+    entered (the bug only triggers when transcript_path exists).
+    """
+
+    active = working_dir / ".hestai" / "state" / "sessions" / "active" / session_id
+    active.mkdir(parents=True, exist_ok=True)
+
+    # Seed a tiny transcript file so the redaction branch is taken.
+    transcript = working_dir / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"role": "user", "content": "hi"}) + "\n",
+        encoding="utf-8",
+    )
+
+    session_data: dict[str, Any] = {
+        "session_id": session_id,
+        "role": "impl",
+        # focus=None is the trigger: focus.replace("/", "-") raises
+        # AttributeError before ``dest`` is bound.
+        "focus": None,
+        "branch": "main",
+        "transcript_path": str(transcript),
+        "created_at": "2026-04-26T00:00:00+00:00",
+    }
+    (active / "session.json").write_text(json.dumps(session_data))
+    return active
+
+
+@pytest.mark.integration
+class TestClockOutDestUnboundCleanup:
+    """Cubic P1 #3: cleanup handler must not leak UnboundLocalError."""
+
+    def test_clock_out_focus_none_does_not_leak_unbound_local_error(
+        self, tmp_path: Path
+    ) -> None:
+        """focus=None must not cause UnboundLocalError when dest is referenced
+        in the cleanup handler. A structured response is required."""
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        sid = "session-focus-none"
+        _write_session_with_focus_none(tmp_path, sid)
+
+        # MUST NOT raise UnboundLocalError (or any unstructured error).
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # Top-level shape preserved.
+        assert isinstance(result, dict)
+        assert "status" in result
+        assert "portable_publication" in result
+        # archive_path is None because the redaction branch failed before
+        # dest could be assigned.
+        assert result["archive_path"] is None

--- a/tests/integration/test_clock_out_portable_publish.py
+++ b/tests/integration/test_clock_out_portable_publish.py
@@ -1,0 +1,384 @@
+"""GROUP_012: CLOCK_OUT_INTEGRATION — RED-first tests.
+
+Asserts the PSS publish + outbox integration in ``tools.clock_out`` per
+BUILD-PLAN §INTEGRATION_PLAN CLOCK_OUT_EDIT_PLAN and §TDD_TEST_LIST
+GROUP_012 (TEST_129..TEST_138).
+
+Binding rulings exercised here:
+
+- A2 (CIV) skip-publish must write outbox status record with reason
+  code (no silent skip).
+- CE RISK_010 fail-closed publish: no publish without redacted
+  input/output provenance pair.
+- CE RISK_005 v1 payload keys = {session_id, role, focus, archive_path,
+  decisions, blockers, learnings, description}.
+- R7: clock_out has two separable outcomes (local archive vs portable
+  publish); local must succeed independently from publish.
+- R9: duplicate publish is idempotent (same payload_hash).
+- B2_START_BLOCKER_004: never publish without complete provenance.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path, *, override: dict[str, Any] | None = None) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(override or _identity_dict()))
+
+
+def _write_session(working_dir: Path, session_id: str, *, role: str, focus: str) -> Path:
+    """Seed an active session directory for clock_out to consume."""
+    active = working_dir / ".hestai" / "state" / "sessions" / "active" / session_id
+    active.mkdir(parents=True, exist_ok=True)
+    session_data = {
+        "session_id": session_id,
+        "role": role,
+        "focus": focus,
+        "branch": "main",
+        "transcript_path": None,
+        "created_at": "2026-04-26T00:00:00+00:00",
+    }
+    (active / "session.json").write_text(json.dumps(session_data))
+    return active
+
+
+def _clock_in_then_session(
+    working_dir: Path, *, role: str = "impl", focus: str | None = "task"
+) -> str:
+    """Run clock_in (with identity configured) so that a snapshot exists.
+
+    Returns the created session_id so clock_out can target it.
+    """
+    from hestai_context_mcp.tools.clock_in import clock_in
+
+    with patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"):
+        result = clock_in(role=role, working_dir=str(working_dir), focus=focus)
+    return result["session_id"]
+
+
+@pytest.mark.integration
+class TestClockOutLocalArchiveSeparable:
+    """TEST_129 + TEST_158."""
+
+    def test_clock_out_local_archive_success_independent_from_portable_publish(
+        self, tmp_path: Path
+    ) -> None:
+        """Local archive completes regardless of publish outcome."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        # No identity configured -> publish is skipped, but archive flow runs.
+        sid = "session-localonly"
+        _write_session(tmp_path, sid, role="impl", focus="task")
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert result["status"] == "success"
+        # Portable publication block exists and is structured even without identity.
+        assert "portable_publication" in result
+        assert "unpublished_memory_exists" in result
+        assert isinstance(result["unpublished_memory_exists"], bool)
+
+
+@pytest.mark.integration
+class TestClockOutArtifactBuild:
+    """TEST_130 + TEST_136 + TEST_137."""
+
+    def test_clock_out_builds_artifact_after_redaction_success(self, tmp_path: Path) -> None:
+        """When identity is set + provenance is complete, clock_out publishes."""
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import IdentityTuple, PortableNamespace
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+        # clock_in creates an active session via SessionManager; reuse sid.
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert result["status"] == "success"
+        publication = result["portable_publication"]
+        assert publication["status"] in {"published", "duplicate"}
+        assert publication["artifact_id"]
+        assert publication["sequence_id"] is not None
+
+        # Artifact is on disk via the adapter's namespace path.
+        identity = IdentityTuple(**_identity_dict())
+        ns = PortableNamespace(
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            user_id=identity.user_id,
+            state_schema_version=identity.state_schema_version,
+            carrier_namespace=identity.carrier_namespace,
+        )
+        refs = LocalFilesystemAdapter(working_dir=tmp_path).list_artifacts(ns)
+        assert len(refs) >= 1
+
+    def test_clock_out_missing_redaction_provenance_fails_publication_not_archive(
+        self, tmp_path: Path
+    ) -> None:
+        """Provenance gate fails publication only; archive flow still runs."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        # Patch build_provenance_or_raise to simulate provenance failure.
+        from hestai_context_mcp.storage.provenance import ProvenanceIncompleteError
+
+        def _broken(**kwargs: Any) -> Any:
+            raise ProvenanceIncompleteError(
+                code="provenance_incomplete",
+                missing_field="engine_version",
+                message="simulated incomplete provenance",
+            )
+
+        with patch(
+            "hestai_context_mcp.tools.clock_out.build_provenance_or_raise",
+            side_effect=_broken,
+        ):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert result["status"] == "success"  # archive still succeeded
+        publication = result["portable_publication"]
+        assert publication["status"] == "failed"
+        assert publication["error_code"] == "provenance_incomplete"
+        # Skip path writes outbox status record (A2): unpublished memory exists.
+        assert result["unpublished_memory_exists"] is True
+
+    def test_clock_out_artifact_parent_ids_include_prior_snapshot_refs(
+        self, tmp_path: Path
+    ) -> None:
+        """Published artifact parent_ids reference the snapshot's prior artifact ids."""
+        import hashlib
+
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            ArtifactRef,
+            IdentityTuple,
+            PortableMemoryArtifact,
+            PortableNamespace,
+            WritePrecondition,
+        )
+        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+        from hestai_context_mcp.tools.clock_out import clock_out
+        from datetime import UTC, datetime
+
+        _write_identity_config(tmp_path)
+
+        # Seed a prior artifact so clock_in's snapshot has a non-empty refs list.
+        identity = IdentityTuple(**_identity_dict())
+        prior_payload = {"id": "art-prior", "seq": 1}
+        prior = PortableMemoryArtifact(
+            artifact_id="art-prior",
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=identity,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=1,
+            parent_ids=(),
+            redaction_provenance=build_provenance_or_raise(
+                input_text="i", output_text="o", redacted_credential_categories=()
+            ),
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=hashlib.sha256(
+                json.dumps(prior_payload, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest(),
+            payload=prior_payload,
+        )
+        ref = ArtifactRef(
+            artifact_id=prior.artifact_id,
+            identity=prior.identity,
+            artifact_kind=prior.artifact_kind,
+            sequence_id=prior.sequence_id,
+            created_at=prior.created_at,
+            payload_hash=prior.payload_hash,
+            carrier_path="",
+        )
+        LocalFilesystemAdapter(working_dir=tmp_path).write_artifact(ref, prior, WritePrecondition())
+
+        sid = _clock_in_then_session(tmp_path)
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        publication = result["portable_publication"]
+        assert publication["status"] in {"published", "duplicate"}
+
+        # Read back via adapter and confirm parent_ids include prior id.
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        ns = PortableNamespace(
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            user_id=identity.user_id,
+            state_schema_version=identity.state_schema_version,
+            carrier_namespace=identity.carrier_namespace,
+        )
+        refs = adapter.list_artifacts(ns)
+        new_refs = [r for r in refs if r.artifact_id != "art-prior"]
+        assert new_refs, "clock_out should have written at least one new artifact"
+        new_artifact = adapter.read_artifact(new_refs[0])
+        from hestai_context_mcp.storage.types import PortableMemoryArtifact as PMA
+
+        assert isinstance(new_artifact, PMA)
+        assert "art-prior" in new_artifact.parent_ids
+
+
+@pytest.mark.integration
+class TestClockOutPublishIntegration:
+    """TEST_131 + TEST_132 + TEST_133."""
+
+    def test_clock_out_publishes_artifact_to_local_filesystem_adapter(
+        self, tmp_path: Path
+    ) -> None:
+        """Adapter gets exactly one publish call (no remote, no Git refs)."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        publication = result["portable_publication"]
+        assert publication["carrier_namespace"] == _identity_dict()["carrier_namespace"]
+        # carrier_path is local; absolute path under working_dir.
+        receipt = publication.get("durable_carrier_receipt") or ""
+        assert ".hestai" in receipt and "portable" in receipt and "artifacts" in receipt
+
+    def test_clock_out_return_includes_portable_publication_status(self, tmp_path: Path) -> None:
+        """portable_publication is always present, even when skipped."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        sid = "session-without-identity"
+        _write_session(tmp_path, sid, role="impl", focus="task")
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert "portable_publication" in result
+        publication = result["portable_publication"]
+        for key in ("status", "artifact_id", "sequence_id", "carrier_namespace", "queued_path"):
+            assert key in publication
+
+    def test_clock_out_return_includes_unpublished_memory_exists_false_when_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """When publish succeeds, unpublished_memory_exists is False."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        publication = result["portable_publication"]
+        assert publication["status"] in {"published", "duplicate"}
+        assert result["unpublished_memory_exists"] is False
+
+
+@pytest.mark.integration
+class TestClockOutPublishFailure:
+    """TEST_134 + TEST_135."""
+
+    def test_clock_out_publish_failure_queues_outbox_and_reports_local_success(
+        self, tmp_path: Path
+    ) -> None:
+        """Adapter raise -> outbox status record exists; archive succeeded."""
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        # Force the adapter publish call to raise an OSError after archive.
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        def _raise(self: Any, *args: Any, **kwargs: Any) -> None:
+            raise OSError("simulated adapter failure")
+
+        with patch.object(LocalFilesystemAdapter, "write_artifact", _raise):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert result["status"] == "success"  # archive succeeded
+        publication = result["portable_publication"]
+        assert publication["status"] == "failed"
+        # Outbox queued path is recorded.
+        assert publication["queued_path"]
+        # The outbox file exists.
+        assert Path(publication["queued_path"]).exists()
+
+    def test_clock_out_publish_failure_sets_unpublished_memory_exists_true(
+        self, tmp_path: Path
+    ) -> None:
+        """When publish fails, unpublished_memory_exists is True."""
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        def _raise(self: Any, *args: Any, **kwargs: Any) -> None:
+            raise OSError("simulated adapter failure")
+
+        with patch.object(LocalFilesystemAdapter, "write_artifact", _raise):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        assert result["unpublished_memory_exists"] is True
+
+
+@pytest.mark.integration
+class TestClockOutDuplicateIdempotent:
+    """TEST_138."""
+
+    def test_clock_out_duplicate_publish_is_idempotent_same_hash(self, tmp_path: Path) -> None:
+        """Re-publishing the same payload hash returns DUPLICATE not FAILED."""
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            ArtifactRef,
+            IdentityTuple,
+            PortableMemoryArtifact,
+            WritePrecondition,
+        )
+        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+        from hestai_context_mcp.tools.clock_out import clock_out
+        from datetime import UTC, datetime
+        import hashlib
+
+        _write_identity_config(tmp_path)
+        sid = _clock_in_then_session(tmp_path)
+
+        # Pre-seed an artifact with the deterministic id clock_out will derive.
+        # We don't know the id until clock_out builds it, so we let clock_out
+        # publish first, then call clock_out again on a fresh session with the
+        # same content -> should hit duplicate.
+        result1 = clock_out(session_id=sid, working_dir=str(tmp_path))
+        assert result1["portable_publication"]["status"] in {"published", "duplicate"}
+
+        # Second clock_out with identical session content. Re-create session and
+        # session.json with the same role/focus so the v1 payload yields the same
+        # hash.
+        sid2 = _clock_in_then_session(tmp_path)
+        # Ensure we're targeting the same artifact_id by reusing the first
+        # publication's seed: write a manual duplicate via the adapter.
+        # If our derivation is content-stable, clock_out's second call should
+        # observe the existing artifact_id and return DUPLICATE rather than FAILED.
+        # We guard by asserting status is in {published, duplicate}, never failed.
+        result2 = clock_out(session_id=sid2, working_dir=str(tmp_path))
+        assert result2["portable_publication"]["status"] in {"published", "duplicate"}
+        assert result2["portable_publication"]["status"] != "failed"

--- a/tests/integration/test_clock_out_portable_publish.py
+++ b/tests/integration/test_clock_out_portable_publish.py
@@ -343,29 +343,41 @@ class TestClockOutDuplicateIdempotent:
     """TEST_138."""
 
     def test_clock_out_duplicate_publish_is_idempotent_same_hash(self, tmp_path: Path) -> None:
-        """Re-publishing the same payload hash returns DUPLICATE not FAILED."""
+        """Re-publishing the same payload hash returns DUPLICATE not FAILED.
+
+        Cubic P2 #8 fix: the artifact_id seed is content-addressed on
+        ``session_id|identity|payload_hash`` (clock_out.py:673). Calling
+        ``_clock_in_then_session`` twice generated DIFFERENT sids, so the
+        second publish derived a different artifact_id and never hit
+        duplicate detection — the original test was vacuous. We must
+        REUSE the same session_id (and same role/focus, so v1 payload
+        is identical) across both publish calls.
+        """
 
         from hestai_context_mcp.tools.clock_out import clock_out
 
         _write_identity_config(tmp_path)
-        sid = _clock_in_then_session(tmp_path)
+        sid = _clock_in_then_session(tmp_path, role="impl", focus="task")
 
-        # Pre-seed an artifact with the deterministic id clock_out will derive.
-        # We don't know the id until clock_out builds it, so we let clock_out
-        # publish first, then call clock_out again on a fresh session with the
-        # same content -> should hit duplicate.
+        # First publish.
         result1 = clock_out(session_id=sid, working_dir=str(tmp_path))
         assert result1["portable_publication"]["status"] in {"published", "duplicate"}
+        first_artifact_id = result1["portable_publication"]["artifact_id"]
+        assert first_artifact_id  # sanity: non-empty
 
-        # Second clock_out with identical session content. Re-create session and
-        # session.json with the same role/focus so the v1 payload yields the same
-        # hash.
-        sid2 = _clock_in_then_session(tmp_path)
-        # Ensure we're targeting the same artifact_id by reusing the first
-        # publication's seed: write a manual duplicate via the adapter.
-        # If our derivation is content-stable, clock_out's second call should
-        # observe the existing artifact_id and return DUPLICATE rather than FAILED.
-        # We guard by asserting status is in {published, duplicate}, never failed.
-        result2 = clock_out(session_id=sid2, working_dir=str(tmp_path))
-        assert result2["portable_publication"]["status"] in {"published", "duplicate"}
-        assert result2["portable_publication"]["status"] != "failed"
+        # clock_out removes the active session dir; recreate it with the
+        # SAME sid + same role + same focus so v1 payload hash and
+        # artifact_id seed are identical to the first call.
+        _write_session(tmp_path, sid, role="impl", focus="task")
+
+        # Second publish — content-addressed artifact_id matches the
+        # already-on-disk artifact, so the adapter returns DUPLICATE.
+        result2 = clock_out(session_id=sid, working_dir=str(tmp_path))
+        publication2 = result2["portable_publication"]
+        assert publication2["artifact_id"] == first_artifact_id, (
+            "duplicate test requires identical artifact_ids; "
+            f"got {publication2['artifact_id']!r} != {first_artifact_id!r}"
+        )
+        # The §INTEGRATION_PLAN R9 idempotent-on-same-hash contract:
+        # the second publish MUST report status="duplicate".
+        assert publication2["status"] == "duplicate"

--- a/tests/integration/test_clock_out_portable_publish.py
+++ b/tests/integration/test_clock_out_portable_publish.py
@@ -81,20 +81,53 @@ class TestClockOutLocalArchiveSeparable:
     def test_clock_out_local_archive_success_independent_from_portable_publish(
         self, tmp_path: Path
     ) -> None:
-        """Local archive completes regardless of publish outcome."""
+        """Local archive completes regardless of publish outcome.
+
+        Cubic P3 #10 fix: previously this test seeded a session whose
+        ``transcript_path`` was None, which short-circuited the entire
+        archive/redaction branch — the test only verified the
+        no-archive path. To genuinely cover "local archive success
+        independent from portable publish" we seed a real transcript
+        file and assert archive_path is non-null and the on-disk
+        archive actually exists.
+        """
         from hestai_context_mcp.tools.clock_out import clock_out
+
+        # Seed a small transcript so the archive/redaction branch runs.
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(
+            json.dumps({"role": "user", "content": "hi"}) + "\n",
+            encoding="utf-8",
+        )
 
         # No identity configured -> publish is skipped, but archive flow runs.
         sid = "session-localonly"
-        _write_session(tmp_path, sid, role="impl", focus="task")
+        active = tmp_path / ".hestai" / "state" / "sessions" / "active" / sid
+        active.mkdir(parents=True, exist_ok=True)
+        session_data: dict[str, Any] = {
+            "session_id": sid,
+            "role": "impl",
+            "focus": "task",
+            "branch": "main",
+            "transcript_path": str(transcript),
+            "created_at": "2026-04-26T00:00:00+00:00",
+        }
+        (active / "session.json").write_text(json.dumps(session_data))
 
         result = clock_out(session_id=sid, working_dir=str(tmp_path))
 
         assert result["status"] == "success"
+        # Archive branch genuinely ran: archive_path is non-null and the file exists.
+        assert result["archive_path"] is not None
+        assert Path(result["archive_path"]).exists()
         # Portable publication block exists and is structured even without identity.
         assert "portable_publication" in result
         assert "unpublished_memory_exists" in result
         assert isinstance(result["unpublished_memory_exists"], bool)
+        # Publication is skipped because no identity; archive succeeded
+        # independently per R7 (local archive separable from publish).
+        assert result["portable_publication"]["status"] == "failed"
+        assert result["portable_publication"]["artifact_id"] is None
 
 
 @pytest.mark.integration

--- a/tests/integration/test_clock_out_portable_publish.py
+++ b/tests/integration/test_clock_out_portable_publish.py
@@ -168,8 +168,10 @@ class TestClockOutArtifactBuild:
     ) -> None:
         """Published artifact parent_ids reference the snapshot's prior artifact ids."""
         import hashlib
+        from datetime import UTC, datetime
 
         from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
         from hestai_context_mcp.storage.types import (
             ArtifactKind,
             ArtifactRef,
@@ -178,9 +180,7 @@ class TestClockOutArtifactBuild:
             PortableNamespace,
             WritePrecondition,
         )
-        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
         from hestai_context_mcp.tools.clock_out import clock_out
-        from datetime import UTC, datetime
 
         _write_identity_config(tmp_path)
 
@@ -236,9 +236,8 @@ class TestClockOutArtifactBuild:
         new_refs = [r for r in refs if r.artifact_id != "art-prior"]
         assert new_refs, "clock_out should have written at least one new artifact"
         new_artifact = adapter.read_artifact(new_refs[0])
-        from hestai_context_mcp.storage.types import PortableMemoryArtifact as PMA
 
-        assert isinstance(new_artifact, PMA)
+        assert isinstance(new_artifact, PortableMemoryArtifact)
         assert "art-prior" in new_artifact.parent_ids
 
 
@@ -246,9 +245,7 @@ class TestClockOutArtifactBuild:
 class TestClockOutPublishIntegration:
     """TEST_131 + TEST_132 + TEST_133."""
 
-    def test_clock_out_publishes_artifact_to_local_filesystem_adapter(
-        self, tmp_path: Path
-    ) -> None:
+    def test_clock_out_publishes_artifact_to_local_filesystem_adapter(self, tmp_path: Path) -> None:
         """Adapter gets exactly one publish call (no remote, no Git refs)."""
         from hestai_context_mcp.tools.clock_out import clock_out
 
@@ -347,18 +344,8 @@ class TestClockOutDuplicateIdempotent:
 
     def test_clock_out_duplicate_publish_is_idempotent_same_hash(self, tmp_path: Path) -> None:
         """Re-publishing the same payload hash returns DUPLICATE not FAILED."""
-        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
-        from hestai_context_mcp.storage.types import (
-            ArtifactKind,
-            ArtifactRef,
-            IdentityTuple,
-            PortableMemoryArtifact,
-            WritePrecondition,
-        )
-        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+
         from hestai_context_mcp.tools.clock_out import clock_out
-        from datetime import UTC, datetime
-        import hashlib
 
         _write_identity_config(tmp_path)
         sid = _clock_in_then_session(tmp_path)

--- a/tests/integration/test_clock_out_rework_redaction_failclose.py
+++ b/tests/integration/test_clock_out_rework_redaction_failclose.py
@@ -126,12 +126,12 @@ class TestRedactionFailureBlocksPublish:
 
         # The response MUST carry a structured failure for portable_publication.
         publication = result["portable_publication"]
-        assert publication["status"] == "failed", (
-            f"redaction failure must fail-closed for publish, got {publication}"
-        )
-        assert publication["error_code"] == "redaction_failure", (
-            f"expected error_code='redaction_failure', got {publication['error_code']!r}"
-        )
+        assert (
+            publication["status"] == "failed"
+        ), f"redaction failure must fail-closed for publish, got {publication}"
+        assert (
+            publication["error_code"] == "redaction_failure"
+        ), f"expected error_code='redaction_failure', got {publication['error_code']!r}"
 
         # No PortableMemoryArtifact JSON file written anywhere under portable artifacts.
         portable = tmp_path / ".hestai" / "state" / "portable"
@@ -152,9 +152,7 @@ class TestRedactionFailureBlocksPublish:
         # Archive path MUST be null (redaction failed -> no archive).
         assert result["archive_path"] is None
 
-    def test_redaction_engine_raise_writes_outbox_status_record(
-        self, tmp_path: Path
-    ) -> None:
+    def test_redaction_engine_raise_writes_outbox_status_record(self, tmp_path: Path) -> None:
         """A2 second-order concern: skip must leave a durable on-disk audit.
 
         After GREEN: an outbox status entry with reason_code='redaction_failure'
@@ -188,9 +186,9 @@ class TestRedactionFailureBlocksPublish:
             if payload.get("error_code") == "redaction_failure":
                 matched = True
                 # session-id linkage so operators can correlate.
-                assert sid in entry.name or sid in str(payload), (
-                    f"outbox entry must reference session_id {sid!r}: {payload}"
-                )
+                assert sid in entry.name or sid in str(
+                    payload
+                ), f"outbox entry must reference session_id {sid!r}: {payload}"
                 break
         assert matched, (
             f"no outbox entry with error_code='redaction_failure' "
@@ -227,9 +225,9 @@ class TestRedactionFailureBlocksPublish:
 
         # The response payload (anywhere) must not contain the TESTONLY marker.
         rendered = json.dumps(result, default=str)
-        assert "TESTONLY" not in rendered, (
-            "unredacted TESTONLY secret leaked into clock_out response"
-        )
+        assert (
+            "TESTONLY" not in rendered
+        ), "unredacted TESTONLY secret leaked into clock_out response"
 
         # And no PortableMemoryArtifact JSON written.
         portable = tmp_path / ".hestai" / "state" / "portable"
@@ -238,9 +236,9 @@ class TestRedactionFailureBlocksPublish:
                 if "/outbox/" in str(p) or "/snapshots/" in str(p) or p.name == "identity.json":
                     continue
                 content = p.read_text(encoding="utf-8")
-                assert "TESTONLY" not in content, (
-                    f"unredacted secret leaked into on-disk artifact at {p}"
-                )
+                assert (
+                    "TESTONLY" not in content
+                ), f"unredacted secret leaked into on-disk artifact at {p}"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_clock_out_rework_redaction_failclose.py
+++ b/tests/integration/test_clock_out_rework_redaction_failclose.py
@@ -1,0 +1,314 @@
+"""GROUP_016 — REWORK CYCLE RED tests for RISK_010 fail-closed publish.
+
+Asserts the binding ruling from CE NO-GO + CRS CONDITIONAL on B1 ADR-0013:
+when ``RedactionEngine.copy_and_redact`` raises (or otherwise fails), the
+clock_out tool MUST fail-closed:
+
+- NO ``PortableMemoryArtifact`` is written to the LocalFilesystemAdapter
+  (no on-disk file under ``portable/.../artifacts/``).
+- The response carries a structured ``portable_publication.error_code``
+  that names the redaction failure class.
+- A durable outbox status record is written with the redaction-failure
+  reason code, so the skip is auditable on disk (A2 second-order
+  concern + PROD::I1 lifecycle integrity).
+- The published artifact response MUST NOT carry an ``input_artifact_hash``
+  equal to its ``output_artifact_hash`` for non-empty inputs (RISK_010
+  provenance integrity: input_text and output_text must be independently
+  derived). The fallback "same source" pattern that the original
+  implementation used is forbidden.
+
+These tests reproduce the CE-cited scenario that returned NO-GO in
+Stage C: patched RedactionEngine.copy_and_redact raises -> clock_out
+returned status=published with archive_path=null and an unredacted
+"TESTONLY" secret in decisions. After the rework GREEN fix, each test
+below MUST pass empirically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(_identity_dict()))
+
+
+def _seed_session_with_transcript(working_dir: Path, session_id: str) -> Path:
+    """Seed an active session whose session.json points at a real transcript.
+
+    The transcript contains a TESTONLY secret-like marker so any leak in the
+    published artifact is unambiguously detectable. This is the CE-cited
+    reproducer scenario.
+    """
+
+    active = working_dir / ".hestai" / "state" / "sessions" / "active" / session_id
+    active.mkdir(parents=True, exist_ok=True)
+
+    transcript = working_dir / "transcript.jsonl"
+    # Use a 'TESTONLY' marker plus a sk- shaped string so an unredacted leak
+    # is detectable both as a literal substring and via a redaction pattern.
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "DECISION: keep TESTONLY-secret-sk-"
+                                "AAAAAAAAAAAAAAAAAAAA out of archives"
+                            ),
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n"
+    )
+
+    session_data = {
+        "session_id": session_id,
+        "role": "impl",
+        "focus": "rework",
+        "branch": "main",
+        "transcript_path": str(transcript),
+        "created_at": "2026-04-26T00:00:00+00:00",
+    }
+    (active / "session.json").write_text(json.dumps(session_data))
+    return active
+
+
+@pytest.mark.integration
+class TestRedactionFailureBlocksPublish:
+    """BLOCKER 1 / RISK_010: redaction failure must fail-closed for publish."""
+
+    def test_redaction_engine_raise_blocks_publish_no_artifact_written(
+        self, tmp_path: Path
+    ) -> None:
+        """CE-cited reproducer: patched RedactionEngine raises -> no publish.
+
+        After GREEN: clock_out must NOT publish a PortableMemoryArtifact when
+        the redaction engine fails. No JSON file under portable artifacts.
+        """
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = "session-redaction-failure"
+        _seed_session_with_transcript(tmp_path, sid)
+
+        def _raise(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("simulated redaction engine failure")
+
+        with patch(
+            "hestai_context_mcp.tools.clock_out.RedactionEngine.copy_and_redact",
+            side_effect=_raise,
+        ):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # The response MUST carry a structured failure for portable_publication.
+        publication = result["portable_publication"]
+        assert publication["status"] == "failed", (
+            f"redaction failure must fail-closed for publish, got {publication}"
+        )
+        assert publication["error_code"] == "redaction_failure", (
+            f"expected error_code='redaction_failure', got {publication['error_code']!r}"
+        )
+
+        # No PortableMemoryArtifact JSON file written anywhere under portable artifacts.
+        portable = tmp_path / ".hestai" / "state" / "portable"
+        artifact_files: list[Path] = []
+        if portable.exists():
+            for p in portable.rglob("*.json"):
+                # Outbox entries and identity.json are allowed; reject artifact files only.
+                if "/outbox/" in str(p) or p.name == "identity.json":
+                    continue
+                if "/snapshots/" in str(p):
+                    continue
+                artifact_files.append(p)
+        assert artifact_files == [], (
+            "redaction failure must NOT leave a PortableMemoryArtifact on disk; "
+            f"found: {artifact_files}"
+        )
+
+        # Archive path MUST be null (redaction failed -> no archive).
+        assert result["archive_path"] is None
+
+    def test_redaction_engine_raise_writes_outbox_status_record(
+        self, tmp_path: Path
+    ) -> None:
+        """A2 second-order concern: skip must leave a durable on-disk audit.
+
+        After GREEN: an outbox status entry with reason_code='redaction_failure'
+        exists under .hestai/state/portable/outbox/ for the session.
+        """
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = "session-redaction-failure-outbox"
+        _seed_session_with_transcript(tmp_path, sid)
+
+        def _raise(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("simulated redaction engine failure")
+
+        with patch(
+            "hestai_context_mcp.tools.clock_out.RedactionEngine.copy_and_redact",
+            side_effect=_raise,
+        ):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        outbox = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        assert outbox.exists(), "outbox dir must be created on structured skip"
+        entries = list(outbox.glob("*.json"))
+        assert entries, "outbox must contain a status record after redaction failure"
+
+        # The outbox entry must name the reason and the session.
+        matched = False
+        for entry in entries:
+            payload = json.loads(entry.read_text(encoding="utf-8"))
+            if payload.get("error_code") == "redaction_failure":
+                matched = True
+                # session-id linkage so operators can correlate.
+                assert sid in entry.name or sid in str(payload), (
+                    f"outbox entry must reference session_id {sid!r}: {payload}"
+                )
+                break
+        assert matched, (
+            f"no outbox entry with error_code='redaction_failure' "
+            f"in {[e.name for e in entries]}"
+        )
+
+        # unpublished_memory_exists reflects the durable skip.
+        assert result["unpublished_memory_exists"] is True
+
+    def test_redaction_failure_does_not_leak_unredacted_secret_in_response(
+        self, tmp_path: Path
+    ) -> None:
+        """RISK_010: even on failure, no unredacted secret can appear anywhere.
+
+        After GREEN: response is structured-fail with no transcript content
+        carried through; archive_path is null; no published artifact carries
+        the TESTONLY marker (the entire publish path is blocked).
+        """
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = "session-no-leak"
+        _seed_session_with_transcript(tmp_path, sid)
+
+        def _raise(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("simulated redaction engine failure")
+
+        with patch(
+            "hestai_context_mcp.tools.clock_out.RedactionEngine.copy_and_redact",
+            side_effect=_raise,
+        ):
+            result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # The response payload (anywhere) must not contain the TESTONLY marker.
+        rendered = json.dumps(result, default=str)
+        assert "TESTONLY" not in rendered, (
+            "unredacted TESTONLY secret leaked into clock_out response"
+        )
+
+        # And no PortableMemoryArtifact JSON written.
+        portable = tmp_path / ".hestai" / "state" / "portable"
+        if portable.exists():
+            for p in portable.rglob("*.json"):
+                if "/outbox/" in str(p) or "/snapshots/" in str(p) or p.name == "identity.json":
+                    continue
+                content = p.read_text(encoding="utf-8")
+                assert "TESTONLY" not in content, (
+                    f"unredacted secret leaked into on-disk artifact at {p}"
+                )
+
+
+@pytest.mark.integration
+class TestProvenanceIntegritySameSourceForbidden:
+    """BLOCKER 1 second test gap: input_text == output_text must fail-closed."""
+
+    def test_provenance_with_identical_input_and_output_for_nonempty_payload_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """RISK_010: provenance integrity check.
+
+        After GREEN: when there is no transcript, clock_out must NOT use
+        ``payload_canonical`` as both input_text and output_text — that
+        produces equal input/output hashes which is a structural forgery
+        (no actual redaction was performed). Either skip publish with a
+        structured reason, or use a deterministic empty-input constant
+        distinct from the output.
+        """
+
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import IdentityTuple, PortableNamespace
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        _write_identity_config(tmp_path)
+        sid = "session-no-transcript-provenance"
+        # Seed session WITHOUT a transcript_path so the no-transcript path
+        # is exercised. This is the legitimate "no transcript" case.
+        active = tmp_path / ".hestai" / "state" / "sessions" / "active" / sid
+        active.mkdir(parents=True, exist_ok=True)
+        (active / "session.json").write_text(
+            json.dumps(
+                {
+                    "session_id": sid,
+                    "role": "impl",
+                    "focus": "rework",
+                    "branch": "main",
+                    "transcript_path": None,
+                    "created_at": "2026-04-26T00:00:00+00:00",
+                }
+            )
+        )
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # If publish proceeded, read back any artifact and assert provenance
+        # integrity (input_artifact_hash != output_artifact_hash).
+        identity = IdentityTuple(**_identity_dict())
+        ns = PortableNamespace(
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            user_id=identity.user_id,
+            state_schema_version=identity.state_schema_version,
+            carrier_namespace=identity.carrier_namespace,
+        )
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        refs = adapter.list_artifacts(ns)
+        for ref in refs:
+            artifact = adapter.read_artifact(ref)
+            # Only PortableMemoryArtifact carries redaction_provenance.
+            from hestai_context_mcp.storage.types import PortableMemoryArtifact
+
+            if isinstance(artifact, PortableMemoryArtifact):
+                p = artifact.redaction_provenance
+                assert p.input_artifact_hash != p.output_artifact_hash, (
+                    "RISK_010 provenance integrity: input_artifact_hash MUST NOT "
+                    "equal output_artifact_hash for non-empty payloads (the original "
+                    "fallback that used payload_canonical for both inputs is forbidden); "
+                    f"input={p.input_artifact_hash!r} output={p.output_artifact_hash!r}"
+                )
+        # Either way, the response must carry a defined structured publication block.
+        assert "portable_publication" in result

--- a/tests/integration/test_clock_out_rework_skip_outbox.py
+++ b/tests/integration/test_clock_out_rework_skip_outbox.py
@@ -1,0 +1,157 @@
+"""GROUP_018 — REWORK CYCLE RED tests for ADDITIONAL CONCERN 1.
+
+Asserts the binding A2 second-order concern from CE Stage C: when
+clock_out hits a fail-closed identity skip path (per RISK_001), a
+durable outbox status record MUST be written to disk so the skip is
+auditable, not just surfaced in the response.
+
+Per the rework directive::
+
+    when clock_out skips publish for any structured reason
+    (no_identity_configured, redaction_failure, provenance_incomplete),
+    write an outbox status record with reason_code field at
+    .hestai/state/portable/outbox/{session_id}-{reason_code}.json
+
+This test asserts the file exists after the no_identity_configured skip.
+The redaction_failure case is covered by the BLOCKER 1 paired tests in
+``test_clock_out_rework_redaction_failclose.py``; this file focuses on
+the identity-skip case so the audit trail is observable independently
+in commit history (ADDITIONAL CONCERN 1 has its own RED+GREEN pair per
+the rework COMMIT POLICY).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _write_session(working_dir: Path, session_id: str) -> Path:
+    """Seed an active session directory for clock_out without identity."""
+
+    active = working_dir / ".hestai" / "state" / "sessions" / "active" / session_id
+    active.mkdir(parents=True, exist_ok=True)
+    (active / "session.json").write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "role": "impl",
+                "focus": "rework",
+                "branch": "main",
+                "transcript_path": None,
+                "created_at": "2026-04-26T00:00:00+00:00",
+            }
+        )
+    )
+    return active
+
+
+@pytest.mark.integration
+class TestNoIdentityConfiguredOutboxStatusRecord:
+    """ADDITIONAL CONCERN 1: skip must leave durable on-disk audit."""
+
+    def test_no_identity_configured_skip_writes_outbox_status_record(
+        self, tmp_path: Path
+    ) -> None:
+        """A2 + PROD::I1: identity-skip writes durable outbox record.
+
+        After GREEN: a file exists at
+        ``.hestai/state/portable/outbox/{session_id}-no_identity_configured.json``
+        when clock_out skips publish because identity is unconfigured.
+        """
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        sid = "session-no-identity-skip"
+        _write_session(tmp_path, sid)
+
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # Response surface confirms the structured skip reason.
+        publication = result["portable_publication"]
+        assert publication["status"] == "failed"
+        assert publication["error_code"] == "no_identity_configured"
+
+        # Durable on-disk audit: skip-status record under the outbox.
+        outbox = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        assert outbox.exists(), "outbox directory must be created on structured skip"
+        expected = outbox / f"{sid}-no_identity_configured.json"
+        assert expected.exists(), (
+            f"expected skip-status file at {expected} (ADDITIONAL CONCERN 1: "
+            "every structured skip must leave a durable on-disk record); "
+            f"actual entries: {[p.name for p in outbox.iterdir()]}"
+        )
+        record = json.loads(expected.read_text(encoding="utf-8"))
+        assert record["session_id"] == sid
+        assert record["error_code"] == "no_identity_configured"
+        assert record["kind"] == "skip_status"
+        assert "recorded_at" in record
+
+        # And unpublished_memory_exists reflects the durable skip.
+        assert result["unpublished_memory_exists"] is True
+
+    def test_no_identity_configured_skip_outbox_record_is_idempotent_on_repeated_clock_out(
+        self, tmp_path: Path
+    ) -> None:
+        """Repeated skip with same session+reason must not corrupt the record."""
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        sid = "session-no-identity-idempotent"
+        _write_session(tmp_path, sid)
+        clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        # Second call (re-create session because clock_out removed it).
+        _write_session(tmp_path, sid)
+        result = clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        outbox = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        expected = outbox / f"{sid}-no_identity_configured.json"
+        assert expected.exists()
+
+        # Record is well-formed JSON (overwriting, not corrupting).
+        record = json.loads(expected.read_text(encoding="utf-8"))
+        assert record["session_id"] == sid
+        assert record["error_code"] == "no_identity_configured"
+
+        # Response is consistent.
+        publication = result["portable_publication"]
+        assert publication["status"] == "failed"
+        assert publication["error_code"] == "no_identity_configured"
+
+
+@pytest.mark.integration
+class TestSkipReasonCodeFileNamingConvention:
+    """Naming convention guard: {session_id}-{reason_code}.json under outbox/."""
+
+    def test_skip_status_file_name_is_session_id_dash_reason_code(
+        self, tmp_path: Path
+    ) -> None:
+        """The on-disk filename follows {session_id}-{reason_code}.json (CE rework)."""
+
+        from hestai_context_mcp.tools.clock_out import clock_out
+
+        sid = "session-naming-convention"
+        _write_session(tmp_path, sid)
+        clock_out(session_id=sid, working_dir=str(tmp_path))
+
+        outbox = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        skip_records: list[Any] = list(outbox.glob(f"{sid}-*.json"))
+        assert skip_records, f"no skip-status records for session {sid} under {outbox}"
+        for path in skip_records:
+            stem = path.stem  # e.g. "session-naming-convention-no_identity_configured"
+            assert stem.startswith(f"{sid}-"), (
+                f"skip-status filename {path.name!r} must start with "
+                f"'{sid}-' for operator correlation"
+            )
+            reason_code = stem[len(sid) + 1 :]
+            assert reason_code, "reason_code segment must be non-empty"
+            # The on-disk record echoes the reason_code in its 'error_code' field.
+            record = json.loads(path.read_text(encoding="utf-8"))
+            assert record["error_code"] == reason_code, (
+                f"filename reason_code {reason_code!r} must match record "
+                f"error_code {record['error_code']!r}"
+            )

--- a/tests/integration/test_clock_out_rework_skip_outbox.py
+++ b/tests/integration/test_clock_out_rework_skip_outbox.py
@@ -53,9 +53,7 @@ def _write_session(working_dir: Path, session_id: str) -> Path:
 class TestNoIdentityConfiguredOutboxStatusRecord:
     """ADDITIONAL CONCERN 1: skip must leave durable on-disk audit."""
 
-    def test_no_identity_configured_skip_writes_outbox_status_record(
-        self, tmp_path: Path
-    ) -> None:
+    def test_no_identity_configured_skip_writes_outbox_status_record(self, tmp_path: Path) -> None:
         """A2 + PROD::I1: identity-skip writes durable outbox record.
 
         After GREEN: a file exists at
@@ -127,9 +125,7 @@ class TestNoIdentityConfiguredOutboxStatusRecord:
 class TestSkipReasonCodeFileNamingConvention:
     """Naming convention guard: {session_id}-{reason_code}.json under outbox/."""
 
-    def test_skip_status_file_name_is_session_id_dash_reason_code(
-        self, tmp_path: Path
-    ) -> None:
+    def test_skip_status_file_name_is_session_id_dash_reason_code(self, tmp_path: Path) -> None:
         """The on-disk filename follows {session_id}-{reason_code}.json (CE rework)."""
 
         from hestai_context_mcp.tools.clock_out import clock_out

--- a/tests/integration/test_get_context_purity.py
+++ b/tests/integration/test_get_context_purity.py
@@ -1,0 +1,300 @@
+"""GROUP_013: GET_CONTEXT_PURITY — RED-first tests.
+
+Asserts that ``get_context`` remains a pure read per BUILD-PLAN
+§INTEGRATION_PLAN GET_CONTEXT_EDIT_PLAN and §TDD_TEST_LIST GROUP_013
+(TEST_139..TEST_148).
+
+Binding rulings exercised here:
+
+- OPTION_C: ``get_context(working_dir: str)`` signature is unchanged.
+- G3: source-level guard — no ``StorageAdapter`` or
+  ``LocalFilesystemAdapter`` symbols appear inside ``get_context.py``.
+- INVARIANT_001 (R10): filesystem snapshot diff is empty before and
+  after ``get_context``.
+- R5 + R10: snapshot mtime is unchanged across calls; outbox files
+  are not drained / created.
+- R7: ``get_context`` never publishes or restores; that boundary is
+  owned by clock_in / clock_out exclusively.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GET_CONTEXT_PATH = _REPO_ROOT / "src" / "hestai_context_mcp" / "tools" / "get_context.py"
+
+
+def _snapshot_fs(root: Path) -> dict[str, tuple[float, int]]:
+    """Take a (mtime_ns, size) snapshot of every regular file under ``root``."""
+    out: dict[str, tuple[float, int]] = {}
+    if not root.exists():
+        return out
+    for path in root.rglob("*"):
+        if path.is_file():
+            stat = path.stat()
+            out[str(path.relative_to(root))] = (stat.st_mtime_ns, stat.st_size)
+    return out
+
+
+@pytest.mark.integration
+class TestGetContextSignatureContract:
+    """TEST_140 + TEST_141 + TEST_145 — OPTION_C guard."""
+
+    def test_get_context_signature_is_option_c(self) -> None:
+        """OPTION_C: signature is exactly ``get_context(working_dir: str)``."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        sig = inspect.signature(get_context)
+        params = list(sig.parameters)
+        assert params == [
+            "working_dir"
+        ], f"OPTION_C requires get_context(working_dir: str); got {params}"
+        wd_param = sig.parameters["working_dir"]
+        assert (
+            wd_param.annotation is str
+        ), f"working_dir must be annotated str; got {wd_param.annotation}"
+
+    def test_get_context_does_not_import_storage_adapter_protocol(self) -> None:
+        """G3: ``StorageAdapter`` symbol is absent from get_context.py source."""
+        source = _GET_CONTEXT_PATH.read_text(encoding="utf-8")
+        assert (
+            "StorageAdapter" not in source
+        ), "G3 violation: 'StorageAdapter' must not appear in get_context.py"
+
+    def test_get_context_does_not_import_local_filesystem_adapter(self) -> None:
+        """G3: ``LocalFilesystemAdapter`` symbol is absent from get_context.py."""
+        source = _GET_CONTEXT_PATH.read_text(encoding="utf-8")
+        assert (
+            "LocalFilesystemAdapter" not in source
+        ), "G3 violation: 'LocalFilesystemAdapter' must not appear in get_context.py"
+
+    def test_get_context_visible_return_shape_remains_backward_compatible(
+        self, tmp_path: Path
+    ) -> None:
+        """The response top-level keys remain {working_dir, context}."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        result = get_context(working_dir=str(tmp_path))
+        assert set(result.keys()) >= {"working_dir", "context"}
+        ctx = result["context"]
+        assert {
+            "product_north_star",
+            "project_context",
+            "phase_constraints",
+            "git_state",
+            "active_sessions",
+        } <= set(ctx.keys())
+
+
+@pytest.mark.integration
+class TestGetContextFilesystemPurity:
+    """TEST_139 + TEST_142 — INVARIANT_001."""
+
+    def test_get_context_filesystem_snapshot_diff_empty_before_after(self, tmp_path: Path) -> None:
+        """R10 INVARIANT_001: fs snapshot diff is empty across get_context."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        # Pre-seed an existing state directory so we have files to diff
+        # against; get_context must touch nothing.
+        state_dir = tmp_path / ".hestai" / "state" / "context"
+        state_dir.mkdir(parents=True)
+        (state_dir / "PROJECT-CONTEXT.oct.md").write_text("seed\n")
+
+        before = _snapshot_fs(tmp_path)
+        get_context(working_dir=str(tmp_path))
+        after = _snapshot_fs(tmp_path)
+
+        # Diff: any added, removed, or mtime-changed entry is a violation.
+        added = set(after) - set(before)
+        removed = set(before) - set(after)
+        assert not added, f"get_context created files: {sorted(added)}"
+        assert not removed, f"get_context removed files: {sorted(removed)}"
+        for k in before:
+            assert before[k] == after[k], f"get_context mutated {k}: {before[k]} -> {after[k]}"
+
+    def test_get_context_does_not_create_portable_directories(self, tmp_path: Path) -> None:
+        """R10: get_context never creates portable/{outbox,snapshots,artifacts}."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        get_context(working_dir=str(tmp_path))
+
+        portable = tmp_path / ".hestai" / "state" / "portable"
+        # The portable subtree must not be created by get_context.
+        assert not (portable / "outbox").exists()
+        assert not (portable / "snapshots").exists()
+        assert not (portable / "artifacts").exists()
+
+
+@pytest.mark.integration
+class TestGetContextSnapshotStability:
+    """TEST_143 + TEST_144 — R5 + R7 + INVARIANT_001."""
+
+    def test_get_context_does_not_modify_snapshot_mtime(self, tmp_path: Path) -> None:
+        """G3 + R5: a pre-existing snapshot's mtime is not changed by get_context."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        snap_dir = tmp_path / ".hestai" / "state" / "portable" / "snapshots" / "sess-1"
+        snap_dir.mkdir(parents=True)
+        proj = snap_dir / "context-projection.json"
+        meta = snap_dir / "metadata.json"
+        proj.write_text("{}")
+        meta.write_text("{}")
+
+        # Set a known mtime in the past so any touch is detectable.
+        past = 1_700_000_000
+        os.utime(proj, (past, past))
+        os.utime(meta, (past, past))
+
+        before_proj = proj.stat().st_mtime
+        before_meta = meta.stat().st_mtime
+
+        get_context(working_dir=str(tmp_path))
+
+        assert (
+            proj.stat().st_mtime == before_proj
+        ), "get_context modified context-projection.json mtime"
+        assert meta.stat().st_mtime == before_meta, "get_context modified metadata.json mtime"
+
+    def test_get_context_does_not_drain_outbox(self, tmp_path: Path) -> None:
+        """R7 + G3: outbox entries are not consumed/created by get_context."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        outbox_dir = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        outbox_dir.mkdir(parents=True)
+        entry = outbox_dir / "art-1.json"
+        entry.write_text(json.dumps({"artifact_id": "art-1", "status": "failed"}))
+        before = list(outbox_dir.iterdir())
+
+        get_context(working_dir=str(tmp_path))
+
+        after = list(outbox_dir.iterdir())
+        # No file added, none removed.
+        assert {p.name for p in before} == {p.name for p in after}
+        # Content unchanged.
+        assert entry.read_text() == json.dumps({"artifact_id": "art-1", "status": "failed"})
+
+
+@pytest.mark.integration
+class TestGetContextSnapshotRead:
+    """TEST_146 + TEST_147 + TEST_148 — local-only behavior."""
+
+    def test_get_context_reads_local_snapshot_when_available(self, tmp_path: Path) -> None:
+        """When a snapshot exists, get_context reads only the local projection.
+
+        OPTION_C: signature unchanged. The 'reads local snapshot' contract
+        is delegate-friendly: get_context's response remains the same
+        shape; this test only verifies that the call does not raise when
+        a snapshot is present and that the response shape stays intact.
+        """
+        from hestai_context_mcp.tools.get_context import get_context
+
+        snap_dir = tmp_path / ".hestai" / "state" / "portable" / "snapshots" / "sess-x"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "context-projection.json").write_text(
+            json.dumps({"identity": {}, "tombstoned_artifact_ids": [], "artifact_refs": []})
+        )
+        (snap_dir / "metadata.json").write_text(json.dumps({"session_id": "sess-x"}))
+
+        result = get_context(working_dir=str(tmp_path))
+        assert "context" in result
+        # The response must not surface restoration as having happened
+        # (TEST_148): no "restore_status" / "portable_state" keys leak in.
+        assert "portable_state" not in result
+        assert "restore_status" not in result
+
+    def test_get_context_without_snapshot_falls_back_to_existing_local_projection(
+        self, tmp_path: Path
+    ) -> None:
+        """Behavior when no snapshot is present: existing PROJECT-CONTEXT path."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        ctx_dir = tmp_path / ".hestai" / "state" / "context"
+        ctx_dir.mkdir(parents=True)
+        (ctx_dir / "PROJECT-CONTEXT.oct.md").write_text("local-projection-only\n")
+
+        result = get_context(working_dir=str(tmp_path))
+        assert "context" in result
+        # project_context surfaced; no portable_state in response.
+        assert "portable_state" not in result
+
+    def test_get_context_never_reports_hydration_as_successful(self, tmp_path: Path) -> None:
+        """TEST_148: get_context never surfaces hydration as happening from itself."""
+        from hestai_context_mcp.tools.get_context import get_context
+
+        snap_dir = tmp_path / ".hestai" / "state" / "portable" / "snapshots" / "sess-y"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "context-projection.json").write_text(
+            json.dumps({"identity": {}, "tombstoned_artifact_ids": [], "artifact_refs": []})
+        )
+        (snap_dir / "metadata.json").write_text(json.dumps({"session_id": "sess-y"}))
+
+        result = get_context(working_dir=str(tmp_path))
+        # Forbidden keys: anything that suggests hydration semantics.
+        forbidden = {"portable_state", "restore_status", "hydrated", "restored_artifacts"}
+        assert not (forbidden & set(result.keys()))
+        # And no restore_status key buried under context either.
+        assert "restore_status" not in result.get("context", {})
+
+
+@pytest.mark.integration
+class TestGetContextSourceLevelGuard:
+    """G3 source guard — independent of behavior."""
+
+    def test_get_context_module_has_no_storage_adapter_imports(self) -> None:
+        """Source AST: no ``from hestai_context_mcp.storage.local_filesystem`` etc."""
+        source = _GET_CONTEXT_PATH.read_text(encoding="utf-8")
+        forbidden_imports = (
+            r"from\s+hestai_context_mcp\.storage\.local_filesystem",
+            r"from\s+hestai_context_mcp\.storage\.outbox",
+            r"from\s+hestai_context_mcp\.storage\.protocol",
+            r"import\s+hestai_context_mcp\.storage\.local_filesystem",
+        )
+        for pattern in forbidden_imports:
+            assert not re.search(
+                pattern, source
+            ), f"G3 violation: get_context.py must not match /{pattern}/"
+
+    def test_get_context_module_does_not_reference_adapter_symbols(self) -> None:
+        """Belt-and-braces: forbidden symbol names are absent."""
+        source = _GET_CONTEXT_PATH.read_text(encoding="utf-8")
+        for symbol in ("StorageAdapter", "LocalFilesystemAdapter", "OutboxStore"):
+            assert (
+                symbol not in source
+            ), f"G3 violation: '{symbol}' must not appear in get_context.py"
+
+    def test_get_context_module_carries_explicit_purity_marker(self) -> None:
+        """G3: get_context.py must carry an explicit PURITY_GUARD marker.
+
+        The marker is a load-bearing comment + docstring contract. Future
+        modifications can grep for it before adding any storage import.
+        Per CE RISK_003 OPTION_C: get_context has zero side effects and
+        its session-bound snapshot is exposed only via
+        ``clock_in.portable_state.snapshot``. The marker MUST cite both
+        rulings so any reader of the file knows why imports are forbidden.
+        """
+        source = _GET_CONTEXT_PATH.read_text(encoding="utf-8")
+        # Single explicit marker comment that cites the binding rulings.
+        assert "PURITY_GUARD::G3" in source, (
+            "G3 violation: get_context.py must carry an explicit "
+            "'PURITY_GUARD::G3' marker citing CE RISK_003 OPTION_C."
+        )
+        # The marker must also reference OPTION_C so the tie-back to the
+        # arbitration record is unambiguous.
+        assert "OPTION_C" in source, (
+            "G3 violation: get_context.py must reference 'OPTION_C' so the "
+            "binding ruling that forbids signature/behavior change is "
+            "discoverable in-source."
+        )
+
+
+# Sanity helper kept inline so the file is self-contained.
+def _ensure_no_response_key(result: dict[str, Any], key: str) -> None:
+    assert key not in result, f"response must not contain key {key!r}"

--- a/tests/integration/test_get_context_purity.py
+++ b/tests/integration/test_get_context_purity.py
@@ -121,16 +121,17 @@ class TestGetContextFilesystemPurity:
             assert before[k] == after[k], f"get_context mutated {k}: {before[k]} -> {after[k]}"
 
     def test_get_context_does_not_create_portable_directories(self, tmp_path: Path) -> None:
-        """R10: get_context never creates portable/{outbox,snapshots,artifacts}."""
+        """R10: get_context never creates portable/{outbox,snapshots,pss}."""
         from hestai_context_mcp.tools.get_context import get_context
 
         get_context(working_dir=str(tmp_path))
 
         portable = tmp_path / ".hestai" / "state" / "portable"
         # The portable subtree must not be created by get_context.
+        # CE rework RISK_006: artifacts now live under portable/pss/.
         assert not (portable / "outbox").exists()
         assert not (portable / "snapshots").exists()
-        assert not (portable / "artifacts").exists()
+        assert not (portable / "pss").exists()
 
 
 @pytest.mark.integration

--- a/tests/integration/test_pss_lifecycle_local_filesystem.py
+++ b/tests/integration/test_pss_lifecycle_local_filesystem.py
@@ -1,0 +1,494 @@
+"""GROUP_014: FULL_LOCAL_LIFECYCLE — RED-first tests.
+
+End-to-end PSS lifecycle over LocalFilesystemAdapter only:
+
+  clock_in -> publish via clock_out -> next clock_in restores ->
+  tombstone roundtrip -> projection deterministic -> session cleanup
+  works while publish is queued.
+
+Per BUILD-PLAN §TDD_TEST_LIST GROUP_014 (TEST_149..TEST_158) and
+§INTEGRATION_PLAN. Binding rulings exercised:
+
+- R5: clock_in restores via adapter and writes a named snapshot.
+- R7: clock_out has separable outcomes (local archive vs publish).
+- R8: tombstones exclude memory on next clock_in.
+- R9: append-first monotonic order; same-id same-hash idempotent.
+- R10 INVARIANT_002: full suite passes with remote adapters disabled.
+  (We assert no remote adapter imports or hits during lifecycle.)
+- R11: no custom Git refs are used.
+- R12: no remote adapter / network behavior.
+- B2_START_BLOCKER_003: no remote adapters / config / wire schemas.
+- B2_START_BLOCKER_004: never publish without provenance pair.
+- B2_START_BLOCKER_005: no custom Git refs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _identity_dict() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+def _write_identity_config(working_dir: Path, *, override: dict[str, Any] | None = None) -> None:
+    cfg_path = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(override or _identity_dict()))
+
+
+def _do_clock_in(working_dir: Path) -> str:
+    from hestai_context_mcp.tools.clock_in import clock_in
+
+    with patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"):
+        result = clock_in(role="impl", working_dir=str(working_dir), focus="task")
+    return result["session_id"]
+
+
+def _do_clock_out(working_dir: Path, session_id: str) -> dict[str, Any]:
+    from hestai_context_mcp.tools.clock_out import clock_out
+
+    return clock_out(session_id=session_id, working_dir=str(working_dir))
+
+
+def _seed_artifact(working_dir: Path, *, artifact_id: str, sequence_id: int) -> None:
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        PortableMemoryArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    payload = {"id": artifact_id, "seq": sequence_id}
+    payload_hash = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    artifact = PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=build_provenance_or_raise(
+            input_text="i", output_text="o", redacted_credential_categories=()
+        ),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=payload_hash,
+        payload=payload,
+    )
+    ref = ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_artifact(
+        ref, artifact, WritePrecondition()
+    )
+
+
+def _seed_tombstone(working_dir: Path, *, target_artifact_id: str, sequence_id: int) -> None:
+    from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        IdentityTuple,
+        TombstoneArtifact,
+        WritePrecondition,
+    )
+
+    identity = IdentityTuple(**_identity_dict())
+    tomb = TombstoneArtifact(
+        artifact_id=f"tomb-{target_artifact_id}",
+        artifact_kind=ArtifactKind.TOMBSTONE,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(target_artifact_id,),
+        target_artifact_id=target_artifact_id,
+        reason="user-revoked",
+        publisher_identity=identity,
+        redaction_provenance=None,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=hashlib.sha256(target_artifact_id.encode()).hexdigest(),
+    )
+    ref = ArtifactRef(
+        artifact_id=tomb.artifact_id,
+        identity=tomb.identity,
+        artifact_kind=tomb.artifact_kind,
+        sequence_id=tomb.sequence_id,
+        created_at=tomb.created_at,
+        payload_hash=tomb.payload_hash,
+        carrier_path="",
+    )
+    LocalFilesystemAdapter(working_dir=working_dir).write_tombstone(ref, tomb, WritePrecondition())
+
+
+@pytest.mark.integration
+class TestEndToEndLocalLifecycle:
+    """TEST_149 + TEST_158."""
+
+    def test_clock_out_then_next_clock_in_restores_memory_from_local_adapter(
+        self, tmp_path: Path
+    ) -> None:
+        """clock_out publishes; subsequent clock_in restores it via the adapter."""
+        _write_identity_config(tmp_path)
+
+        sid1 = _do_clock_in(tmp_path)
+        result_out = _do_clock_out(tmp_path, sid1)
+        assert result_out["portable_publication"]["status"] in {"published", "duplicate"}
+        assert result_out["unpublished_memory_exists"] is False
+
+        # Next clock_in must see the published artifact via the adapter.
+        sid2 = _do_clock_in(tmp_path)
+        assert sid2 != sid1
+
+        # The session 2 named snapshot must include the published artifact.
+        from hestai_context_mcp.storage.snapshots import read_session_snapshot
+
+        snap = read_session_snapshot(working_dir=tmp_path, session_id=sid2)
+        refs = snap["metadata"]["artifact_refs"]
+        assert len(refs) >= 1, "second clock_in should restore the first session's publication"
+
+    def test_local_archive_and_session_cleanup_still_work_when_publish_queued(
+        self, tmp_path: Path
+    ) -> None:
+        """Adapter raise -> archive succeeded, session cleaned up, outbox queued."""
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        _write_identity_config(tmp_path)
+        sid = _do_clock_in(tmp_path)
+
+        def _raise(self: Any, *args: Any, **kwargs: Any) -> None:
+            raise OSError("queued path simulation")
+
+        with patch.object(LocalFilesystemAdapter, "write_artifact", _raise):
+            result = _do_clock_out(tmp_path, sid)
+
+        assert result["status"] == "success"  # archive succeeded
+        # session dir gone (cleanup ran)
+        assert not (tmp_path / ".hestai" / "state" / "sessions" / "active" / sid).exists()
+        # outbox has an entry
+        assert result["unpublished_memory_exists"] is True
+        outbox = tmp_path / ".hestai" / "state" / "portable" / "outbox"
+        assert outbox.exists()
+        assert any(p.suffix == ".json" for p in outbox.iterdir())
+
+
+@pytest.mark.integration
+class TestTombstoneLifecycle:
+    """TEST_150 + TEST_154."""
+
+    def test_tombstone_published_between_sessions_excludes_memory_on_next_clock_in(
+        self, tmp_path: Path
+    ) -> None:
+        """Tombstone -> next clock_in projection excludes the target."""
+        _write_identity_config(tmp_path)
+
+        # Seed an artifact, then tombstone it; next clock_in must exclude.
+        _seed_artifact(tmp_path, artifact_id="art-tomb-target", sequence_id=1)
+        _seed_tombstone(tmp_path, target_artifact_id="art-tomb-target", sequence_id=2)
+
+        sid = _do_clock_in(tmp_path)
+
+        from hestai_context_mcp.storage.snapshots import read_session_snapshot
+
+        snap = read_session_snapshot(working_dir=tmp_path, session_id=sid)
+        proj = snap["projection"]
+        assert "art-tomb-target" in proj["tombstoned_artifact_ids"]
+        # No artifact_refs entry survives.
+        ref_ids = {r["artifact_id"] for r in proj["artifact_refs"]}
+        assert "art-tomb-target" not in ref_ids
+
+    def test_restore_merges_valid_artifacts_by_identity_and_monotonic_order(
+        self, tmp_path: Path
+    ) -> None:
+        """Multiple artifacts merge in monotonic (sequence_id, artifact_id) order."""
+        _write_identity_config(tmp_path)
+
+        _seed_artifact(tmp_path, artifact_id="art-a", sequence_id=10)
+        _seed_artifact(tmp_path, artifact_id="art-b", sequence_id=5)
+        _seed_artifact(tmp_path, artifact_id="art-c", sequence_id=20)
+
+        sid = _do_clock_in(tmp_path)
+
+        from hestai_context_mcp.storage.snapshots import read_session_snapshot
+
+        snap = read_session_snapshot(working_dir=tmp_path, session_id=sid)
+        ordered = [
+            (r["sequence_id"], r["artifact_id"]) for r in snap["projection"]["artifact_refs"]
+        ]
+        assert ordered == sorted(ordered), "projection must be sorted by (seq, id)"
+
+
+@pytest.mark.integration
+class TestProjectionDeterminism:
+    """TEST_151 — INVARIANT_004."""
+
+    def test_two_machine_roots_same_artifacts_produce_same_context_shape(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """Two distinct project roots with identical artifacts -> identical projection."""
+        root1 = tmp_path_factory.mktemp("machine-1")
+        root2 = tmp_path_factory.mktemp("machine-2")
+
+        for root in (root1, root2):
+            _write_identity_config(root)
+            _seed_artifact(root, artifact_id="art-shared-1", sequence_id=1)
+            _seed_artifact(root, artifact_id="art-shared-2", sequence_id=2)
+
+        sid1 = _do_clock_in(root1)
+        sid2 = _do_clock_in(root2)
+
+        from hestai_context_mcp.storage.snapshots import read_session_snapshot
+
+        snap1 = read_session_snapshot(working_dir=root1, session_id=sid1)
+        snap2 = read_session_snapshot(working_dir=root2, session_id=sid2)
+
+        # Projection content (artifact_refs sans machine-specific paths)
+        # is identical across machines.
+        assert snap1["projection"] == snap2["projection"]
+
+
+@pytest.mark.integration
+class TestRemoteDisabledAndNoNetwork:
+    """TEST_152 + TEST_156 + TEST_157 — INVARIANT_002 + R11."""
+
+    def test_full_suite_passes_with_remote_adapters_disabled(self, tmp_path: Path) -> None:
+        """Lifecycle works without any remote adapter present in the codebase."""
+        _write_identity_config(tmp_path)
+        sid = _do_clock_in(tmp_path)
+        result = _do_clock_out(tmp_path, sid)
+        assert result["status"] == "success"
+        # We use only LocalFilesystemAdapter; no remote path even references
+        # carrier classes other than the local adapter. Asserted directly:
+        from hestai_context_mcp import storage
+
+        # Inspect __all__ for top-level adapter exports beyond the local one.
+        public_exports = set(getattr(storage, "__all__", []))
+        adapter_exports = {n for n in public_exports if n.endswith("Adapter")}
+        # StorageAdapter (the protocol) and LocalFilesystemAdapter are
+        # the only legal entries in B1 per R12 and B2_START_BLOCKER_003.
+        allowed = {"StorageAdapter", "LocalFilesystemAdapter"}
+        assert adapter_exports <= allowed, (
+            f"R12 / B2_START_BLOCKER_003 violation: unexpected adapters "
+            f"exported: {adapter_exports - allowed}"
+        )
+
+    def test_local_filesystem_mode_has_no_network_calls(self, tmp_path: Path) -> None:
+        """Patch socket.socket -> any DNS / TCP attempt during lifecycle raises."""
+        _write_identity_config(tmp_path)
+
+        original_socket = socket.socket
+
+        class _NoNetworkSocket(original_socket):  # type: ignore[misc, valid-type]
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise OSError("INVARIANT_002 violation: PSS lifecycle attempted a network call")
+
+        with patch("socket.socket", _NoNetworkSocket):
+            sid = _do_clock_in(tmp_path)
+            result = _do_clock_out(tmp_path, sid)
+            assert result["status"] == "success"
+
+    def test_custom_git_ref_storage_is_not_used(self, tmp_path: Path) -> None:
+        """R11: no custom Git refs (refs/hestai/*) are written during lifecycle."""
+        _write_identity_config(tmp_path)
+        sid = _do_clock_in(tmp_path)
+        _do_clock_out(tmp_path, sid)
+
+        # No .git directory created; no refs/hestai paths exist.
+        for path in tmp_path.rglob("*"):
+            assert "refs/hestai" not in str(path), f"R11 violation: {path}"
+
+    def test_local_filesystem_adapter_advertises_local_only_classification(self) -> None:
+        """B2_START_BLOCKER_003: adapter exposes a public is_local_only() method.
+
+        The local-only flag is the single canonical way for downstream
+        callers (and the post-B2 quality gate chain) to mechanically
+        confirm that the LocalFilesystemAdapter is the only storage
+        carrier in B1. This is a positive structural invariant: it must
+        return True for the local adapter and the property must exist.
+        """
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        adapter = LocalFilesystemAdapter(working_dir=Path("/tmp"))
+        # Method exists and returns True for the local adapter.
+        assert hasattr(adapter, "is_local_only"), (
+            "B2_START_BLOCKER_003 violation: LocalFilesystemAdapter must "
+            "expose is_local_only() -> bool"
+        )
+        assert (
+            adapter.is_local_only() is True
+        ), "LocalFilesystemAdapter.is_local_only() must return True"
+
+
+@pytest.mark.integration
+class TestFailClosedStreamGuard:
+    """TEST_153 + TEST_155."""
+
+    def test_hydration_failure_does_not_publish_over_newer_stream(self, tmp_path: Path) -> None:
+        """Schema-too-new artifact -> structured error AND no v1 publish over it."""
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            ArtifactRef,
+            IdentityTuple,
+            PortableMemoryArtifact,
+            WritePrecondition,
+        )
+
+        _write_identity_config(tmp_path)
+
+        # Seed a "v1-on-disk" artifact whose minimum_reader_version is 99
+        # so the reader treats it as schema_too_new on hydrate.
+        # We use the v1 schema slot to keep the file shape valid (no v2
+        # invented per RISK_007); the minimum_reader_version field is what
+        # raises SchemaTooNewError on validate.
+        identity = IdentityTuple(**_identity_dict())
+        # NOTE: state_schema_version stays 1 (validation requires it to be
+        # in SUPPORTED_SCHEMA_VERSIONS); we trip the "too new" gate via
+        # minimum_reader_version=99 which IS the documented v2-machine
+        # rejection path per ADR-0013 R4 second-to-last bullet.
+        payload = {"newer": "stream"}
+        payload_hash = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        artifact = PortableMemoryArtifact(
+            artifact_id="art-v2",
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=identity,
+            schema_version=1,
+            producer_version="9",
+            minimum_reader_version=99,
+            created_at=datetime.now(UTC),
+            sequence_id=1,
+            parent_ids=(),
+            redaction_provenance=build_provenance_or_raise(
+                input_text="i", output_text="o", redacted_credential_categories=()
+            ),
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=payload_hash,
+            payload=payload,
+        )
+        ref = ArtifactRef(
+            artifact_id=artifact.artifact_id,
+            identity=artifact.identity,
+            artifact_kind=artifact.artifact_kind,
+            sequence_id=artifact.sequence_id,
+            created_at=artifact.created_at,
+            payload_hash=artifact.payload_hash,
+            carrier_path="",
+        )
+        LocalFilesystemAdapter(working_dir=tmp_path).write_artifact(
+            ref, artifact, WritePrecondition()
+        )
+
+        # clock_in must surface schema_too_new (not silent empty).
+        from hestai_context_mcp.tools.clock_in import clock_in
+
+        with patch("hestai_context_mcp.tools.clock_in.get_current_branch", return_value="main"):
+            result = clock_in(role="impl", working_dir=str(tmp_path))
+        ps = result["portable_state"]
+        assert ps["restore_status"] == "schema_too_new"
+        assert ps["error"] and ps["error"]["code"] == "schema_too_new"
+
+    def test_restore_refuses_fork_or_workspace_identity_mismatch(self, tmp_path: Path) -> None:
+        """Identity mismatch -> structured restore_status='identity_mismatch'."""
+        # Configure identity A.
+        _write_identity_config(tmp_path)
+
+        # Seed an artifact bound to identity B (different workspace_id).
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            ArtifactRef,
+            IdentityTuple,
+            PortableMemoryArtifact,
+            WritePrecondition,
+        )
+
+        identity_b = IdentityTuple(
+            project_id="proj-A",
+            workspace_id="OTHER-WORKSPACE",
+            user_id="alice",
+            state_schema_version=1,
+            carrier_namespace="personal",
+        )
+        payload = {"id": "fork-leak"}
+        ph = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        artifact = PortableMemoryArtifact(
+            artifact_id="fork-leak",
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=identity_b,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=1,
+            parent_ids=(),
+            redaction_provenance=build_provenance_or_raise(
+                input_text="i", output_text="o", redacted_credential_categories=()
+            ),
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=ph,
+            payload=payload,
+        )
+        ref = ArtifactRef(
+            artifact_id=artifact.artifact_id,
+            identity=identity_b,
+            artifact_kind=artifact.artifact_kind,
+            sequence_id=artifact.sequence_id,
+            created_at=artifact.created_at,
+            payload_hash=artifact.payload_hash,
+            carrier_path="",
+        )
+        LocalFilesystemAdapter(working_dir=tmp_path).write_artifact(
+            ref, artifact, WritePrecondition()
+        )
+
+        # clock_in (with identity A) sees no artifacts under namespace A's
+        # tree because they live under workspace_id=OTHER-WORKSPACE; the
+        # restore status remains "ok" with artifact_count=0. The structural
+        # invariant we assert: forked-workspace artifacts are NEVER merged
+        # into A's projection.
+        sid = _do_clock_in(tmp_path)
+
+        from hestai_context_mcp.storage.snapshots import read_session_snapshot
+
+        snap = read_session_snapshot(working_dir=tmp_path, session_id=sid)
+        ref_ids = {r["artifact_id"] for r in snap["projection"]["artifact_refs"]}
+        assert (
+            "fork-leak" not in ref_ids
+        ), "R3 violation: fork/workspace artifact leaked into projection"

--- a/tests/storage/test_classification.py
+++ b/tests/storage/test_classification.py
@@ -1,0 +1,155 @@
+"""GROUP_009: CLASSIFICATION — RED-first tests for storage/classification.py.
+
+Asserts the state-classification helper contract per BUILD-PLAN
+§TDD_TEST_LIST GROUP_009 (TEST_099..TEST_108) and ADR-0013 R1.
+
+Binding rulings exercised here:
+- R1: classification is mandatory; unknown state → LOCAL_MUTABLE.
+- §MIGRATION_PLAN EXISTING_STATE_CLASSIFICATION_MAP fixes the
+  authoritative mapping for known paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.storage.types import StateClassification
+
+
+@pytest.mark.unit
+class TestKnownLocalMutablePaths:
+    """TEST_099..TEST_103."""
+
+    def _classify(self, *, working_dir: Path, relative: str) -> StateClassification:
+        from hestai_context_mcp.storage.classification import classify_state_path
+
+        return classify_state_path(working_dir / relative, working_dir=working_dir)
+
+    def test_sessions_active_session_json_is_local_mutable(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/sessions/active/abc/session.json",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+    def test_sessions_archive_redacted_jsonl_is_local_mutable(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/sessions/archive/2026-04-26-foo-redacted.jsonl",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+    def test_learnings_index_is_local_mutable(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/learnings-index.jsonl",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+    def test_context_state_fast_layer_is_local_mutable(self, tmp_path: Path) -> None:
+        for f in ("current-focus.oct.md", "checklist.oct.md", "blockers.oct.md"):
+            assert (
+                self._classify(
+                    working_dir=tmp_path,
+                    relative=f".hestai/state/context/state/{f}",
+                )
+                is StateClassification.LOCAL_MUTABLE
+            )
+
+    def test_portable_outbox_is_local_mutable(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/outbox/art-1.json",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+
+@pytest.mark.unit
+class TestPortableMemoryPaths:
+    """TEST_104..TEST_105."""
+
+    def _classify(self, *, working_dir: Path, relative: str) -> StateClassification:
+        from hestai_context_mcp.storage.classification import classify_state_path
+
+        return classify_state_path(working_dir / relative, working_dir=working_dir)
+
+    def test_portable_artifacts_are_portable_memory(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/artifacts/personal/proj/wt/u/v1/art-1.json",
+            )
+            is StateClassification.PORTABLE_MEMORY
+        )
+
+    def test_portable_tombstones_are_portable_memory(self, tmp_path: Path) -> None:
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/tombstones/personal/proj/wt/u/v1/tomb-1.json",
+            )
+            is StateClassification.PORTABLE_MEMORY
+        )
+
+
+@pytest.mark.unit
+class TestDerivedProjectionPaths:
+    """TEST_106..TEST_107."""
+
+    def _classify(self, *, working_dir: Path, relative: str) -> StateClassification:
+        from hestai_context_mcp.storage.classification import classify_state_path
+
+        return classify_state_path(working_dir / relative, working_dir=working_dir)
+
+    def test_portable_snapshots_are_derived_projection(self, tmp_path: Path) -> None:
+        for f in ("context-projection.json", "metadata.json"):
+            assert (
+                self._classify(
+                    working_dir=tmp_path,
+                    relative=f".hestai/state/portable/snapshots/sess-1/{f}",
+                )
+                is StateClassification.DERIVED_PROJECTION
+            )
+
+    def test_materialized_project_context_from_portable_memory_is_derived_projection(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.classification import (
+            classify_materialized_context,
+        )
+
+        # Default-classification of the bare PROJECT-CONTEXT path is fail-closed
+        # to LOCAL_MUTABLE per MAP_008. The explicit "from portable memory"
+        # helper lifts that to DERIVED_PROJECTION.
+        target = tmp_path / ".hestai" / "state" / "context" / "PROJECT-CONTEXT.oct.md"
+        assert (
+            classify_materialized_context(target, derived_from_portable_memory=True)
+            is StateClassification.DERIVED_PROJECTION
+        )
+        assert (
+            classify_materialized_context(target, derived_from_portable_memory=False)
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+
+@pytest.mark.unit
+class TestUnknownPath:
+    """TEST_108 — fail-closed default (R1)."""
+
+    def test_unknown_state_path_defaults_to_local_mutable(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.classification import classify_state_path
+
+        unknown = tmp_path / ".hestai" / "state" / "something-new" / "x.bin"
+        assert (
+            classify_state_path(unknown, working_dir=tmp_path) is StateClassification.LOCAL_MUTABLE
+        )

--- a/tests/storage/test_classification.py
+++ b/tests/storage/test_classification.py
@@ -84,19 +84,24 @@ class TestPortableMemoryPaths:
         return classify_state_path(working_dir / relative, working_dir=working_dir)
 
     def test_portable_artifacts_are_portable_memory(self, tmp_path: Path) -> None:
+        # CE rework RISK_006: ADR-0013 abstract path layout
+        # portable/pss/{ns}/{proj}/{ws}/{user}/artifacts/{id}.json (no
+        # v{schema_version} segment).
         assert (
             self._classify(
                 working_dir=tmp_path,
-                relative=".hestai/state/portable/artifacts/personal/proj/wt/u/v1/art-1.json",
+                relative=".hestai/state/portable/pss/personal/proj/wt/u/artifacts/art-1.json",
             )
             is StateClassification.PORTABLE_MEMORY
         )
 
     def test_portable_tombstones_are_portable_memory(self, tmp_path: Path) -> None:
+        # CE rework RISK_006: tombstones live under the per-identity subtree
+        # at portable/pss/{ns}/{proj}/{ws}/{user}/tombstones/{id}.json.
         assert (
             self._classify(
                 working_dir=tmp_path,
-                relative=".hestai/state/portable/tombstones/personal/proj/wt/u/v1/tomb-1.json",
+                relative=".hestai/state/portable/pss/personal/proj/wt/u/tombstones/tomb-1.json",
             )
             is StateClassification.PORTABLE_MEMORY
         )

--- a/tests/storage/test_classification_segment_strictness.py
+++ b/tests/storage/test_classification_segment_strictness.py
@@ -1,0 +1,94 @@
+"""Cubic rework cycle 2 — Finding #7 (P2, classification.py:61).
+
+RED-first test: classifier must enforce the EXACT ADR-0013 PSS layout
+``portable/pss/{ns}/{proj}/{ws}/{user}/{leaf}/{id}.json`` — 8 segments
+relative to ``.hestai/state/``. The current ``len(parts) >= 4`` guard
+is too permissive: a malformed 5-segment path
+``portable/pss/{ns}/artifacts/x.json`` matches because parts[-2]==
+"artifacts", and is incorrectly classified as PORTABLE_MEMORY.
+
+RULE_005 of BUILD-PLAN §SCOPE_DISCIPLINE: "If a component cannot be
+classified, treat it as LOCAL_MUTABLE." Per PROD::I4 STRUCTURED_RETURN_SHAPES
+(no shape leaks for malformed paths) and ADR-0013 R1 (path geometry is
+the basis of classification), only paths matching the canonical layout
+exactly may resolve to PORTABLE_MEMORY.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestPSSPathSegmentStrictness:
+    """Cubic P2 #7: enforce canonical PSS layout segment count."""
+
+    def _classify(self, *, working_dir: Path, relative: str) -> object:
+        from hestai_context_mcp.storage.classification import classify_state_path
+
+        return classify_state_path(working_dir / relative, working_dir=working_dir)
+
+    def test_canonical_8_segment_artifacts_is_portable_memory(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/pss/ns/proj/wt/user/artifacts/art-1.json",
+            )
+            is StateClassification.PORTABLE_MEMORY
+        )
+
+    def test_canonical_8_segment_tombstones_is_portable_memory(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/pss/ns/proj/wt/user/tombstones/t-1.json",
+            )
+            is StateClassification.PORTABLE_MEMORY
+        )
+
+    def test_truncated_pss_path_is_local_mutable(self, tmp_path: Path) -> None:
+        """``portable/pss/ns/proj`` (4 segments) is structurally too short
+        and must NOT be classified as PORTABLE_MEMORY (RULE_005)."""
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/pss/ns/proj",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+    def test_short_pss_with_artifacts_segment_is_local_mutable(self, tmp_path: Path) -> None:
+        """A 5-segment ``portable/pss/{ns}/artifacts/x.json`` matches the
+        permissive ``len >= 4`` guard and parts[-2] == 'artifacts', so it
+        is currently misclassified as PORTABLE_MEMORY. Strict layout
+        enforcement must reject it."""
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/pss/ns/artifacts/x.json",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )
+
+    def test_too_many_segments_is_local_mutable(self, tmp_path: Path) -> None:
+        """Excess depth beyond the canonical 8-segment layout must also be
+        rejected (fail-closed) rather than classified as PORTABLE_MEMORY."""
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert (
+            self._classify(
+                working_dir=tmp_path,
+                relative=".hestai/state/portable/pss/ns/proj/wt/user/extra/artifacts/x.json",
+            )
+            is StateClassification.LOCAL_MUTABLE
+        )

--- a/tests/storage/test_identity.py
+++ b/tests/storage/test_identity.py
@@ -1,0 +1,180 @@
+"""GROUP_003: IDENTITY_VALIDATION — RED-first tests for storage/identity.py.
+
+Asserts the IdentityTuple validation contract per ADR-0013 R3:
+- All five identity fields must be non-blank strings.
+- ``state_schema_version`` must be a positive int in the supported set.
+- Path-traversal / control-character / separator characters are rejected
+  *before* any path construction (R3 + R10).
+- A namespace/identity mismatch returns a structured ``RestoreError``,
+  not silent empty fallback (RISK_001 + A1 fail-closed observability).
+- The validator has no filesystem side effects.
+
+R-trace: see BUILD-PLAN §TDD_TEST_LIST GROUP_003_IDENTITY_VALIDATION.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _identity(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "project_id": "hestai-context-mcp",
+        "workspace_id": "build-adr-13",
+        "user_id": "shaun",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestValidIdentity:
+    """TEST_021: a fully-valid identity passes."""
+
+    def test_valid_identity_tuple_passes_validation(self) -> None:
+        from hestai_context_mcp.storage.identity import validate_identity_tuple
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        identity = IdentityTuple(**_identity())  # type: ignore[arg-type]
+        # No exception -> success.
+        result = validate_identity_tuple(identity)
+        assert result is identity
+
+
+@pytest.mark.unit
+class TestBlankRejection:
+    """TEST_022..TEST_025: blank components are rejected."""
+
+    @pytest.mark.parametrize(
+        "field",
+        ["project_id", "workspace_id", "user_id", "carrier_namespace"],
+    )
+    def test_blank_component_is_rejected(self, field: str) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_identity_tuple,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        identity = IdentityTuple(**_identity(**{field: "  "}))  # type: ignore[arg-type]
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_identity_tuple(identity)
+        assert excinfo.value.code == "blank_identity_component"
+        assert excinfo.value.field == field
+
+
+@pytest.mark.unit
+class TestUnsupportedSchemaVersion:
+    """TEST_026: state_schema_version must be in SUPPORTED set."""
+
+    @pytest.mark.parametrize("version", [0, -1, 99])
+    def test_unsupported_schema_version_is_rejected(self, version: int) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_identity_tuple,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        identity = IdentityTuple(**_identity(state_schema_version=version))  # type: ignore[arg-type]
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_identity_tuple(identity)
+        assert excinfo.value.code == "unsupported_schema_version"
+
+
+@pytest.mark.unit
+class TestPathTraversalRejection:
+    """TEST_027/TEST_028/TEST_029: unsafe characters rejected before path construction."""
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("project_id", "p/q"),
+            ("workspace_id", "w\\x"),
+            ("user_id", "..//evil"),
+            ("carrier_namespace", "team\nrogue"),
+            ("project_id", "a\tb"),
+            ("user_id", "u\rv"),
+        ],
+    )
+    def test_unsafe_characters_in_identity_components_rejected(
+        self, field: str, value: str
+    ) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_identity_tuple,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        identity = IdentityTuple(**_identity(**{field: value}))  # type: ignore[arg-type]
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_identity_tuple(identity)
+        assert excinfo.value.code in {"path_separator", "path_traversal", "control_character"}
+        assert excinfo.value.field == field
+
+
+@pytest.mark.unit
+class TestNamespaceIdentityMismatch:
+    """TEST_030/TEST_031: namespace and identity must align (structured error)."""
+
+    def test_namespace_and_identity_mismatch_is_structured_error(self) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_namespace_matches_identity,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple, PortableNamespace
+
+        identity = IdentityTuple(**_identity())  # type: ignore[arg-type]
+        namespace = PortableNamespace(
+            project_id="other-project",
+            workspace_id=identity.workspace_id,
+            user_id=identity.user_id,
+            state_schema_version=identity.state_schema_version,
+            carrier_namespace=identity.carrier_namespace,
+        )
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_namespace_matches_identity(namespace=namespace, identity=identity)
+        assert excinfo.value.code == "namespace_identity_mismatch"
+
+    def test_restore_identity_mismatch_does_not_return_empty_success(self) -> None:
+        # RISK_001 + A1 — fail-closed: an identity mismatch must surface as
+        # a structured RestoreError so callers can react, not pretend success.
+        from hestai_context_mcp.storage.identity import RestoreError
+
+        err = RestoreError(code="identity_mismatch", message="forks not allowed")
+        assert err.code == "identity_mismatch"
+        # cause is optional but field exists for chained diagnostics.
+        assert hasattr(err, "cause")
+
+
+@pytest.mark.unit
+class TestNoSideEffects:
+    """TEST_032: validation has no filesystem side effects."""
+
+    def test_identity_validation_has_no_filesystem_side_effects(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.identity import validate_identity_tuple
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        before = sorted(p.name for p in tmp_path.iterdir())
+        identity = IdentityTuple(**_identity())  # type: ignore[arg-type]
+        validate_identity_tuple(identity)
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert before == after
+
+
+@pytest.mark.unit
+class TestRestoreErrorStructure:
+    """A1: structured RestoreError has code + cause (fail-closed observability)."""
+
+    def test_restore_error_carries_code_and_cause(self) -> None:
+        from hestai_context_mcp.storage.identity import RestoreError
+
+        cause = ValueError("upstream")
+        err = RestoreError(code="schema_too_new", message="reader too old", cause=cause)
+        assert err.code == "schema_too_new"
+        assert err.cause is cause
+        # Inheriting from Exception so callers can raise/catch normally.
+        assert isinstance(err, Exception)

--- a/tests/storage/test_identity_resolver_failclosed.py
+++ b/tests/storage/test_identity_resolver_failclosed.py
@@ -28,7 +28,9 @@ def _config(working_dir: Path, payload: dict[str, Any]) -> Path:
 class TestResolveIdentityFailClosedOnNonStringField:
     """Cubic P2 #6: non-string fields must NOT be coerced via str(...)."""
 
-    @pytest.mark.parametrize("field", ["project_id", "workspace_id", "user_id", "carrier_namespace"])
+    @pytest.mark.parametrize(
+        "field", ["project_id", "workspace_id", "user_id", "carrier_namespace"]
+    )
     @pytest.mark.parametrize("value", [123, ["a"], {"k": "v"}])
     def test_non_string_field_returns_none_not_coerced(
         self, tmp_path: Path, field: str, value: Any

--- a/tests/storage/test_identity_resolver_failclosed.py
+++ b/tests/storage/test_identity_resolver_failclosed.py
@@ -1,0 +1,50 @@
+"""Cubic rework cycle 2 — Finding #6 (P2, identity_resolver.py:54).
+
+RED-first test: ``resolve_identity`` must NOT silently coerce a
+non-string identity field (e.g., int, list, dict) via ``str(...)``.
+RISK_001 fail-closed default requires returning ``None`` (treat as
+"no identity configured") so the caller surfaces a structured
+``no_identity_configured`` skip rather than binding to a fabricated
+identity. PROD::I2 fail-closed identity safety.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _config(working_dir: Path, payload: dict[str, Any]) -> Path:
+    cfg = working_dir / ".hestai" / "state" / "portable" / "identity.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps(payload))
+    return cfg
+
+
+@pytest.mark.unit
+class TestResolveIdentityFailClosedOnNonStringField:
+    """Cubic P2 #6: non-string fields must NOT be coerced via str(...)."""
+
+    @pytest.mark.parametrize("field", ["project_id", "workspace_id", "user_id", "carrier_namespace"])
+    @pytest.mark.parametrize("value", [123, ["a"], {"k": "v"}])
+    def test_non_string_field_returns_none_not_coerced(
+        self, tmp_path: Path, field: str, value: Any
+    ) -> None:
+        from hestai_context_mcp.storage.identity_resolver import resolve_identity
+
+        payload: dict[str, Any] = {
+            "project_id": "proj-A",
+            "workspace_id": "wt-build",
+            "user_id": "alice",
+            "state_schema_version": 1,
+            "carrier_namespace": "personal",
+        }
+        payload[field] = value
+        _config(tmp_path, payload)
+
+        # Must return None (fail-closed) rather than coerce to e.g. "123".
+        result = resolve_identity(tmp_path)
+        assert result is None

--- a/tests/storage/test_identity_schema_version_bool.py
+++ b/tests/storage/test_identity_schema_version_bool.py
@@ -1,0 +1,50 @@
+"""Cubic rework cycle 2 — Finding #5 (P1, identity.py:120).
+
+RED-first test: ``isinstance(value, int)`` accepts ``bool`` because
+``bool`` subclasses ``int``. ``state_schema_version=True`` would
+silently coerce to 1 and pass validation. Per PROD::I2 fail-closed
+identity validation it must raise ``IdentityValidationError`` with
+code ``unsupported_schema_version`` regardless of the truthy/falsy
+bool value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _base() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+@pytest.mark.unit
+class TestSchemaVersionBoolRejection:
+    """Cubic P1 #5: bool must be rejected even though it subclasses int."""
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_state_schema_version_is_rejected(self, value: bool) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_identity_tuple,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        kwargs = _base()
+        kwargs["state_schema_version"] = value
+        identity = IdentityTuple(**kwargs)  # type: ignore[arg-type]
+
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_identity_tuple(identity)
+
+        # Bool is structurally invalid as a schema version even though
+        # ``isinstance(bool, int)`` is True.
+        assert excinfo.value.code == "unsupported_schema_version"
+        assert excinfo.value.field == "state_schema_version"

--- a/tests/storage/test_identity_type_rejection.py
+++ b/tests/storage/test_identity_type_rejection.py
@@ -35,9 +35,7 @@ class TestNonStringIdentityComponentTypeRejection:
         "value",
         [123, ["a", "b"], {"k": "v"}, 1.5, ("a",)],
     )
-    def test_non_string_component_raises_structured_error(
-        self, field: str, value: Any
-    ) -> None:
+    def test_non_string_component_raises_structured_error(self, field: str, value: Any) -> None:
         from hestai_context_mcp.storage.identity import (
             IdentityValidationError,
             validate_identity_tuple,

--- a/tests/storage/test_identity_type_rejection.py
+++ b/tests/storage/test_identity_type_rejection.py
@@ -1,0 +1,55 @@
+"""Cubic rework cycle 2 — Finding #2 (P1, identity.py:74).
+
+RED-first test: non-string truthy values (int, list, dict, float, tuple)
+for the four string fields must NOT reach ``.strip()``; they must raise
+``IdentityValidationError`` with code ``invalid_identity_component_type``
+(PROD::I2 fail-closed identity validation, RISK_001).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _base() -> dict[str, Any]:
+    return {
+        "project_id": "proj-A",
+        "workspace_id": "wt-build",
+        "user_id": "alice",
+        "state_schema_version": 1,
+        "carrier_namespace": "personal",
+    }
+
+
+@pytest.mark.unit
+class TestNonStringIdentityComponentTypeRejection:
+    """Cubic P1 #2: non-string truthy values must fail-closed structured."""
+
+    @pytest.mark.parametrize(
+        "field",
+        ["project_id", "workspace_id", "user_id", "carrier_namespace"],
+    )
+    @pytest.mark.parametrize(
+        "value",
+        [123, ["a", "b"], {"k": "v"}, 1.5, ("a",)],
+    )
+    def test_non_string_component_raises_structured_error(
+        self, field: str, value: Any
+    ) -> None:
+        from hestai_context_mcp.storage.identity import (
+            IdentityValidationError,
+            validate_identity_tuple,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        kwargs = _base()
+        kwargs[field] = value
+        identity = IdentityTuple(**kwargs)  # type: ignore[arg-type]
+
+        with pytest.raises(IdentityValidationError) as excinfo:
+            validate_identity_tuple(identity)
+
+        assert excinfo.value.code == "invalid_identity_component_type"
+        assert excinfo.value.field == field

--- a/tests/storage/test_local_filesystem_adapter.py
+++ b/tests/storage/test_local_filesystem_adapter.py
@@ -13,7 +13,7 @@ Binding rulings exercised here:
 - R11: no shelling out to git, no custom Git refs.
 - R12: no remote SDKs, no network imports.
 - RISK_006: local carrier path layout mirrors the abstract ADR layout
-  under .hestai/state/portable/artifacts/.
+  under .hestai/state/portable/pss/{ns}/{proj}/{ws}/{user}/artifacts/.
 """
 
 from __future__ import annotations
@@ -219,7 +219,7 @@ class TestWriteArtifact:
         ack = adapter.write_artifact(ref, artifact, WritePrecondition())
         # An on-disk file exists under the artifacts subtree.
         artifact_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
         )
         assert artifact_files
         assert any(artifact.artifact_id in p.name for p in artifact_files)
@@ -288,10 +288,11 @@ class TestWriteArtifact:
         with pytest.raises(ProvenanceIncompleteError):
             adapter.write_artifact(ref, artifact, WritePrecondition())
 
-        # G4 atomic-guard: NO partial file written under the artifacts tree.
-        artifacts_dir = tmp_path / ".hestai" / "state" / "portable" / "artifacts"
-        if artifacts_dir.exists():
-            assert not list(artifacts_dir.rglob("*.json"))
+        # G4 atomic-guard: NO partial file written under the pss subtree
+        # (CE rework RISK_006: ADR-0013 abstract path).
+        pss_dir = tmp_path / ".hestai" / "state" / "portable" / "pss"
+        if pss_dir.exists():
+            assert not list(pss_dir.rglob("*.json"))
 
     def test_local_filesystem_write_is_create_only_by_default(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.types import WritePrecondition
@@ -419,7 +420,7 @@ class TestReadArtifact:
 
         # Tamper with the on-disk file.
         artifact_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
         )
         assert artifact_files
         target = artifact_files[0]
@@ -519,9 +520,12 @@ class TestWriteTombstone:
         tomb = self._make_tombstone(target_artifact_id="art-1")
         ack = adapter.write_tombstone(self._ref_for_tombstone(tomb), tomb, WritePrecondition())
         assert ack.artifact_id == tomb.artifact_id
-        tombstones_dir = tmp_path / ".hestai" / "state" / "portable" / "tombstones"
-        assert tombstones_dir.exists()
-        assert list(tombstones_dir.rglob("*.json"))
+        # CE rework RISK_006: tombstones live under per-identity subtree at
+        # portable/pss/{ns}/{proj}/{ws}/{user}/tombstones/{id}.json.
+        pss_root = tmp_path / ".hestai" / "state" / "portable" / "pss"
+        assert pss_root.exists()
+        tombstones = [p for p in pss_root.rglob("*.json") if p.parent.name == "tombstones"]
+        assert tombstones, f"no tombstone files found under {pss_root}"
 
     def test_write_tombstone_does_not_delete_target_artifact(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.types import WritePrecondition
@@ -530,7 +534,7 @@ class TestWriteTombstone:
         artifact = _make_artifact(artifact_id="art-1", sequence_id=1)
         adapter.write_artifact(_make_ref_for(artifact), artifact, WritePrecondition())
         target_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
         )
         assert target_files
         target_file = target_files[0]

--- a/tests/storage/test_local_filesystem_adapter.py
+++ b/tests/storage/test_local_filesystem_adapter.py
@@ -218,7 +218,9 @@ class TestWriteArtifact:
         ref = _make_ref_for(artifact)
         ack = adapter.write_artifact(ref, artifact, WritePrecondition())
         # An on-disk file exists under the artifacts subtree.
-        artifact_files = list((tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json"))
+        artifact_files = list(
+            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+        )
         assert artifact_files
         assert any(artifact.artifact_id in p.name for p in artifact_files)
         assert ack.artifact_id == artifact.artifact_id
@@ -315,9 +317,7 @@ class TestWriteArtifact:
         ack2 = adapter.write_artifact(ref, artifact, WritePrecondition())
         assert ack2.status == PublishStatus.DUPLICATE
 
-    def test_duplicate_artifact_id_different_hash_fails_precondition(
-        self, tmp_path: Path
-    ) -> None:
+    def test_duplicate_artifact_id_different_hash_fails_precondition(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.types import PublishStatus, WritePrecondition
 
         adapter = self._adapter(tmp_path)

--- a/tests/storage/test_local_filesystem_adapter.py
+++ b/tests/storage/test_local_filesystem_adapter.py
@@ -1,0 +1,625 @@
+"""GROUP_006: LOCAL_FILESYSTEM_ADAPTER_CAPABILITIES — RED-first tests.
+
+Asserts the LocalFilesystemAdapter contract per BUILD-PLAN
+§TDD_TEST_LIST GROUP_006 (TEST_057..TEST_078).
+
+Binding rulings exercised here:
+- INVARIANT_003 (R6 + R10): write_artifact fails closed without complete
+  redaction provenance.
+- G4 (CIV): provenance guard MUST raise BEFORE any side-effecting filesystem
+  write — partial files cannot exist.
+- R9 / RISK_002: append-first monotonic IDs, deterministic list order,
+  duplicate-id semantics (idempotent same-hash, fail conflicting-hash).
+- R11: no shelling out to git, no custom Git refs.
+- R12: no remote SDKs, no network imports.
+- RISK_006: local carrier path layout mirrors the abstract ADR layout
+  under .hestai/state/portable/artifacts/.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _identity() -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id="proj-A",
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _namespace_from(identity: Any) -> Any:
+    from hestai_context_mcp.storage.types import PortableNamespace
+
+    return PortableNamespace(
+        project_id=identity.project_id,
+        workspace_id=identity.workspace_id,
+        user_id=identity.user_id,
+        state_schema_version=identity.state_schema_version,
+        carrier_namespace=identity.carrier_namespace,
+    )
+
+
+def _provenance(input_text: str = "i", output_text: str = "o") -> Any:
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+
+    return build_provenance_or_raise(
+        input_text=input_text,
+        output_text=output_text,
+        redacted_credential_categories=(),
+    )
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _make_artifact(
+    *,
+    artifact_id: str = "art-001",
+    sequence_id: int = 1,
+    payload: dict[str, Any] | None = None,
+    identity: Any | None = None,
+    provenance: Any | None = None,
+) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactKind, PortableMemoryArtifact
+
+    payload = payload or {"k": "v"}
+    identity = identity or _identity()
+    provenance = provenance or _provenance()
+    return PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=provenance,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_payload_hash(payload),
+        payload=payload,
+    )
+
+
+def _make_ref_for(artifact: Any) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactRef
+
+    return ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",  # filled by adapter on write; ignored on read
+    )
+
+
+@pytest.mark.unit
+class TestLocalFilesystemAdapterImplementsProtocol:
+    """TEST_057."""
+
+    def test_local_filesystem_adapter_implements_storage_adapter_protocol(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        assert isinstance(adapter, StorageAdapter)
+
+
+@pytest.mark.unit
+class TestCapabilitiesMatrix:
+    """TEST_058..TEST_061."""
+
+    def _adapter(self, tmp_path: Path) -> Any:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        return LocalFilesystemAdapter(working_dir=tmp_path)
+
+    def test_local_filesystem_capabilities_meet_required_publication_matrix(
+        self, tmp_path: Path
+    ) -> None:
+        a = self._adapter(tmp_path)
+        caps = a.capabilities
+        # Required for publication per ADR R2 capability matrix.
+        assert caps.strong_list_consistency is True
+        assert caps.atomic_compare_and_swap is True
+        assert caps.conditional_writes is True
+        assert caps.read_only is False
+
+    def test_local_filesystem_encryption_capabilities_are_false_for_local_policy(
+        self, tmp_path: Path
+    ) -> None:
+        a = self._adapter(tmp_path)
+        # Local disk is outside this ADR; the adapter does not implement
+        # at-rest/in-transit encryption itself.
+        assert a.capabilities.encryption_at_rest is False
+        assert a.capabilities.encryption_in_transit is False
+
+    def test_local_filesystem_has_strong_list_consistency(self, tmp_path: Path) -> None:
+        assert self._adapter(tmp_path).capabilities.strong_list_consistency is True
+
+    def test_local_filesystem_conditional_writes_required(self, tmp_path: Path) -> None:
+        assert self._adapter(tmp_path).capabilities.conditional_writes is True
+
+
+@pytest.mark.unit
+class TestPortableStateRoot:
+    """TEST_062 + TEST_063 — root layout + unsafe namespace rejection."""
+
+    def test_local_filesystem_uses_portable_state_root_only(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        assert adapter.portable_root == tmp_path / ".hestai" / "state" / "portable"
+        # The adapter never writes outside portable_root.
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+        # All produced files live under portable_root.
+        for path in tmp_path.rglob("*"):
+            if path.is_file():
+                assert adapter.portable_root in path.parents or path == adapter.portable_root
+
+    def test_local_filesystem_rejects_unsafe_namespace_before_path_construction(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.identity import IdentityValidationError
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import PortableNamespace
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        bad = PortableNamespace(
+            project_id="../../etc",
+            workspace_id="wt",
+            user_id="alice",
+            state_schema_version=1,
+            carrier_namespace="personal",
+        )
+        with pytest.raises(IdentityValidationError):
+            adapter.list_artifacts(bad)
+
+
+@pytest.mark.unit
+class TestWriteArtifact:
+    """TEST_064..TEST_069 — write semantics."""
+
+    def _adapter(self, tmp_path: Path) -> Any:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        return LocalFilesystemAdapter(working_dir=tmp_path)
+
+    def test_local_filesystem_write_creates_artifact_file(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+        # An on-disk file exists under the artifacts subtree.
+        artifact_files = list((tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json"))
+        assert artifact_files
+        assert any(artifact.artifact_id in p.name for p in artifact_files)
+        assert ack.artifact_id == artifact.artifact_id
+
+    def test_local_filesystem_write_returns_publish_ack(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import (
+            PublishAck,
+            PublishStatus,
+            WritePrecondition,
+        )
+
+        adapter = self._adapter(tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+        assert isinstance(ack, PublishAck)
+        assert ack.status == PublishStatus.PUBLISHED
+        assert ack.identity == artifact.identity
+        assert ack.sequence_id == artifact.sequence_id
+        assert ack.carrier_namespace == artifact.identity.carrier_namespace
+
+    def test_local_filesystem_write_fails_without_complete_redaction_provenance(
+        self, tmp_path: Path
+    ) -> None:
+        """INVARIANT_003 — provenance gate fails closed (G4 atomic guard)."""
+        from hestai_context_mcp.storage.provenance import ProvenanceIncompleteError
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            PortableMemoryArtifact,
+            RedactionProvenance,
+            WritePrecondition,
+        )
+
+        adapter = self._adapter(tmp_path)
+        identity = _identity()
+        # Provenance with empty engine_name simulates incomplete provenance.
+        bad_provenance = RedactionProvenance(
+            engine_name="",  # missing
+            engine_version="1",
+            ruleset_hash="x" * 64,
+            input_artifact_hash="a" * 64,
+            output_artifact_hash="b" * 64,
+            redacted_at=datetime.now(UTC),
+            classification_label="PORTABLE_MEMORY",
+            redacted_credential_categories=(),
+        )
+        payload = {"k": "v"}
+        artifact = PortableMemoryArtifact(
+            artifact_id="bad-1",
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=identity,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=1,
+            parent_ids=(),
+            redaction_provenance=bad_provenance,
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=_payload_hash(payload),
+            payload=payload,
+        )
+        ref = _make_ref_for(artifact)
+
+        with pytest.raises(ProvenanceIncompleteError):
+            adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        # G4 atomic-guard: NO partial file written under the artifacts tree.
+        artifacts_dir = tmp_path / ".hestai" / "state" / "portable" / "artifacts"
+        if artifacts_dir.exists():
+            assert not list(artifacts_dir.rglob("*.json"))
+
+    def test_local_filesystem_write_is_create_only_by_default(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+        # A second call with the SAME id but DIFFERENT payload (different
+        # hash) must NOT overwrite — see TEST_069 for the exact behavior.
+        # Default precondition is if_absent=True.
+        assert WritePrecondition().if_absent is True
+
+    def test_duplicate_artifact_id_same_hash_is_idempotent_duplicate_ack(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.types import PublishStatus, WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+        ack2 = adapter.write_artifact(ref, artifact, WritePrecondition())
+        assert ack2.status == PublishStatus.DUPLICATE
+
+    def test_duplicate_artifact_id_different_hash_fails_precondition(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.types import PublishStatus, WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        artifact1 = _make_artifact(payload={"k": "v"})
+        ref1 = _make_ref_for(artifact1)
+        adapter.write_artifact(ref1, artifact1, WritePrecondition())
+
+        # Same artifact_id, different payload (different hash) → FAILED.
+        artifact2 = _make_artifact(payload={"k": "v2"})
+        # rebuild ref with the *first* artifact_id + the *second* payload hash
+        from hestai_context_mcp.storage.types import ArtifactRef
+
+        ref2 = ArtifactRef(
+            artifact_id=artifact1.artifact_id,
+            identity=artifact2.identity,
+            artifact_kind=artifact2.artifact_kind,
+            sequence_id=artifact2.sequence_id,
+            created_at=artifact2.created_at,
+            payload_hash=artifact2.payload_hash,
+            carrier_path="",
+        )
+        from hestai_context_mcp.storage.types import ArtifactKind, PortableMemoryArtifact
+
+        # Force same artifact_id, different payload.
+        conflicting = PortableMemoryArtifact(
+            artifact_id=artifact1.artifact_id,
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=artifact2.identity,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=artifact2.created_at,
+            sequence_id=artifact2.sequence_id,
+            parent_ids=(),
+            redaction_provenance=artifact2.redaction_provenance,
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=artifact2.payload_hash,
+            payload=artifact2.payload,
+        )
+        ack = adapter.write_artifact(ref2, conflicting, WritePrecondition())
+        assert ack.status == PublishStatus.FAILED
+        assert ack.error_code is not None
+
+
+@pytest.mark.unit
+class TestListArtifacts:
+    """TEST_070..TEST_071."""
+
+    def test_list_artifacts_returns_monotonic_sequence_order(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        # Insert in non-monotonic order.
+        a3 = _make_artifact(artifact_id="art-3", sequence_id=3, payload={"i": 3})
+        a1 = _make_artifact(artifact_id="art-1", sequence_id=1, payload={"i": 1})
+        a2 = _make_artifact(artifact_id="art-2", sequence_id=2, payload={"i": 2})
+        for art in (a3, a1, a2):
+            adapter.write_artifact(_make_ref_for(art), art, WritePrecondition())
+
+        refs = adapter.list_artifacts(_namespace_from(_identity()))
+        seqs = [r.sequence_id for r in refs]
+        assert seqs == sorted(seqs)
+        assert seqs == [1, 2, 3]
+
+    def test_list_artifacts_after_id_filters_exclusive(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        a1 = _make_artifact(artifact_id="art-1", sequence_id=1, payload={"i": 1})
+        a2 = _make_artifact(artifact_id="art-2", sequence_id=2, payload={"i": 2})
+        a3 = _make_artifact(artifact_id="art-3", sequence_id=3, payload={"i": 3})
+        for art in (a1, a2, a3):
+            adapter.write_artifact(_make_ref_for(art), art, WritePrecondition())
+
+        ns = _namespace_from(_identity())
+        refs = adapter.list_artifacts(ns, after_id="art-1")
+        ids = [r.artifact_id for r in refs]
+        assert "art-1" not in ids
+        assert ids == ["art-2", "art-3"]
+
+
+@pytest.mark.unit
+class TestReadArtifact:
+    """TEST_072..TEST_073."""
+
+    def test_read_artifact_validates_payload_hash(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.local_filesystem import (
+            LocalFilesystemAdapter,
+            PayloadHashMismatchError,
+        )
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        # Tamper with the on-disk file.
+        artifact_files = list(
+            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+        )
+        assert artifact_files
+        target = artifact_files[0]
+        raw = json.loads(target.read_text())
+        raw["payload"] = {"tampered": True}
+        target.write_text(json.dumps(raw))
+
+        with pytest.raises(PayloadHashMismatchError):
+            adapter.read_artifact(ref)
+
+    def test_read_artifact_rejects_identity_mismatch(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.identity import IdentityValidationError
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactRef,
+            IdentityTuple,
+            WritePrecondition,
+        )
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        # Build a ref with a *different* identity pointing at the same path.
+        wrong_identity = IdentityTuple(
+            project_id="proj-OTHER",
+            workspace_id="wt-build",
+            user_id="alice",
+            state_schema_version=1,
+            carrier_namespace="personal",
+        )
+        bad_ref = ArtifactRef(
+            artifact_id=ref.artifact_id,
+            identity=wrong_identity,
+            artifact_kind=ref.artifact_kind,
+            sequence_id=ref.sequence_id,
+            created_at=ref.created_at,
+            payload_hash=ref.payload_hash,
+            carrier_path=ref.carrier_path,
+        )
+        with pytest.raises((IdentityValidationError, FileNotFoundError)):
+            adapter.read_artifact(bad_ref)
+
+
+@pytest.mark.unit
+class TestWriteTombstone:
+    """TEST_074..TEST_076."""
+
+    def _adapter(self, tmp_path: Path) -> Any:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        return LocalFilesystemAdapter(working_dir=tmp_path)
+
+    def _make_tombstone(self, *, target_artifact_id: str, sequence_id: int = 99) -> Any:
+        from hestai_context_mcp.storage.types import ArtifactKind, TombstoneArtifact
+
+        identity = _identity()
+        return TombstoneArtifact(
+            artifact_id=f"tomb-{target_artifact_id}",
+            artifact_kind=ArtifactKind.TOMBSTONE,
+            identity=identity,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=sequence_id,
+            parent_ids=(target_artifact_id,),
+            target_artifact_id=target_artifact_id,
+            reason="user-revoked",
+            publisher_identity=identity,
+            redaction_provenance=None,
+            classification_label="PORTABLE_MEMORY",
+            payload_hash=hashlib.sha256(target_artifact_id.encode()).hexdigest(),
+        )
+
+    def _ref_for_tombstone(self, tomb: Any) -> Any:
+        from hestai_context_mcp.storage.types import ArtifactRef
+
+        return ArtifactRef(
+            artifact_id=tomb.artifact_id,
+            identity=tomb.identity,
+            artifact_kind=tomb.artifact_kind,
+            sequence_id=tomb.sequence_id,
+            created_at=tomb.created_at,
+            payload_hash=tomb.payload_hash,
+            carrier_path="",
+        )
+
+    def test_write_tombstone_appends_tombstone_file(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        # First seed a memory artifact to tombstone.
+        artifact = _make_artifact(artifact_id="art-1", sequence_id=1)
+        adapter.write_artifact(_make_ref_for(artifact), artifact, WritePrecondition())
+        tomb = self._make_tombstone(target_artifact_id="art-1")
+        ack = adapter.write_tombstone(self._ref_for_tombstone(tomb), tomb, WritePrecondition())
+        assert ack.artifact_id == tomb.artifact_id
+        tombstones_dir = tmp_path / ".hestai" / "state" / "portable" / "tombstones"
+        assert tombstones_dir.exists()
+        assert list(tombstones_dir.rglob("*.json"))
+
+    def test_write_tombstone_does_not_delete_target_artifact(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = self._adapter(tmp_path)
+        artifact = _make_artifact(artifact_id="art-1", sequence_id=1)
+        adapter.write_artifact(_make_ref_for(artifact), artifact, WritePrecondition())
+        target_files = list(
+            (tmp_path / ".hestai" / "state" / "portable" / "artifacts").rglob("*.json")
+        )
+        assert target_files
+        target_file = target_files[0]
+        before = target_file.read_text()
+
+        tomb = self._make_tombstone(target_artifact_id="art-1")
+        adapter.write_tombstone(self._ref_for_tombstone(tomb), tomb, WritePrecondition())
+        assert target_file.exists()
+        assert target_file.read_text() == before
+
+    def test_write_tombstone_for_redaction_failure_requires_provenance(
+        self, tmp_path: Path
+    ) -> None:
+        """If reason indicates post-hoc redaction failure, provenance is required."""
+        from hestai_context_mcp.storage.local_filesystem import (
+            TombstoneProvenanceRequiredError,
+        )
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            TombstoneArtifact,
+            WritePrecondition,
+        )
+
+        adapter = self._adapter(tmp_path)
+        identity = _identity()
+        bad_tomb = TombstoneArtifact(
+            artifact_id="tomb-bad",
+            artifact_kind=ArtifactKind.TOMBSTONE,
+            identity=identity,
+            schema_version=1,
+            producer_version="1",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=10,
+            parent_ids=("art-x",),
+            target_artifact_id="art-x",
+            reason="redaction_failure",  # post-hoc redaction failure
+            publisher_identity=identity,
+            redaction_provenance=None,  # MISSING
+            classification_label="PORTABLE_MEMORY",
+            payload_hash="0" * 64,
+        )
+        from hestai_context_mcp.storage.types import ArtifactRef
+
+        ref = ArtifactRef(
+            artifact_id=bad_tomb.artifact_id,
+            identity=bad_tomb.identity,
+            artifact_kind=bad_tomb.artifact_kind,
+            sequence_id=bad_tomb.sequence_id,
+            created_at=bad_tomb.created_at,
+            payload_hash=bad_tomb.payload_hash,
+            carrier_path="",
+        )
+        with pytest.raises(TombstoneProvenanceRequiredError):
+            adapter.write_tombstone(ref, bad_tomb, WritePrecondition())
+
+
+@pytest.mark.unit
+class TestAdapterSourceInvariants:
+    """TEST_077..TEST_078 — module-level structural guards."""
+
+    _SRC = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "hestai_context_mcp"
+        / "storage"
+        / "local_filesystem.py"
+    )
+
+    def test_adapter_never_shells_out_to_git(self) -> None:
+        text = self._SRC.read_text()
+        assert "subprocess" not in text or '"git"' not in text
+        # No git CLI invocations of any kind.
+        assert not re.search(r"\bsubprocess\.\w+\(.*\bgit\b", text)
+        # No custom Git refs language.
+        assert "refs/hestai" not in text
+
+    def test_adapter_has_no_network_imports(self) -> None:
+        text = self._SRC.read_text()
+        forbidden = (
+            "import requests",
+            "import httpx",
+            "import boto",
+            "import urllib3",
+            "from urllib3",
+            "import aiohttp",
+            "from boto",
+            "from requests",
+            "from httpx",
+        )
+        for token in forbidden:
+            assert token not in text, f"local_filesystem.py imports forbidden module: {token}"

--- a/tests/storage/test_local_filesystem_adapter.py
+++ b/tests/storage/test_local_filesystem_adapter.py
@@ -218,9 +218,7 @@ class TestWriteArtifact:
         ref = _make_ref_for(artifact)
         ack = adapter.write_artifact(ref, artifact, WritePrecondition())
         # An on-disk file exists under the artifacts subtree.
-        artifact_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
-        )
+        artifact_files = list((tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json"))
         assert artifact_files
         assert any(artifact.artifact_id in p.name for p in artifact_files)
         assert ack.artifact_id == artifact.artifact_id
@@ -419,9 +417,7 @@ class TestReadArtifact:
         adapter.write_artifact(ref, artifact, WritePrecondition())
 
         # Tamper with the on-disk file.
-        artifact_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
-        )
+        artifact_files = list((tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json"))
         assert artifact_files
         target = artifact_files[0]
         raw = json.loads(target.read_text())
@@ -533,9 +529,7 @@ class TestWriteTombstone:
         adapter = self._adapter(tmp_path)
         artifact = _make_artifact(artifact_id="art-1", sequence_id=1)
         adapter.write_artifact(_make_ref_for(artifact), artifact, WritePrecondition())
-        target_files = list(
-            (tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json")
-        )
+        target_files = list((tmp_path / ".hestai" / "state" / "portable" / "pss").rglob("*.json"))
         assert target_files
         target_file = target_files[0]
         before = target_file.read_text()

--- a/tests/storage/test_local_filesystem_pagination.py
+++ b/tests/storage/test_local_filesystem_pagination.py
@@ -1,0 +1,143 @@
+"""Cubic rework cycle 2 — Finding #4 (P1, local_filesystem.py:414).
+
+RED-first test: ``list_artifacts(after_id=...)`` must paginate by the
+same key as the sort, ``(sequence_id, artifact_id)``. Filtering by
+lexicographic ``r.artifact_id > after_id`` returns wrong results when
+artifact_ids do not increase monotonically with sequence_ids. PROD::I1
+SESSION_LIFECYCLE_INTEGRITY relies on a correct cursor for restore-time
+listing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _identity() -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id="proj-A",
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _namespace() -> Any:
+    from hestai_context_mcp.storage.types import PortableNamespace
+
+    identity = _identity()
+    return PortableNamespace(
+        project_id=identity.project_id,
+        workspace_id=identity.workspace_id,
+        user_id=identity.user_id,
+        state_schema_version=identity.state_schema_version,
+        carrier_namespace=identity.carrier_namespace,
+    )
+
+
+def _provenance() -> Any:
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+
+    return build_provenance_or_raise(
+        input_text="i", output_text="o", redacted_credential_categories=()
+    )
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _seed(adapter: Any, artifact_id: str, sequence_id: int) -> None:
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        ArtifactRef,
+        PortableMemoryArtifact,
+        WritePrecondition,
+    )
+
+    payload = {"id": artifact_id, "seq": sequence_id}
+    artifact = PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=_identity(),
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=_provenance(),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_payload_hash(payload),
+        payload=payload,
+    )
+    ref = ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+    adapter.write_artifact(ref, artifact, WritePrecondition())
+
+
+@pytest.mark.unit
+class TestListArtifactsPaginationCursorTuple:
+    """Cubic P1 #4: paginate by (sequence_id, artifact_id), not lex of id."""
+
+    def test_pagination_returns_correct_tail_when_id_lex_differs_from_sort(
+        self, tmp_path: Path
+    ) -> None:
+        """Construct artifacts where lex order on artifact_id alone differs
+        from the canonical (sequence_id, artifact_id) sort, then assert
+        ``after_id`` returns the correct tail."""
+
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        ns = _namespace()
+
+        # Sequence 1 has the lex-greatest id; sequence 2 has the lex-least.
+        # Canonical sort: A(seq=1, id="zzz"), B(seq=2, id="aaa")
+        # Lexicographic sort of ids only: B, A — different!
+        _seed(adapter, artifact_id="zzz", sequence_id=1)
+        _seed(adapter, artifact_id="aaa", sequence_id=2)
+
+        full = adapter.list_artifacts(ns)
+        assert [r.artifact_id for r in full] == ["zzz", "aaa"], (
+            "sort must be (sequence_id, artifact_id); got " f"{[r.artifact_id for r in full]}"
+        )
+
+        # Cursor at first ref: tail must contain the second ref.
+        tail = adapter.list_artifacts(ns, after_id="zzz")
+        assert [r.artifact_id for r in tail] == ["aaa"], (
+            "pagination must use sort key, not lex of artifact_id alone; "
+            f"got {[r.artifact_id for r in tail]}"
+        )
+
+    def test_pagination_returns_empty_after_last_ref(self, tmp_path: Path) -> None:
+        """Cursor at the last ref returns an empty tail regardless of id-lex order."""
+
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        ns = _namespace()
+        _seed(adapter, artifact_id="zzz", sequence_id=1)
+        _seed(adapter, artifact_id="aaa", sequence_id=2)
+
+        # ``aaa`` is the last in the canonical (seq, id) sort.
+        tail = adapter.list_artifacts(ns, after_id="aaa")
+        assert tail == []

--- a/tests/storage/test_local_filesystem_path_layout_rework.py
+++ b/tests/storage/test_local_filesystem_path_layout_rework.py
@@ -123,9 +123,7 @@ class TestLocalFilesystemPssPathLayout:
             f"^pss/[^/]+/[^/]+/[^/]+/[^/]+/artifacts/[^/]+\\.json$"
         )
 
-    def test_write_artifact_top_segment_is_pss_not_portable_artifacts(
-        self, tmp_path: Path
-    ) -> None:
+    def test_write_artifact_top_segment_is_pss_not_portable_artifacts(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
         from hestai_context_mcp.storage.types import WritePrecondition
 
@@ -135,9 +133,9 @@ class TestLocalFilesystemPssPathLayout:
         adapter.write_artifact(ref, artifact, WritePrecondition())
 
         # New layout: pss/ exists; portable/artifacts/{ns}/... does NOT.
-        assert (tmp_path / ".hestai" / "state" / "portable" / "pss").exists(), (
-            "ADR-0013 binding requires top segment 'pss' under portable root"
-        )
+        assert (
+            tmp_path / ".hestai" / "state" / "portable" / "pss"
+        ).exists(), "ADR-0013 binding requires top segment 'pss' under portable root"
         # The legacy 'artifacts/' top-segment subtree at portable/artifacts/{ns}
         # must not be created. (Note: the END-position 'artifacts/' segment
         # under pss/{ns}/{proj}/{ws}/{user}/artifacts IS expected.)
@@ -151,9 +149,7 @@ class TestLocalFilesystemPssPathLayout:
                 f"found: {json_files}"
             )
 
-    def test_write_artifact_does_not_include_v_schema_version_segment(
-        self, tmp_path: Path
-    ) -> None:
+    def test_write_artifact_does_not_include_v_schema_version_segment(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
         from hestai_context_mcp.storage.types import WritePrecondition
 
@@ -166,9 +162,11 @@ class TestLocalFilesystemPssPathLayout:
         assert receipt is not None
         # No segment named v1, v2, etc. The schema_version is a field on
         # PortableMemoryArtifact and PortableNamespace, not a path segment.
-        rel_str = str(Path(receipt).resolve().relative_to(
-            (tmp_path / ".hestai" / "state" / "portable").resolve()
-        ))
+        rel_str = str(
+            Path(receipt)
+            .resolve()
+            .relative_to((tmp_path / ".hestai" / "state" / "portable").resolve())
+        )
         for part in Path(rel_str).parts:
             assert not re.match(r"^v\d+$", part), (
                 f"path segment {part!r} matches v<int> shape; "
@@ -188,8 +186,10 @@ class TestLocalFilesystemPssPathLayout:
 
         receipt = ack.durable_carrier_receipt
         assert receipt is not None
-        rel = Path(receipt).resolve().relative_to(
-            (tmp_path / ".hestai" / "state" / "portable").resolve()
+        rel = (
+            Path(receipt)
+            .resolve()
+            .relative_to((tmp_path / ".hestai" / "state" / "portable").resolve())
         )
         parts = rel.parts
         # Expected: ('pss', ns, proj, ws, user, 'artifacts', '<id>.json')

--- a/tests/storage/test_local_filesystem_path_layout_rework.py
+++ b/tests/storage/test_local_filesystem_path_layout_rework.py
@@ -1,0 +1,205 @@
+"""GROUP_017 — REWORK CYCLE RED tests for RISK_006 path layout drift.
+
+Asserts the binding ruling from CE Stage C: the LocalFilesystemAdapter
+on-disk path layout MUST match the ADR-0013 abstract path
+``pss/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/artifacts/{artifact_id}``.
+
+The current (pre-rework) layout was
+``portable/artifacts/{ns}/{proj}/{ws}/{user}/v{schema_version}/{id}.json``
+which violates the ruling on three counts:
+
+- Top segment is ``portable/artifacts`` instead of ``pss``.
+- The ``artifacts/`` segment lives at the top instead of the END.
+- ``v{schema_version}`` is in the path; ADR-0013 binds schema_version as
+  a field inside PortableMemoryArtifact and PortableNamespace, NOT as a
+  path component (over-specification beyond the binding ruling).
+
+After GREEN: every artifact write produces a file whose path relative to
+the portable root matches::
+
+    ^pss/[^/]+/[^/]+/[^/]+/[^/]+/artifacts/[^/]+\\.json$
+
+The local portable root remains ``.hestai/state/portable/`` per the
+BUILD-PLAN §FILE_LAYOUT NEW_FILE local_filesystem.py STRUCTURE rule
+"Rooted under .hestai/state/portable for local carrier state."
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _identity() -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id="proj-A",
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _make_artifact() -> Any:
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+    from hestai_context_mcp.storage.types import (
+        ArtifactKind,
+        PortableMemoryArtifact,
+    )
+
+    payload = {"k": "v"}
+    provenance = build_provenance_or_raise(
+        input_text="i", output_text="o", redacted_credential_categories=()
+    )
+    return PortableMemoryArtifact(
+        artifact_id="art-rework-001",
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=_identity(),
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=1,
+        parent_ids=(),
+        redaction_provenance=provenance,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_payload_hash(payload),
+        payload=payload,
+    )
+
+
+def _make_ref_for(artifact: Any) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactRef
+
+    return ArtifactRef(
+        artifact_id=artifact.artifact_id,
+        identity=artifact.identity,
+        artifact_kind=artifact.artifact_kind,
+        sequence_id=artifact.sequence_id,
+        created_at=artifact.created_at,
+        payload_hash=artifact.payload_hash,
+        carrier_path="",
+    )
+
+
+# ADR-0013 abstract path regex (relative to the portable root).
+_PSS_PATH_REGEX = re.compile(r"^pss/[^/]+/[^/]+/[^/]+/[^/]+/artifacts/[^/]+\.json$")
+
+
+@pytest.mark.unit
+class TestLocalFilesystemPssPathLayout:
+    """BLOCKER 2 / RISK_006: path geometry must match ADR-0013 abstract path."""
+
+    def test_write_artifact_produces_path_matching_pss_regex(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        # Receipt must match the regex relative to the portable root.
+        receipt = ack.durable_carrier_receipt
+        assert receipt is not None, "PUBLISHED ack must carry a durable_carrier_receipt"
+        portable_root = tmp_path / ".hestai" / "state" / "portable"
+        relative = Path(receipt).resolve().relative_to(portable_root.resolve())
+        assert _PSS_PATH_REGEX.match(str(relative)), (
+            f"path {relative!r} does not match ADR-0013 abstract path regex "
+            f"^pss/[^/]+/[^/]+/[^/]+/[^/]+/artifacts/[^/]+\\.json$"
+        )
+
+    def test_write_artifact_top_segment_is_pss_not_portable_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        # New layout: pss/ exists; portable/artifacts/{ns}/... does NOT.
+        assert (tmp_path / ".hestai" / "state" / "portable" / "pss").exists(), (
+            "ADR-0013 binding requires top segment 'pss' under portable root"
+        )
+        # The legacy 'artifacts/' top-segment subtree at portable/artifacts/{ns}
+        # must not be created. (Note: the END-position 'artifacts/' segment
+        # under pss/{ns}/{proj}/{ws}/{user}/artifacts IS expected.)
+        legacy_top = tmp_path / ".hestai" / "state" / "portable" / "artifacts"
+        # If it exists, it MUST be empty — but the cleanest assertion is that
+        # no JSON files are produced under the legacy top-level path.
+        if legacy_top.exists():
+            json_files = list(legacy_top.rglob("*.json"))
+            assert json_files == [], (
+                f"legacy top-level portable/artifacts/ must not contain artifact files; "
+                f"found: {json_files}"
+            )
+
+    def test_write_artifact_does_not_include_v_schema_version_segment(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        receipt = ack.durable_carrier_receipt
+        assert receipt is not None
+        # No segment named v1, v2, etc. The schema_version is a field on
+        # PortableMemoryArtifact and PortableNamespace, not a path segment.
+        rel_str = str(Path(receipt).resolve().relative_to(
+            (tmp_path / ".hestai" / "state" / "portable").resolve()
+        ))
+        for part in Path(rel_str).parts:
+            assert not re.match(r"^v\d+$", part), (
+                f"path segment {part!r} matches v<int> shape; "
+                "v{schema_version} is over-specification beyond ADR-0013 ruling"
+            )
+
+    def test_write_artifact_artifacts_segment_is_at_end_before_artifact_id(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.local_filesystem import LocalFilesystemAdapter
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        adapter = LocalFilesystemAdapter(working_dir=tmp_path)
+        artifact = _make_artifact()
+        ref = _make_ref_for(artifact)
+        ack = adapter.write_artifact(ref, artifact, WritePrecondition())
+
+        receipt = ack.durable_carrier_receipt
+        assert receipt is not None
+        rel = Path(receipt).resolve().relative_to(
+            (tmp_path / ".hestai" / "state" / "portable").resolve()
+        )
+        parts = rel.parts
+        # Expected: ('pss', ns, proj, ws, user, 'artifacts', '<id>.json')
+        assert len(parts) == 7, (
+            f"expected 7 path segments (pss, ns, proj, ws, user, artifacts, id.json); "
+            f"got {len(parts)}: {parts}"
+        )
+        assert parts[0] == "pss"
+        assert parts[-2] == "artifacts", (
+            f"'artifacts' segment must be second-from-last (just before artifact id); "
+            f"got parts={parts}"
+        )
+        assert parts[-1].endswith(".json")

--- a/tests/storage/test_outbox.py
+++ b/tests/storage/test_outbox.py
@@ -1,0 +1,216 @@
+"""GROUP_007: OUTBOX — RED-first tests for storage/outbox.py.
+
+Asserts the Durable Outbound Queue contract per BUILD-PLAN
+§TDD_TEST_LIST GROUP_007 (TEST_079..TEST_088) and ADR-0013 R7.
+
+Binding rulings exercised here:
+- RISK_008 + G7: B1 implements queue creation + status only — no retry
+  orchestration. Drain/retry tools are deferred until a future ADR.
+- A2 (CIV): clock_out emits a structured ``portable_publication`` status
+  record even when publish is skipped (e.g., no transcript / provenance
+  unavailable). The outbox surface here exposes
+  ``unpublished_memory_exists`` so the clock_out integration can route
+  status without re-implementing queue scanning.
+- R7: queue path is ``.hestai/state/portable/outbox/{artifact_id}.json``.
+- R10: parse errors surface as structured errors, not silent skips.
+- get_context purity: no outbox file is created/modified by reads
+  (TEST_088).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _identity() -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id="proj-A",
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _failed_ack(artifact_id: str = "art-1") -> Any:
+    from hestai_context_mcp.storage.types import PublishAck, PublishStatus
+
+    identity = _identity()
+    return PublishAck(
+        artifact_id=artifact_id,
+        identity=identity,
+        carrier_namespace=identity.carrier_namespace,
+        sequence_id=1,
+        status=PublishStatus.FAILED,
+        durable_carrier_receipt=None,
+        queued_path=None,
+        published_at=None,
+        error_code="adapter_io_error",
+        error_message="simulated failure",
+    )
+
+
+@pytest.mark.unit
+class TestOutboxRoot:
+    """TEST_079."""
+
+    def test_outbox_root_is_hestai_state_portable_outbox(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        assert store.root == tmp_path / ".hestai" / "state" / "portable" / "outbox"
+
+
+@pytest.mark.unit
+class TestEnqueue:
+    """TEST_080..TEST_082."""
+
+    def test_enqueue_unpublished_artifact_writes_json_by_artifact_id(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        ack = _failed_ack(artifact_id="art-42")
+        path = store.enqueue(
+            ack=ack,
+            error_code="adapter_io_error",
+            error_message="simulated failure",
+        )
+        assert path.name == "art-42.json"
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["artifact_id"] == "art-42"
+
+    def test_enqueue_uses_atomic_replace(self, tmp_path: Path) -> None:
+        """Atomic replace: a tmp staging directory is used and the final file
+        is the only one in place after enqueue.
+        """
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        ack = _failed_ack(artifact_id="art-1")
+        path = store.enqueue(ack=ack, error_code="x", error_message="y")
+        # No leftover .tmp file in the outbox dir.
+        assert path.exists()
+        leftovers = [p for p in store.root.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+    def test_outbox_entry_contains_artifact_ack_error_and_retry_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        ack = _failed_ack(artifact_id="art-77")
+        path = store.enqueue(
+            ack=ack,
+            error_code="adapter_io_error",
+            error_message="simulated failure",
+        )
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for k in (
+            "artifact_id",
+            "identity",
+            "carrier_namespace",
+            "sequence_id",
+            "status",
+            "error_code",
+            "error_message",
+            "enqueued_at",
+            "retry_count",
+        ):
+            assert k in data, f"missing key {k!r}"
+        # B1 status-only: retry_count starts at 0 and is never advanced
+        # automatically (RISK_008 + G7).
+        assert data["retry_count"] == 0
+
+
+@pytest.mark.unit
+class TestStatus:
+    """TEST_083..TEST_084."""
+
+    def test_outbox_status_true_when_entries_exist(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        store.enqueue(ack=_failed_ack("a-1"), error_code="x", error_message="y")
+        assert store.unpublished_memory_exists() is True
+
+    def test_outbox_status_false_when_empty(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        assert store.unpublished_memory_exists() is False
+
+
+@pytest.mark.unit
+class TestList:
+    """TEST_085..TEST_086."""
+
+    def test_list_outbox_entries_is_deterministic(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        store.enqueue(ack=_failed_ack("a-3"), error_code="x", error_message="y")
+        store.enqueue(ack=_failed_ack("a-1"), error_code="x", error_message="y")
+        store.enqueue(ack=_failed_ack("a-2"), error_code="x", error_message="y")
+        ids = [e["artifact_id"] for e in store.list_entries()]
+        assert ids == ["a-1", "a-2", "a-3"]
+
+    def test_outbox_unknown_entry_parse_error_is_structured(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxParseError, OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        store.root.mkdir(parents=True, exist_ok=True)
+        bad = store.root / "broken.json"
+        bad.write_text("{not-json")
+        with pytest.raises(OutboxParseError):
+            store.list_entries()
+
+
+@pytest.mark.unit
+class TestClassification:
+    """TEST_087."""
+
+    def test_outbox_is_classified_local_mutable(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        from hestai_context_mcp.storage.types import StateClassification
+
+        store = OutboxStore(working_dir=tmp_path)
+        assert store.classification is StateClassification.LOCAL_MUTABLE
+
+
+@pytest.mark.unit
+class TestPurityIntegration:
+    """TEST_088 — get_context never touches outbox files."""
+
+    def test_get_context_does_not_touch_outbox_mtime(self, tmp_path: Path) -> None:
+        # Set up a project with a North Star and an outbox entry.
+        (tmp_path / ".hestai" / "north-star").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".hestai" / "north-star" / "000-PROJECT-NORTH-STAR.oct.md").write_text("ns")
+
+        from hestai_context_mcp.storage.outbox import OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        store.enqueue(ack=_failed_ack("art-py"), error_code="x", error_message="y")
+        outbox_files = list(store.root.glob("*.json"))
+        assert outbox_files
+        before = {p: p.stat().st_mtime_ns for p in outbox_files}
+        # Nudge the clock so any unintended mtime change becomes visible
+        # if the call writes anything.
+        time.sleep(0.005)
+
+        from hestai_context_mcp.tools.get_context import get_context
+
+        get_context(working_dir=str(tmp_path))
+
+        after = {p: p.stat().st_mtime_ns for p in outbox_files}
+        for p in outbox_files:
+            assert before[p] == after[p], f"get_context modified outbox file {p}"

--- a/tests/storage/test_outbox.py
+++ b/tests/storage/test_outbox.py
@@ -180,7 +180,6 @@ class TestClassification:
 
     def test_outbox_is_classified_local_mutable(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.outbox import OutboxStore
-
         from hestai_context_mcp.storage.types import StateClassification
 
         store = OutboxStore(working_dir=tmp_path)

--- a/tests/storage/test_outbox_unicode_decode.py
+++ b/tests/storage/test_outbox_unicode_decode.py
@@ -1,0 +1,38 @@
+"""Cubic rework cycle 2 — Finding #9 (P2, outbox.py:169).
+
+RED-first test: ``OutboxStore.list_entries`` must raise ``OutboxParseError``
+for ALL parse failures, not just JSONDecodeError. ``read_text(encoding=
+"utf-8")`` raises UnicodeDecodeError when the file contains non-UTF-8
+bytes. The current ``except (OSError, json.JSONDecodeError)`` misses
+this case and the UnicodeDecodeError leaks unstructured (PROD::I4
+STRUCTURED_RETURN_SHAPES violation, R10 fail-closed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestOutboxNonUtf8DecodeFailsStructured:
+    """Cubic P2 #9: UnicodeDecodeError must be wrapped as OutboxParseError."""
+
+    def test_non_utf8_bytes_raise_outbox_parse_error_not_unicode_decode_error(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.outbox import OutboxParseError, OutboxStore
+
+        store = OutboxStore(working_dir=tmp_path)
+        # Create a non-UTF-8 outbox entry — invalid byte 0xFF in standalone.
+        store.root.mkdir(parents=True, exist_ok=True)
+        bad = store.root / "bad.json"
+        bad.write_bytes(b"\xff\xfe\xfd not utf-8")
+
+        # Must wrap the decode failure structurally; no UnicodeDecodeError leak.
+        with pytest.raises(OutboxParseError) as excinfo:
+            store.list_entries()
+
+        assert excinfo.value.code == "outbox_entry_parse_failed"
+        assert str(bad) == excinfo.value.path

--- a/tests/storage/test_projection.py
+++ b/tests/storage/test_projection.py
@@ -1,0 +1,277 @@
+"""GROUP_010: PROJECTION_RESTORE — RED-first tests for storage/projection.py.
+
+Asserts the deterministic projection builder per BUILD-PLAN
+§TDD_TEST_LIST GROUP_010 (TEST_109..TEST_118) and ADR-0013
+R3/R4/R5/R8/R9/R10.
+
+Binding rulings exercised here:
+- R9: monotonic merge, idempotent same-hash duplicates, structured
+  conflict for different-hash duplicates.
+- R8: tombstones are applied BEFORE merge so the projection never
+  contains a tombstoned artifact (A3 — tombstone round-trip).
+- R10 / INVARIANT_004: same artifacts on different machine roots
+  produce the same projection shape (no machine-specific absolute
+  paths leaking into portable fields).
+- R10 / INVARIANT_005: hydration failure is a structured error, not a
+  silent empty fallback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+
+def _identity(*, project_id: str = "proj-A") -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id=project_id,
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _provenance() -> Any:
+    from hestai_context_mcp.storage.provenance import build_provenance_or_raise
+
+    return build_provenance_or_raise(
+        input_text="i",
+        output_text="o",
+        redacted_credential_categories=(),
+    )
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _memory(
+    *,
+    artifact_id: str,
+    sequence_id: int,
+    payload: dict[str, Any] | None = None,
+    identity: Any | None = None,
+) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactKind, PortableMemoryArtifact
+
+    payload = payload or {"id": artifact_id}
+    identity = identity or _identity()
+    return PortableMemoryArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=_provenance(),
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=_hash_payload(payload),
+        payload=payload,
+    )
+
+
+def _tombstone(
+    *,
+    artifact_id: str,
+    sequence_id: int,
+    target_artifact_id: str,
+    reason: str = "user-revoked",
+) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactKind, TombstoneArtifact
+
+    identity = _identity()
+    return TombstoneArtifact(
+        artifact_id=artifact_id,
+        artifact_kind=ArtifactKind.TOMBSTONE,
+        identity=identity,
+        schema_version=1,
+        producer_version="1",
+        minimum_reader_version=1,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(target_artifact_id,),
+        target_artifact_id=target_artifact_id,
+        reason=reason,
+        publisher_identity=identity,
+        redaction_provenance=None,
+        classification_label="PORTABLE_MEMORY",
+        payload_hash=hashlib.sha256(target_artifact_id.encode()).hexdigest(),
+    )
+
+
+@pytest.mark.unit
+class TestProjectionOrdering:
+    """TEST_109."""
+
+    def test_projection_sorts_artifacts_by_sequence_then_id(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        a3 = _memory(artifact_id="art-3", sequence_id=3)
+        a1 = _memory(artifact_id="art-1", sequence_id=1)
+        a2b = _memory(artifact_id="art-2-beta", sequence_id=2)
+        a2a = _memory(artifact_id="art-2-alpha", sequence_id=2)
+        result = build_projection(
+            identity=_identity(),
+            artifacts=(a3, a1, a2b, a2a),
+            tombstones=(),
+        )
+        ids = [r["artifact_id"] for r in result["artifact_refs"]]
+        assert ids == ["art-1", "art-2-alpha", "art-2-beta", "art-3"]
+
+
+@pytest.mark.unit
+class TestProjectionIdentityGuards:
+    """TEST_110."""
+
+    def test_projection_rejects_mixed_identity_artifacts(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        from hestai_context_mcp.storage.identity import IdentityValidationError
+
+        a1 = _memory(artifact_id="art-1", sequence_id=1)
+        a2 = _memory(artifact_id="art-2", sequence_id=2, identity=_identity(project_id="proj-X"))
+        with pytest.raises(IdentityValidationError):
+            build_projection(identity=_identity(), artifacts=(a1, a2), tombstones=())
+
+
+@pytest.mark.unit
+class TestProjectionTombstones:
+    """TEST_111..TEST_113 (A3 tombstone round-trip)."""
+
+    def test_projection_applies_tombstones_before_merge(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        a1 = _memory(artifact_id="art-1", sequence_id=1)
+        a2 = _memory(artifact_id="art-2", sequence_id=2)
+        t1 = _tombstone(artifact_id="tomb-1", sequence_id=3, target_artifact_id="art-1")
+        result = build_projection(
+            identity=_identity(),
+            artifacts=(a1, a2),
+            tombstones=(t1,),
+        )
+        ids = [r["artifact_id"] for r in result["artifact_refs"]]
+        assert "art-1" not in ids
+        assert "art-2" in ids
+        # Tombstone is recorded but does NOT count as a memory ref.
+        assert "tombstoned_artifact_ids" in result
+        assert result["tombstoned_artifact_ids"] == ["art-1"]
+
+    def test_projection_excludes_tombstoned_memory_artifact(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        a1 = _memory(artifact_id="art-1", sequence_id=1, payload={"keep": False})
+        t1 = _tombstone(artifact_id="tomb-1", sequence_id=2, target_artifact_id="art-1")
+        result = build_projection(identity=_identity(), artifacts=(a1,), tombstones=(t1,))
+        assert all(r["artifact_id"] != "art-1" for r in result["artifact_refs"])
+        # Payload merge does not contain the tombstoned artifact's payload.
+        for r in result["artifact_refs"]:
+            assert r.get("payload", {}).get("keep") is not False
+
+    def test_projection_preserves_tombstone_semantics_after_compaction_input(self) -> None:
+        """B1 has no compaction; the projection still treats compacted
+        inputs identically to raw inputs — tombstones still apply."""
+        from hestai_context_mcp.storage.projection import build_projection
+
+        a1 = _memory(artifact_id="art-1", sequence_id=1)
+        a2 = _memory(artifact_id="art-2", sequence_id=2)
+        t1 = _tombstone(artifact_id="tomb-1", sequence_id=3, target_artifact_id="art-1")
+        # Caller pre-sorted (simulated compaction). Build_projection still
+        # applies the tombstone.
+        result = build_projection(
+            identity=_identity(),
+            artifacts=(a1, a2),
+            tombstones=(t1,),
+        )
+        ids = [r["artifact_id"] for r in result["artifact_refs"]]
+        assert "art-1" not in ids
+
+
+@pytest.mark.unit
+class TestProjectionDuplicates:
+    """TEST_114..TEST_115."""
+
+    def test_duplicate_artifact_ids_same_hash_are_idempotent(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        a = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 1})
+        # Same id + identical payload (so same payload_hash).
+        a2 = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 1})
+        result = build_projection(identity=_identity(), artifacts=(a, a2), tombstones=())
+        ids = [r["artifact_id"] for r in result["artifact_refs"]]
+        assert ids == ["art-1"]
+
+    def test_duplicate_artifact_ids_different_hash_are_structured_error(self) -> None:
+        from hestai_context_mcp.storage.projection import (
+            ProjectionError,
+            build_projection,
+        )
+
+        a = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 1})
+        b = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 2})
+        with pytest.raises(ProjectionError):
+            build_projection(identity=_identity(), artifacts=(a, b), tombstones=())
+
+
+@pytest.mark.unit
+class TestProjectionDeterminism:
+    """TEST_116..TEST_117 (R10 / INVARIANT_004)."""
+
+    def test_projection_shape_identical_across_machine_roots(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        # Same artifact set under different "machine root" carrier_paths
+        # (which are in ArtifactRef, not in the artifact itself). The
+        # projection works directly on artifacts, so it must be
+        # path-independent.
+        a1 = _memory(artifact_id="art-1", sequence_id=1, payload={"x": 1})
+        a2 = _memory(artifact_id="art-2", sequence_id=2, payload={"y": 2})
+        r1 = build_projection(identity=_identity(), artifacts=(a1, a2), tombstones=())
+        r2 = build_projection(identity=_identity(), artifacts=(a1, a2), tombstones=())
+        assert r1 == r2
+
+    def test_projection_allows_absolute_paths_only_in_explicit_local_fields(self) -> None:
+        from hestai_context_mcp.storage.projection import build_projection
+
+        # Absolute path in payload would leak machine identity. The
+        # projection must NOT introduce absolute paths on its own; if a
+        # caller smuggles one into a payload, the projection must still
+        # be deterministic, but absolute paths must NOT appear in the
+        # top-level metadata fields.
+        a1 = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 1})
+        result = build_projection(identity=_identity(), artifacts=(a1,), tombstones=())
+        # Top-level identity / artifact_refs must not contain leaked
+        # absolute paths.
+        assert "/" not in result["identity"]["project_id"]
+        for r in result["artifact_refs"]:
+            assert "/" not in r["artifact_id"]
+
+
+@pytest.mark.unit
+class TestProjectionFailureClosed:
+    """TEST_118 — INVARIANT_005."""
+
+    def test_projection_failure_is_structured_not_silent_empty(self) -> None:
+        from hestai_context_mcp.storage.projection import (
+            ProjectionError,
+            build_projection,
+        )
+
+        # Mixed identity is one failure mode; verify the *empty* fallback
+        # is NOT taken — i.e. the function raises rather than returning
+        # an empty projection.
+        a = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 1})
+        b = _memory(artifact_id="art-1", sequence_id=1, payload={"v": 2})
+        with pytest.raises(ProjectionError):
+            build_projection(identity=_identity(), artifacts=(a, b), tombstones=())

--- a/tests/storage/test_projection.py
+++ b/tests/storage/test_projection.py
@@ -136,9 +136,8 @@ class TestProjectionIdentityGuards:
     """TEST_110."""
 
     def test_projection_rejects_mixed_identity_artifacts(self) -> None:
-        from hestai_context_mcp.storage.projection import build_projection
-
         from hestai_context_mcp.storage.identity import IdentityValidationError
+        from hestai_context_mcp.storage.projection import build_projection
 
         a1 = _memory(artifact_id="art-1", sequence_id=1)
         a2 = _memory(artifact_id="art-2", sequence_id=2, identity=_identity(project_id="proj-X"))

--- a/tests/storage/test_provenance.py
+++ b/tests/storage/test_provenance.py
@@ -1,0 +1,289 @@
+"""GROUP_005: REDACTION_PROVENANCE — RED-first tests for storage/provenance.py.
+
+Asserts the redaction provenance contract per ADR-0013 R6 + R10 and the
+binding rulings:
+- RISK_004 + G6: ``REDACTION_ENGINE_NAME`` and ``REDACTION_ENGINE_VERSION``
+  constants live in ``core.redaction`` and propagate into every
+  RedactionProvenance metadata block; the version bumps on pattern or
+  semantic change (A4 contract test).
+- RISK_010: publication fails closed when provenance is incomplete.
+- G4 (CIV): write_artifact paths MUST wrap RedactionProvenance construction
+  in a single atomic guard that raises BEFORE any filesystem write. This
+  group provides the guard helper that downstream groups (006,
+  012) consume.
+
+R-trace: see BUILD-PLAN §TDD_TEST_LIST GROUP_005_REDACTION_PROVENANCE +
+INVARIANT_003.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime, timezone
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRulesetHashDeterministic:
+    """TEST_045: ruleset hash deterministic for current PATTERNS."""
+
+    def test_ruleset_hash_is_deterministic_for_redaction_patterns(self) -> None:
+        from hestai_context_mcp.storage.provenance import compute_ruleset_hash
+
+        h1 = compute_ruleset_hash()
+        h2 = compute_ruleset_hash()
+        assert h1 == h2
+        # Hex digest, non-empty.
+        assert isinstance(h1, str) and len(h1) >= 16
+        int(h1, 16)  # parses as hex
+
+
+@pytest.mark.unit
+class TestEngineNameAndVersion:
+    """TEST_046 + RISK_004 + G6: provenance carries engine name + version."""
+
+    def test_redaction_provenance_contains_engine_name_and_version(self) -> None:
+        from hestai_context_mcp.core.redaction import (
+            REDACTION_ENGINE_NAME,
+            REDACTION_ENGINE_VERSION,
+        )
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="hello sk-AAAAAAAAAAAAAAAAAAAAAA world",
+            output_text="hello [REDACTED_API_KEY] world",
+            redacted_credential_categories=("ai_api_key",),
+        )
+        assert prov.engine_name == REDACTION_ENGINE_NAME
+        assert prov.engine_version == REDACTION_ENGINE_VERSION
+        # G6: REDACTION_ENGINE_VERSION constant is a string and is asserted
+        # present in artifact metadata via this provenance object.
+        assert isinstance(REDACTION_ENGINE_VERSION, str) and REDACTION_ENGINE_VERSION
+
+
+@pytest.mark.unit
+class TestHashesPresent:
+    """TEST_047: input + output hashes present and distinct for non-trivial input."""
+
+    def test_redaction_provenance_contains_input_and_output_hashes(self) -> None:
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="hello sk-AAAAAAAAAAAAAAAAAAAAAA world",
+            output_text="hello [REDACTED_API_KEY] world",
+            redacted_credential_categories=("ai_api_key",),
+        )
+        assert prov.input_artifact_hash and prov.output_artifact_hash
+        assert prov.input_artifact_hash != prov.output_artifact_hash
+
+
+@pytest.mark.unit
+class TestTimestampTimezoneAware:
+    """TEST_048: redacted_at is timezone-aware."""
+
+    def test_redaction_provenance_timestamp_is_timezone_aware(self) -> None:
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="x",
+            output_text="x",
+            redacted_credential_categories=(),
+        )
+        assert prov.redacted_at.tzinfo is not None
+
+
+@pytest.mark.unit
+class TestClassificationLabel:
+    """TEST_049: classification_label gate is PORTABLE_MEMORY."""
+
+    def test_redaction_provenance_classification_must_be_portable_memory(self) -> None:
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="x", output_text="x", redacted_credential_categories=()
+        )
+        assert prov.classification_label == "PORTABLE_MEMORY"
+
+
+@pytest.mark.unit
+class TestCategoriesNormalization:
+    """TEST_050: redacted_credential_categories may be empty, never None."""
+
+    def test_redacted_categories_can_be_empty_but_not_none(self) -> None:
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="x", output_text="x", redacted_credential_categories=()
+        )
+        assert prov.redacted_credential_categories == ()
+
+
+@pytest.mark.unit
+class TestCompletenessValidation:
+    """TEST_051..TEST_054: any missing field fails complete-provenance validation."""
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("engine_name", ""),
+            ("engine_version", ""),
+            ("ruleset_hash", ""),
+            ("input_artifact_hash", ""),
+            ("output_artifact_hash", ""),
+        ],
+    )
+    def test_missing_field_fails_complete_provenance_validation(
+        self, field: str, value: str
+    ) -> None:
+        from hestai_context_mcp.storage.provenance import (
+            ProvenanceIncompleteError,
+            build_provenance,
+            validate_provenance_complete,
+        )
+
+        prov = build_provenance(
+            input_text="x", output_text="x", redacted_credential_categories=()
+        )
+        broken = dataclasses.replace(prov, **{field: value})
+        with pytest.raises(ProvenanceIncompleteError) as excinfo:
+            validate_provenance_complete(broken)
+        assert excinfo.value.code == "provenance_incomplete"
+        assert excinfo.value.missing_field == field
+
+
+@pytest.mark.unit
+class TestStaleRulesetHashFails:
+    """TEST_055: stale ruleset hash fails publication validation."""
+
+    def test_stale_ruleset_hash_fails_publication_validation(self) -> None:
+        from hestai_context_mcp.storage.provenance import (
+            ProvenanceStaleError,
+            assert_ruleset_hash_current,
+            build_provenance,
+        )
+
+        prov = build_provenance(
+            input_text="x", output_text="x", redacted_credential_categories=()
+        )
+        stale = dataclasses.replace(prov, ruleset_hash="0" * 64)
+        with pytest.raises(ProvenanceStaleError) as excinfo:
+            assert_ruleset_hash_current(stale)
+        assert excinfo.value.code == "ruleset_hash_stale"
+
+
+@pytest.mark.unit
+class TestRedactionResultIntegration:
+    """TEST_056: RedactionEngine.redact result feeds provenance categories."""
+
+    def test_existing_redaction_engine_redacted_types_feed_provenance_categories(self) -> None:
+        from hestai_context_mcp.core.redaction import RedactionEngine
+        from hestai_context_mcp.storage.provenance import build_provenance_from_result
+
+        engine = RedactionEngine()
+        text = "Bearer abc123== and AKIAABCDEFGHIJKLMNOP"
+        result = engine.redact(text)
+        prov = build_provenance_from_result(input_text=text, result=result)
+        assert set(prov.redacted_credential_categories) == set(result.redacted_types)
+        assert prov.input_artifact_hash != prov.output_artifact_hash
+
+
+@pytest.mark.unit
+class TestG4AtomicGuard:
+    """G4: build_provenance_or_raise raises BEFORE any side effect when incomplete.
+
+    This is the atomic guard helper that storage/local_filesystem.py and
+    clock_out wrap their write paths in (RISK_010 fail-closed publish).
+    """
+
+    def test_atomic_guard_raises_before_any_write_when_incomplete(self) -> None:
+        from hestai_context_mcp.storage.provenance import (
+            ProvenanceIncompleteError,
+            build_provenance_or_raise,
+        )
+
+        with pytest.raises(ProvenanceIncompleteError):
+            # Empty input/output with no categories is permitted (categories
+            # may be empty per NOTE_009), but blank engine version triggers
+            # the guard via override.
+            build_provenance_or_raise(
+                input_text="x",
+                output_text="x",
+                redacted_credential_categories=(),
+                engine_version_override="",
+            )
+
+
+@pytest.mark.unit
+class TestRedactionEngineVersionBumpContract:
+    """A4: REDACTION_ENGINE_VERSION bump asserts metadata persistence.
+
+    The RISK_004 ruling is that the version is bumped when patterns or
+    semantics change. We assert the bump *contract* by computing a stable
+    digest over PATTERNS at the version's documented snapshot — if anyone
+    edits PATTERNS without bumping REDACTION_ENGINE_VERSION, this test
+    fails and forces the human bump.
+    """
+
+    def test_redaction_engine_version_matches_pattern_set_snapshot(self) -> None:
+        from hestai_context_mcp.core.redaction import (
+            REDACTION_ENGINE_VERSION,
+            RedactionEngine,
+        )
+        from hestai_context_mcp.storage.provenance import compute_ruleset_hash
+
+        # The current PATTERNS set has these named keys; if a new pattern
+        # is added or an existing one renamed, this snapshot must be
+        # updated AND REDACTION_ENGINE_VERSION must be bumped.
+        snapshot_keys = sorted(RedactionEngine.PATTERNS.keys())
+        assert snapshot_keys == [
+            "ai_api_key",
+            "aws_key",
+            "bearer_token",
+            "db_password",
+            "private_key",
+        ], (
+            "RedactionEngine.PATTERNS changed — bump REDACTION_ENGINE_VERSION "
+            "in core.redaction and update this snapshot."
+        )
+        # Version must be a non-empty string; bump cycle is human-driven
+        # (RISK_004). For B1 the documented value is '1'.
+        assert REDACTION_ENGINE_VERSION == "1"
+        # Ruleset hash is computed from PATTERNS — assert it matches a
+        # stored snapshot. We don't pin the exact hex here (it would
+        # over-couple to regex internals); we assert that toggling a
+        # pattern changes the hash deterministically.
+        h_now = compute_ruleset_hash()
+        # mutate-and-restore round trip: alter a pattern's replacement,
+        # confirm hash changes, then restore.
+        original = RedactionEngine.PATTERNS["ai_api_key"]
+        try:
+            RedactionEngine.PATTERNS["ai_api_key"] = (
+                original[0],
+                "[REDACTED_API_KEY_v2]",
+            )
+            h_after = compute_ruleset_hash()
+            assert h_now != h_after
+        finally:
+            RedactionEngine.PATTERNS["ai_api_key"] = original
+        h_restored = compute_ruleset_hash()
+        assert h_now == h_restored
+
+
+@pytest.mark.unit
+class TestProvenanceClassificationLiteral:
+    """CRS C1: classification_label is the Literal['PORTABLE_MEMORY']."""
+
+    def test_provenance_classification_literal(self) -> None:
+        from hestai_context_mcp.storage.provenance import build_provenance
+
+        prov = build_provenance(
+            input_text="x", output_text="x", redacted_credential_categories=()
+        )
+        assert prov.classification_label == "PORTABLE_MEMORY"
+        # tzinfo robustness across Python timezone module variants
+        _ = timezone.utc
+        _ = UTC
+        assert prov.redacted_at.tzinfo is not None
+        # not naive
+        assert prov.redacted_at != datetime.utcnow()

--- a/tests/storage/test_provenance.py
+++ b/tests/storage/test_provenance.py
@@ -19,7 +19,7 @@ INVARIANT_003.
 from __future__ import annotations
 
 import dataclasses
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -100,9 +100,7 @@ class TestClassificationLabel:
     def test_redaction_provenance_classification_must_be_portable_memory(self) -> None:
         from hestai_context_mcp.storage.provenance import build_provenance
 
-        prov = build_provenance(
-            input_text="x", output_text="x", redacted_credential_categories=()
-        )
+        prov = build_provenance(input_text="x", output_text="x", redacted_credential_categories=())
         assert prov.classification_label == "PORTABLE_MEMORY"
 
 
@@ -113,9 +111,7 @@ class TestCategoriesNormalization:
     def test_redacted_categories_can_be_empty_but_not_none(self) -> None:
         from hestai_context_mcp.storage.provenance import build_provenance
 
-        prov = build_provenance(
-            input_text="x", output_text="x", redacted_credential_categories=()
-        )
+        prov = build_provenance(input_text="x", output_text="x", redacted_credential_categories=())
         assert prov.redacted_credential_categories == ()
 
 
@@ -142,9 +138,7 @@ class TestCompletenessValidation:
             validate_provenance_complete,
         )
 
-        prov = build_provenance(
-            input_text="x", output_text="x", redacted_credential_categories=()
-        )
+        prov = build_provenance(input_text="x", output_text="x", redacted_credential_categories=())
         broken = dataclasses.replace(prov, **{field: value})
         with pytest.raises(ProvenanceIncompleteError) as excinfo:
             validate_provenance_complete(broken)
@@ -163,9 +157,7 @@ class TestStaleRulesetHashFails:
             build_provenance,
         )
 
-        prov = build_provenance(
-            input_text="x", output_text="x", redacted_credential_categories=()
-        )
+        prov = build_provenance(input_text="x", output_text="x", redacted_credential_categories=())
         stale = dataclasses.replace(prov, ruleset_hash="0" * 64)
         with pytest.raises(ProvenanceStaleError) as excinfo:
             assert_ruleset_hash_current(stale)
@@ -277,12 +269,10 @@ class TestProvenanceClassificationLiteral:
     def test_provenance_classification_literal(self) -> None:
         from hestai_context_mcp.storage.provenance import build_provenance
 
-        prov = build_provenance(
-            input_text="x", output_text="x", redacted_credential_categories=()
-        )
+        prov = build_provenance(input_text="x", output_text="x", redacted_credential_categories=())
         assert prov.classification_label == "PORTABLE_MEMORY"
         # tzinfo robustness across Python timezone module variants
-        _ = timezone.utc
+        _ = UTC
         _ = UTC
         assert prov.redacted_at.tzinfo is not None
         # not naive

--- a/tests/storage/test_schema.py
+++ b/tests/storage/test_schema.py
@@ -1,0 +1,258 @@
+"""GROUP_004: SCHEMA_AND_MIGRATION — RED-first tests for storage/schema.py.
+
+Asserts the portable artifact schema versioning + migration framework per
+ADR-0013 R4 + R10:
+- ``CURRENT_SCHEMA_VERSION = 1``.
+- ``SUPPORTED_SCHEMA_VERSIONS`` contains 1 (and only 1 for B1).
+- A migration registry exists (with at least the v1 identity migration).
+- Artifacts whose ``minimum_reader_version`` exceeds support fail closed
+  with a structured ``SchemaTooNewError`` (R10 / fail-closed restore).
+- Validators reject identity/schema mismatch, missing payload_hash,
+  negative sequence_id, and non-PORTABLE_MEMORY classification.
+- Hydration failure produces a structured error, never silent empty
+  fallback (INVARIANT_005).
+
+R-trace: see BUILD-PLAN §TDD_TEST_LIST GROUP_004_SCHEMA_AND_MIGRATION.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from hestai_context_mcp.storage.types import (
+    ArtifactKind,
+    IdentityTuple,
+    PortableMemoryArtifact,
+    RedactionProvenance,
+)
+
+
+def _identity() -> IdentityTuple:
+    return IdentityTuple(
+        project_id="hestai-context-mcp",
+        workspace_id="build-adr-13",
+        user_id="shaun",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _provenance() -> RedactionProvenance:
+    return RedactionProvenance(
+        engine_name="hestai-context-mcp.redaction",
+        engine_version="1",
+        ruleset_hash="rh-v1",
+        input_artifact_hash="ih",
+        output_artifact_hash="oh",
+        redacted_at=datetime.now(UTC),
+        classification_label="PORTABLE_MEMORY",
+        redacted_credential_categories=(),
+    )
+
+
+def _make_artifact(
+    *,
+    schema_version: int = 1,
+    minimum_reader_version: int = 1,
+    sequence_id: int = 1,
+    payload_hash: str = "ph",
+    classification_label: str = "PORTABLE_MEMORY",
+) -> PortableMemoryArtifact:
+    return PortableMemoryArtifact(
+        artifact_id="a1",
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        identity=_identity(),
+        schema_version=schema_version,
+        producer_version="0.1.0",
+        minimum_reader_version=minimum_reader_version,
+        created_at=datetime.now(UTC),
+        sequence_id=sequence_id,
+        parent_ids=(),
+        redaction_provenance=_provenance(),
+        classification_label=classification_label,  # type: ignore[arg-type]
+        payload_hash=payload_hash,
+        payload={"k": "v"},
+    )
+
+
+@pytest.mark.unit
+class TestCurrentSchemaVersion:
+    """TEST_033: CURRENT_SCHEMA_VERSION = 1."""
+
+    def test_current_schema_version_is_one(self) -> None:
+        from hestai_context_mcp.storage.schema import CURRENT_SCHEMA_VERSION
+
+        assert CURRENT_SCHEMA_VERSION == 1
+
+
+@pytest.mark.unit
+class TestSchemaSupport:
+    """TEST_034: v1 artifacts are supported by reader."""
+
+    def test_v1_artifact_supported_by_reader(self) -> None:
+        from hestai_context_mcp.storage.schema import is_artifact_supported
+
+        artifact = _make_artifact(schema_version=1, minimum_reader_version=1)
+        assert is_artifact_supported(artifact) is True
+
+
+@pytest.mark.unit
+class TestMinimumReaderVersionFailClosed:
+    """TEST_035 + TEST_036: minimum_reader_version above CURRENT fails closed."""
+
+    def test_minimum_reader_version_above_supported_fails_closed(self) -> None:
+        from hestai_context_mcp.storage.schema import is_artifact_supported
+
+        artifact = _make_artifact(schema_version=2, minimum_reader_version=2)
+        assert is_artifact_supported(artifact) is False
+
+    def test_schema_too_new_error_is_structured(self) -> None:
+        from hestai_context_mcp.storage.schema import SchemaTooNewError, validate_artifact
+
+        artifact = _make_artifact(schema_version=2, minimum_reader_version=2)
+        with pytest.raises(SchemaTooNewError) as excinfo:
+            validate_artifact(artifact)
+        assert excinfo.value.code == "schema_too_new"
+        assert excinfo.value.minimum_reader_version == 2
+
+
+@pytest.mark.unit
+class TestUnknownOptionalFieldsIgnored:
+    """TEST_037: optional fields ignored when minimum_reader_version allows."""
+
+    def test_unknown_optional_fields_ignored_when_min_reader_allows(self) -> None:
+        from hestai_context_mcp.storage.schema import parse_artifact_dict
+
+        # An artifact dict with an unknown forward-compatible field should
+        # parse successfully when minimum_reader_version <= CURRENT.
+        raw = {
+            "artifact_id": "a1",
+            "artifact_kind": ArtifactKind.PORTABLE_MEMORY.value,
+            "identity": {
+                "project_id": "p",
+                "workspace_id": "w",
+                "user_id": "u",
+                "state_schema_version": 1,
+                "carrier_namespace": "personal",
+            },
+            "schema_version": 1,
+            "producer_version": "0.1.0",
+            "minimum_reader_version": 1,
+            "created_at": datetime.now(UTC).isoformat(),
+            "sequence_id": 1,
+            "parent_ids": [],
+            "redaction_provenance": {
+                "engine_name": "e",
+                "engine_version": "1",
+                "ruleset_hash": "r",
+                "input_artifact_hash": "i",
+                "output_artifact_hash": "o",
+                "redacted_at": datetime.now(UTC).isoformat(),
+                "classification_label": "PORTABLE_MEMORY",
+                "redacted_credential_categories": [],
+            },
+            "classification_label": "PORTABLE_MEMORY",
+            "payload_hash": "ph",
+            "payload": {"k": "v"},
+            # Unknown forward-compat field:
+            "future_only_field": "should-be-ignored",
+        }
+        artifact = parse_artifact_dict(raw)
+        assert isinstance(artifact, PortableMemoryArtifact)
+        assert artifact.artifact_id == "a1"
+
+
+@pytest.mark.unit
+class TestMigrationRegistry:
+    """TEST_038/TEST_039: registry exists with at least the v1 identity migration."""
+
+    def test_v1_migration_returns_projection_artifact_without_rewriting_source(self) -> None:
+        from hestai_context_mcp.storage.schema import migrate_into_projection
+
+        artifact = _make_artifact()
+        projection = migrate_into_projection(artifact)
+        # v1 migration: returns artifact unchanged (identity migration).
+        assert projection.artifact_id == artifact.artifact_id
+        assert projection.schema_version == artifact.schema_version
+
+    def test_migration_registry_has_entry_for_v1(self) -> None:
+        from hestai_context_mcp.storage.schema import MIGRATION_REGISTRY
+
+        assert 1 in MIGRATION_REGISTRY
+        # Identity migration is callable.
+        assert callable(MIGRATION_REGISTRY[1])
+
+
+@pytest.mark.unit
+class TestSchemaValidation:
+    """TEST_040..TEST_043: validators reject inconsistent artifacts."""
+
+    def test_schema_validation_rejects_identity_schema_mismatch(self) -> None:
+        from hestai_context_mcp.storage.schema import (
+            SchemaValidationError,
+            validate_artifact,
+        )
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        identity = IdentityTuple(
+            project_id="p",
+            workspace_id="w",
+            user_id="u",
+            state_schema_version=99,  # mismatch vs schema_version=1
+            carrier_namespace="personal",
+        )
+        artifact = _make_artifact()
+        # Replace identity via dataclasses.replace to keep frozen contract.
+        import dataclasses
+
+        artifact = dataclasses.replace(artifact, identity=identity, schema_version=1)
+        with pytest.raises(SchemaValidationError) as excinfo:
+            validate_artifact(artifact)
+        assert excinfo.value.code == "identity_schema_mismatch"
+
+    def test_schema_validation_rejects_missing_payload_hash(self) -> None:
+        from hestai_context_mcp.storage.schema import (
+            SchemaValidationError,
+            validate_artifact,
+        )
+
+        artifact = _make_artifact(payload_hash="")
+        with pytest.raises(SchemaValidationError) as excinfo:
+            validate_artifact(artifact)
+        assert excinfo.value.code == "missing_payload_hash"
+
+    def test_schema_validation_rejects_negative_sequence_id(self) -> None:
+        from hestai_context_mcp.storage.schema import (
+            SchemaValidationError,
+            validate_artifact,
+        )
+
+        artifact = _make_artifact(sequence_id=-1)
+        with pytest.raises(SchemaValidationError) as excinfo:
+            validate_artifact(artifact)
+        assert excinfo.value.code == "non_monotonic_sequence_id"
+
+    def test_schema_validation_rejects_non_portable_classification(self) -> None:
+        from hestai_context_mcp.storage.schema import (
+            SchemaValidationError,
+            validate_artifact,
+        )
+
+        artifact = _make_artifact(classification_label="LOCAL_MUTABLE")
+        with pytest.raises(SchemaValidationError) as excinfo:
+            validate_artifact(artifact)
+        assert excinfo.value.code == "non_portable_classification"
+
+
+@pytest.mark.unit
+class TestRestoreFailureNotSilent:
+    """TEST_044 + INVARIANT_005: hydration failure is structured, not empty."""
+
+    def test_restore_failure_is_not_silent_empty_projection(self) -> None:
+        from hestai_context_mcp.storage.schema import SchemaTooNewError, validate_artifact
+
+        artifact = _make_artifact(schema_version=99, minimum_reader_version=99)
+        with pytest.raises(SchemaTooNewError):
+            validate_artifact(artifact)

--- a/tests/storage/test_snapshots.py
+++ b/tests/storage/test_snapshots.py
@@ -1,0 +1,267 @@
+"""GROUP_008: SNAPSHOTS — RED-first tests for storage/snapshots.py.
+
+Asserts the named-session snapshot contract per BUILD-PLAN
+§TDD_TEST_LIST GROUP_008 (TEST_089..TEST_098) and ADR-0013 R5.
+
+Binding rulings exercised here:
+- R5: snapshot path is .hestai/state/portable/snapshots/{session_id}/
+  context-projection.json. Snapshots are written by clock_in only;
+  reads are pure (no mutation, no directory creation).
+- R3: identity tuple is recorded in snapshot metadata; mismatched
+  identities are refused at write time.
+- R10: snapshot does not drift mid-session — a new artifact published
+  after creation must not be reflected in the existing snapshot.
+- TEST_094: session_id is path-traversal-safe (rejects .., / etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _identity() -> Any:
+    from hestai_context_mcp.storage.types import IdentityTuple
+
+    return IdentityTuple(
+        project_id="proj-A",
+        workspace_id="wt-build",
+        user_id="alice",
+        state_schema_version=1,
+        carrier_namespace="personal",
+    )
+
+
+def _ref(artifact_id: str = "art-1", sequence_id: int = 1) -> Any:
+    from hestai_context_mcp.storage.types import ArtifactKind, ArtifactRef
+
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        identity=_identity(),
+        artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+        sequence_id=sequence_id,
+        created_at=datetime.now(UTC),
+        payload_hash="0" * 64,
+        carrier_path=f"/tmp/{artifact_id}.json",
+    )
+
+
+@pytest.mark.unit
+class TestCreateSnapshot:
+    """TEST_089..TEST_092."""
+
+    def test_create_session_snapshot_writes_under_session_id(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
+
+        sid = "11111111-1111-1111-1111-111111111111"
+        path = create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=_identity(),
+            artifact_refs=(_ref("art-1", 1),),
+            projection_payload={"hello": "world"},
+        )
+        expected = (
+            tmp_path
+            / ".hestai"
+            / "state"
+            / "portable"
+            / "snapshots"
+            / sid
+            / "context-projection.json"
+        )
+        assert path == expected
+        assert expected.exists()
+
+    def test_snapshot_metadata_records_identity_tuple(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
+
+        sid = "22222222-2222-2222-2222-222222222222"
+        identity = _identity()
+        create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=identity,
+            artifact_refs=(_ref(),),
+            projection_payload={},
+        )
+        metadata_path = (
+            tmp_path / ".hestai" / "state" / "portable" / "snapshots" / sid / "metadata.json"
+        )
+        assert metadata_path.exists()
+        meta = json.loads(metadata_path.read_text(encoding="utf-8"))
+        assert meta["identity"]["project_id"] == identity.project_id
+        assert meta["identity"]["workspace_id"] == identity.workspace_id
+        assert meta["identity"]["user_id"] == identity.user_id
+        assert meta["identity"]["state_schema_version"] == identity.state_schema_version
+        assert meta["identity"]["carrier_namespace"] == identity.carrier_namespace
+
+    def test_snapshot_metadata_records_artifact_refs(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
+
+        sid = "33333333-3333-3333-3333-333333333333"
+        refs = (_ref("art-1", 1), _ref("art-2", 2))
+        create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=_identity(),
+            artifact_refs=refs,
+            projection_payload={},
+        )
+        meta = json.loads(
+            (
+                tmp_path / ".hestai" / "state" / "portable" / "snapshots" / sid / "metadata.json"
+            ).read_text(encoding="utf-8")
+        )
+        ids = [r["artifact_id"] for r in meta["artifact_refs"]]
+        assert ids == ["art-1", "art-2"]
+
+    def test_snapshot_metadata_records_created_at(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
+
+        sid = "44444444-4444-4444-4444-444444444444"
+        create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=_identity(),
+            artifact_refs=(),
+            projection_payload={},
+        )
+        meta = json.loads(
+            (
+                tmp_path / ".hestai" / "state" / "portable" / "snapshots" / sid / "metadata.json"
+            ).read_text(encoding="utf-8")
+        )
+        assert "created_at" in meta
+        # Parses as a timezone-aware ISO string.
+        dt = datetime.fromisoformat(meta["created_at"])
+        assert dt.tzinfo is not None
+
+
+@pytest.mark.unit
+class TestReadSnapshot:
+    """TEST_093 + TEST_094."""
+
+    def test_read_session_snapshot_is_pure_read(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import (
+            create_session_snapshot,
+            read_session_snapshot,
+        )
+
+        sid = "55555555-5555-5555-5555-555555555555"
+        create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=_identity(),
+            artifact_refs=(),
+            projection_payload={"k": "v"},
+        )
+        snap_dir = tmp_path / ".hestai" / "state" / "portable" / "snapshots" / sid
+        before = {p: p.stat().st_mtime_ns for p in snap_dir.rglob("*")}
+        time.sleep(0.005)
+        result = read_session_snapshot(working_dir=tmp_path, session_id=sid)
+        assert result["projection"] == {"k": "v"}
+        after = {p: p.stat().st_mtime_ns for p in snap_dir.rglob("*")}
+        for p in snap_dir.rglob("*"):
+            assert before[p] == after[p], f"snapshot read modified {p}"
+
+    def test_snapshot_read_rejects_path_traversal_session_id(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import (
+            SnapshotIdValidationError,
+            read_session_snapshot,
+        )
+
+        for bad in ("../escape", "..", "/abs", "a/b", "a\\b", ""):
+            with pytest.raises(SnapshotIdValidationError):
+                read_session_snapshot(working_dir=tmp_path, session_id=bad)
+
+
+@pytest.mark.unit
+class TestSnapshotConstraints:
+    """TEST_095..TEST_098."""
+
+    def test_snapshot_creation_rejects_identity_mismatch(self, tmp_path: Path) -> None:
+        """Artifact refs whose identity differs from the snapshot identity
+        are refused — prevents cross-identity contamination."""
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
+
+        from hestai_context_mcp.storage.identity import IdentityValidationError
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            ArtifactRef,
+            IdentityTuple,
+        )
+
+        bad_identity = IdentityTuple(
+            project_id="proj-OTHER",
+            workspace_id="wt-build",
+            user_id="alice",
+            state_schema_version=1,
+            carrier_namespace="personal",
+        )
+        bad_ref = ArtifactRef(
+            artifact_id="art-x",
+            identity=bad_identity,
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            sequence_id=1,
+            created_at=datetime.now(UTC),
+            payload_hash="0" * 64,
+            carrier_path="/tmp/x.json",
+        )
+        with pytest.raises(IdentityValidationError):
+            create_session_snapshot(
+                working_dir=tmp_path,
+                session_id="66666666-6666-6666-6666-666666666666",
+                identity=_identity(),
+                artifact_refs=(bad_ref,),
+                projection_payload={},
+            )
+
+    def test_snapshot_classified_derived_projection(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import SNAPSHOT_CLASSIFICATION
+
+        from hestai_context_mcp.storage.types import StateClassification
+
+        assert SNAPSHOT_CLASSIFICATION is StateClassification.DERIVED_PROJECTION
+
+    def test_snapshot_does_not_change_when_new_artifact_is_published_after_creation(
+        self, tmp_path: Path
+    ) -> None:
+        from hestai_context_mcp.storage.snapshots import (
+            create_session_snapshot,
+            read_session_snapshot,
+        )
+
+        sid = "77777777-7777-7777-7777-777777777777"
+        create_session_snapshot(
+            working_dir=tmp_path,
+            session_id=sid,
+            identity=_identity(),
+            artifact_refs=(_ref("art-1", 1),),
+            projection_payload={"only_artifact": "art-1"},
+        )
+        # Simulate a later publish — write an unrelated artifact under
+        # portable/artifacts/. The snapshot must not pick it up.
+        artifacts_dir = tmp_path / ".hestai" / "state" / "portable" / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        (artifacts_dir / "art-2.json").write_text(json.dumps({"artifact_id": "art-2"}))
+        result = read_session_snapshot(working_dir=tmp_path, session_id=sid)
+        assert result["projection"] == {"only_artifact": "art-1"}
+        assert [r["artifact_id"] for r in result["metadata"]["artifact_refs"]] == ["art-1"]
+
+    def test_snapshot_missing_returns_structured_not_found(self, tmp_path: Path) -> None:
+        from hestai_context_mcp.storage.snapshots import (
+            SnapshotNotFoundError,
+            read_session_snapshot,
+        )
+
+        with pytest.raises(SnapshotNotFoundError):
+            read_session_snapshot(
+                working_dir=tmp_path,
+                session_id="00000000-0000-0000-0000-000000000000",
+            )

--- a/tests/storage/test_snapshots.py
+++ b/tests/storage/test_snapshots.py
@@ -188,9 +188,8 @@ class TestSnapshotConstraints:
     def test_snapshot_creation_rejects_identity_mismatch(self, tmp_path: Path) -> None:
         """Artifact refs whose identity differs from the snapshot identity
         are refused — prevents cross-identity contamination."""
-        from hestai_context_mcp.storage.snapshots import create_session_snapshot
-
         from hestai_context_mcp.storage.identity import IdentityValidationError
+        from hestai_context_mcp.storage.snapshots import create_session_snapshot
         from hestai_context_mcp.storage.types import (
             ArtifactKind,
             ArtifactRef,
@@ -224,7 +223,6 @@ class TestSnapshotConstraints:
 
     def test_snapshot_classified_derived_projection(self, tmp_path: Path) -> None:
         from hestai_context_mcp.storage.snapshots import SNAPSHOT_CLASSIFICATION
-
         from hestai_context_mcp.storage.types import StateClassification
 
         assert SNAPSHOT_CLASSIFICATION is StateClassification.DERIVED_PROJECTION

--- a/tests/storage/test_source_invariants_pss.py
+++ b/tests/storage/test_source_invariants_pss.py
@@ -1,0 +1,433 @@
+"""GROUP_015: SOURCE_INVARIANTS — RED-first tests.
+
+Static invariant tests for the PSS storage layer per BUILD-PLAN
+§TDD_TEST_LIST GROUP_015 (TEST_159..TEST_168) plus the CIV G1 acyclic
+storage-layering chain.
+
+These are **structural** assertions that grep / parse the repository
+source and fail CI when a load-bearing invariant drifts. Behavior is
+covered by ``tests/integration/test_pss_lifecycle_local_filesystem.py``
+and ``tests/integration/test_get_context_purity.py``; this file is the
+mechanical guard.
+
+Binding rulings exercised:
+
+- R5: ``get_context.py`` has no StorageAdapter or LocalFilesystemAdapter
+  imports / symbols (G3, also asserted from a different angle in
+  test_get_context_purity.py).
+- R7: only ``clock_out.py`` may publish portable state.
+- R11: no custom Git ref tokens (refs/hestai/*) in storage source.
+- R12: no remote-adapter SDK imports (requests, httpx, boto, gitpython).
+- G1: storage layering chain is acyclic and ordered:
+    types <- protocol <- provenance <- local_filesystem <-
+    outbox <- snapshots <- projection <- classification.
+- INVARIANT_002: full suite is independent of remote adapters.
+- B2_START_BLOCKER_003: no remote adapter / config / wire schema.
+- B2_START_BLOCKER_005: no custom Git refs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC_ROOT = _REPO_ROOT / "src" / "hestai_context_mcp"
+_STORAGE_ROOT = _SRC_ROOT / "storage"
+_TOOLS_ROOT = _SRC_ROOT / "tools"
+
+
+def _iter_python_files(root: Path):
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _read_module_imports(path: Path) -> set[str]:
+    """Return the set of internal `hestai_context_mcp.X.Y` modules imported."""
+    out: set[str] = set()
+    pattern = re.compile(
+        r"^\s*(?:from|import)\s+(hestai_context_mcp\.[\w\.]+)",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(path.read_text(encoding="utf-8")):
+        out.add(match.group(1))
+    return out
+
+
+# ---------- TEST_159 ----------
+
+
+class TestNoRemoteAdapterClassNames:
+    """TEST_159 — No remote adapter class names under storage/."""
+
+    _FORBIDDEN_CLASS_PATTERNS: tuple[re.Pattern[str], ...] = (
+        re.compile(r"\bclass\s+RemoteHttp\w*Adapter\b"),
+        re.compile(r"\bclass\s+S3\w*Adapter\b"),
+        re.compile(r"\bclass\s+GcsAdapter\b"),
+        re.compile(r"\bclass\s+AzureAdapter\b"),
+        re.compile(r"\bclass\s+GitRefAdapter\b"),
+    )
+
+    def test_no_remote_adapter_class_names_under_storage_package(self) -> None:
+        offenders: list[tuple[Path, int, str]] = []
+        for py in _iter_python_files(_STORAGE_ROOT):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                # R12 docstrings are allowed to reference R12 by name; we
+                # only forbid actual class definitions.
+                for pat in self._FORBIDDEN_CLASS_PATTERNS:
+                    if pat.search(line):
+                        offenders.append((py, lineno, line.strip()))
+        assert (
+            not offenders
+        ), "R12 / B2_START_BLOCKER_003 violation — remote adapter class found:\n" + "\n".join(
+            f"  {p}:{n}: {s}" for p, n, s in offenders
+        )
+
+
+# ---------- TEST_160 ----------
+
+
+class TestNoRemoteSdkImports:
+    """TEST_160 — No requests/httpx/boto/gitpython imports in storage/."""
+
+    _FORBIDDEN_IMPORT_PATTERNS: tuple[re.Pattern[str], ...] = (
+        re.compile(r"^\s*(?:from|import)\s+requests\b"),
+        re.compile(r"^\s*(?:from|import)\s+httpx\b"),
+        re.compile(r"^\s*(?:from|import)\s+boto3?\b"),
+        re.compile(r"^\s*(?:from|import)\s+google\.cloud\b"),
+        re.compile(r"^\s*(?:from|import)\s+azure\b"),
+        re.compile(r"^\s*(?:from|import)\s+git\b"),  # gitpython
+    )
+
+    def test_no_remote_sdk_imports_in_storage(self) -> None:
+        offenders: list[tuple[Path, int, str, str]] = []
+        for py in _iter_python_files(_STORAGE_ROOT):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                for pat in self._FORBIDDEN_IMPORT_PATTERNS:
+                    if pat.search(line):
+                        offenders.append((py, lineno, pat.pattern, line.strip()))
+        assert not offenders, "R12 violation — remote SDK import in storage/:\n" + "\n".join(
+            f"  {p}:{n} matched /{pat}/: {s}" for p, n, pat, s in offenders
+        )
+
+
+# ---------- TEST_161 ----------
+
+
+class TestNoCustomGitRefStrings:
+    """TEST_161 — No custom Git ref tokens in storage source."""
+
+    _GIT_REF_TOKENS: tuple[str, ...] = (
+        "refs/hestai",
+        "refs/heads/hestai",
+        "refs/tags/hestai",
+    )
+
+    def test_no_custom_git_ref_strings_in_storage_implementation(self) -> None:
+        offenders: list[tuple[Path, int, str, str]] = []
+        for py in _iter_python_files(_STORAGE_ROOT):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                for token in self._GIT_REF_TOKENS:
+                    if token in line:
+                        offenders.append((py, lineno, token, line.strip()))
+        assert not offenders, (
+            "R11 / B2_START_BLOCKER_005 violation — custom Git ref token in storage/:\n"
+            + "\n".join(f"  {p}:{n} matched '{tok}': {s}" for p, n, tok, s in offenders)
+        )
+
+
+# ---------- TEST_162 ----------
+
+
+class TestGetContextHasNoStorageAdapterImports:
+    """TEST_162 — get_context.py forbids adapter imports."""
+
+    _FORBIDDEN_IMPORT_PATTERNS: tuple[re.Pattern[str], ...] = (
+        re.compile(r"^\s*(?:from|import)\s+hestai_context_mcp\.storage\.local_filesystem"),
+        re.compile(r"^\s*(?:from|import)\s+hestai_context_mcp\.storage\.outbox"),
+        re.compile(r"^\s*(?:from|import)\s+hestai_context_mcp\.storage\.protocol"),
+        re.compile(r"^\s*(?:from|import)\s+hestai_context_mcp\.storage\.snapshots"),
+    )
+
+    def test_get_context_has_no_storage_adapter_imports(self) -> None:
+        path = _TOOLS_ROOT / "get_context.py"
+        source = path.read_text(encoding="utf-8")
+        offenders: list[tuple[int, str, str]] = []
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            for pat in self._FORBIDDEN_IMPORT_PATTERNS:
+                if pat.search(line):
+                    offenders.append((lineno, pat.pattern, line.strip()))
+        assert (
+            not offenders
+        ), "R5 / G3 violation — get_context.py has storage adapter imports:\n" + "\n".join(
+            f"  {n} matched /{pat}/: {s}" for n, pat, s in offenders
+        )
+
+
+# ---------- TEST_163 ----------
+
+
+class TestOnlyClockInRestoresPortableState:
+    """TEST_163 — clock_in is the only tool allowed to restore PSS."""
+
+    def test_clock_in_is_only_tool_allowed_to_restore_portable_state(self) -> None:
+        # Restore is mediated by build_projection / read_artifact pulled in
+        # via clock_in's lazy import path. We assert that no OTHER tool
+        # imports the projection builder or the LocalFilesystemAdapter.
+        forbidden_in_other_tools = re.compile(
+            r"hestai_context_mcp\.storage\.(?:projection|local_filesystem)\b"
+        )
+        offenders: list[tuple[Path, int, str]] = []
+        for py in _iter_python_files(_TOOLS_ROOT):
+            if py.name in {"clock_in.py", "clock_out.py"}:
+                # clock_in restores; clock_out publishes — both legal.
+                continue
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                if forbidden_in_other_tools.search(line):
+                    offenders.append((py, lineno, line.strip()))
+        assert (
+            not offenders
+        ), "R5 violation — non-clock_in tool references restore plumbing:\n" + "\n".join(
+            f"  {p}:{n}: {s}" for p, n, s in offenders
+        )
+
+
+# ---------- TEST_164 ----------
+
+
+class TestOnlyClockOutPublishesPortableState:
+    """TEST_164 — clock_out is the only tool allowed to publish PSS."""
+
+    def test_clock_out_is_only_tool_allowed_to_publish_portable_state(self) -> None:
+        # Publish path uses LocalFilesystemAdapter.write_artifact and
+        # OutboxStore.enqueue. No other tool may reference these.
+        forbidden_in_other_tools = (
+            re.compile(r"\.write_artifact\b"),
+            re.compile(r"OutboxStore\b"),
+        )
+        offenders: list[tuple[Path, int, str, str]] = []
+        for py in _iter_python_files(_TOOLS_ROOT):
+            if py.name == "clock_out.py":
+                continue
+            # clock_in is allowed to mention OutboxStore for status checks.
+            if py.name == "clock_in.py":
+                continue
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                for pat in forbidden_in_other_tools:
+                    if pat.search(line):
+                        offenders.append((py, lineno, pat.pattern, line.strip()))
+        assert (
+            not offenders
+        ), "R5 / R7 violation — non-clock_out tool references publish plumbing:\n" + "\n".join(
+            f"  {p}:{n} matched /{pat}/: {s}" for p, n, pat, s in offenders
+        )
+
+
+# ---------- TEST_165 ----------
+
+
+class TestStorageProtocolHasNoProviderSdkImports:
+    """TEST_165 — storage/protocol.py is provider-agnostic."""
+
+    def test_storage_protocol_has_no_provider_sdk_imports(self) -> None:
+        path = _STORAGE_ROOT / "protocol.py"
+        source = path.read_text(encoding="utf-8")
+        # The protocol must depend only on stdlib + storage.types.
+        bad_imports = re.compile(
+            r"^\s*(?:from|import)\s+"
+            r"(?:requests|httpx|boto3?|google\.cloud|azure|anthropic|openai)\b",
+            re.MULTILINE,
+        )
+        assert not bad_imports.search(
+            source
+        ), "R2 / R12 violation — storage/protocol.py imports a provider SDK"
+
+
+# ---------- TEST_166 ----------
+
+
+class TestLocalFilesystemAdapterHasNoKeyringImport:
+    """TEST_166 — Local adapter never imports keyring or platform secrets."""
+
+    def test_local_filesystem_adapter_has_no_keyring_import(self) -> None:
+        path = _STORAGE_ROOT / "local_filesystem.py"
+        source = path.read_text(encoding="utf-8")
+        bad_imports = re.compile(
+            r"^\s*(?:from|import)\s+(?:keyring|secretstorage|win32cred)\b",
+            re.MULTILINE,
+        )
+        assert not bad_imports.search(
+            source
+        ), "R12 violation — local_filesystem.py imports a credential store SDK"
+
+
+# ---------- TEST_167 ----------
+
+
+class TestNoNewToolRegistration:
+    """TEST_167 — server.py registers exactly the four B1 tools."""
+
+    def test_no_new_tool_registration_for_publish_or_restore(self) -> None:
+        path = _SRC_ROOT / "server.py"
+        source = path.read_text(encoding="utf-8")
+        # Count mcp.tool(...) registrations.
+        registrations = re.findall(r"^\s*mcp\.tool\(([\w_]+)\)", source, re.MULTILINE)
+        assert sorted(registrations) == sorted(
+            ["clock_in", "clock_out", "get_context", "submit_review"]
+        ), (
+            "B2_START_BLOCKER_002 / R5 violation — server.py must register exactly "
+            f"the four B1 tools; got {registrations}"
+        )
+
+    def test_server_does_not_import_publish_or_restore_helpers(self) -> None:
+        path = _SRC_ROOT / "server.py"
+        source = path.read_text(encoding="utf-8")
+        bad = re.compile(r"publish_portable_state|restore_portable_state")
+        assert not bad.search(
+            source
+        ), "R5 violation — server.py must not register publish/restore tools in B1"
+
+
+# ---------- TEST_168 ----------
+
+
+class TestNoHestaiMcpImportsAddedByPss:
+    """TEST_168 — PSS storage modules never import the legacy hestai_mcp pkg."""
+
+    def test_no_hestai_mcp_imports_added_by_pss(self) -> None:
+        bad = re.compile(r"^\s*(?:from|import)\s+hestai_mcp\b", re.MULTILINE)
+        offenders: list[tuple[Path, int, str]] = []
+        for py in _iter_python_files(_STORAGE_ROOT):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                if bad.search(line):
+                    offenders.append((py, lineno, line.strip()))
+        assert (
+            not offenders
+        ), "PROD::I6 / R10 violation — hestai_mcp import in storage/:\n" + "\n".join(
+            f"  {p}:{n}: {s}" for p, n, s in offenders
+        )
+
+
+# ---------- G1: layering acyclicity ----------
+
+
+class TestStorageLayeringAcyclic:
+    """G1 (CIV) — storage modules form an acyclic dependency chain.
+
+    Allowed dependency direction (lower depends on higher only):
+
+        types
+          ^
+          |
+        protocol
+          ^
+          |
+        identity / identity_resolver / schema / provenance
+          ^
+          |
+        local_filesystem
+          ^
+          |
+        outbox
+          ^
+          |
+        snapshots
+          ^
+          |
+        projection
+          ^
+          |
+        classification
+
+    Concretely we encode a strict per-module allow-list of internal
+    storage imports. Any module-level import outside its allow-list is a
+    layering violation.
+    """
+
+    # Per-module allowed internal storage dependencies. A module may
+    # also import its own __init__ (re-export); those are not enumerated.
+    _ALLOWED: dict[str, set[str]] = {
+        "types": set(),
+        "protocol": {"types"},
+        "identity": {"types"},
+        "identity_resolver": {"identity", "types"},
+        "schema": {"types"},
+        "provenance": {"types"},
+        "local_filesystem": {"identity", "provenance", "types"},
+        "outbox": {"types"},
+        "snapshots": {"identity", "types"},
+        "projection": {"identity", "types"},
+        "classification": {"types"},
+    }
+
+    def test_storage_layering_is_acyclic(self) -> None:
+        offenders: list[tuple[str, str]] = []
+        for py in _iter_python_files(_STORAGE_ROOT):
+            mod_name = py.stem
+            if mod_name == "__init__":
+                continue
+            allowed = self._ALLOWED.get(mod_name)
+            if allowed is None:
+                # Unknown module — must be added explicitly to the
+                # allow-list so layering is decided, not inferred.
+                offenders.append(
+                    (mod_name, "module is not in the G1 allow-list; add it explicitly")
+                )
+                continue
+            imports = _read_module_imports(py)
+            internal_storage = {
+                name.split(".")[2]
+                for name in imports
+                if name.startswith("hestai_context_mcp.storage.")
+            }
+            # Self-imports are not possible at module-level here; ignore.
+            internal_storage.discard(mod_name)
+            forbidden = internal_storage - allowed
+            if forbidden:
+                offenders.append(
+                    (mod_name, f"forbidden imports {sorted(forbidden)}; allowed: {sorted(allowed)}")
+                )
+        assert not offenders, "G1 layering violation:\n" + "\n".join(
+            f"  storage/{m}.py: {msg}" for m, msg in offenders
+        )
+
+    def test_storage_classification_is_a_leaf_consumer(self) -> None:
+        """``classification.py`` is the final consumer; nothing imports it."""
+        offenders: list[tuple[Path, int, str]] = []
+        bad = re.compile(r"^\s*(?:from|import)\s+hestai_context_mcp\.storage\.classification")
+        for py in _iter_python_files(_STORAGE_ROOT):
+            if py.stem == "classification":
+                continue
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                if bad.search(line):
+                    offenders.append((py, lineno, line.strip()))
+        assert (
+            not offenders
+        ), "G1 violation — storage.classification must remain a leaf:\n" + "\n".join(
+            f"  {p}:{n}: {s}" for p, n, s in offenders
+        )
+
+    def test_storage_package_exposes_b1_layering_frozen_constant(self) -> None:
+        """G1 — the storage package declares ``B1_LAYERING_FROZEN = True``.
+
+        The constant is the canonical positive marker that the B1
+        layering chain is sealed for the B1 phase. The post-B2 quality
+        gate chain (TMG -> CRS -> CE -> CIV) introspects it at runtime
+        to confirm B1's structural invariants are the ones currently in
+        force. Future B2 work that adds adapters MUST flip this constant
+        to False (or, preferably, replace it with a version-tagged
+        equivalent) so the quality gate chain catches the layering
+        change instead of silently accepting drift.
+        """
+        from hestai_context_mcp import storage
+
+        assert hasattr(storage, "B1_LAYERING_FROZEN"), (
+            "G1 violation: storage package must declare B1_LAYERING_FROZEN "
+            "constant so the post-B2 quality gate chain can introspect "
+            "structural invariants."
+        )
+        assert (
+            storage.B1_LAYERING_FROZEN is True
+        ), "G1 violation: storage.B1_LAYERING_FROZEN must be True in B1."

--- a/tests/storage/test_storage_protocol.py
+++ b/tests/storage/test_storage_protocol.py
@@ -29,19 +29,15 @@ class TestStorageAdapterProtocolRuntimeCheckable:
     """TEST_013: StorageAdapter Protocol exists and is @runtime_checkable."""
 
     def test_storage_adapter_protocol_is_runtime_checkable(self) -> None:
-        from typing import Protocol, runtime_checkable
-
         from hestai_context_mcp.storage.protocol import StorageAdapter
 
-        # @runtime_checkable Protocols expose _is_runtime_protocol = True.
+        # @runtime_checkable Protocols expose _is_runtime_protocol = True
+        # and _is_protocol = True (Python 3.11+ typing internals).
         assert getattr(StorageAdapter, "_is_runtime_protocol", False) is True
-        # Ensure it inherits from Protocol semantics — CRS C2: this is the
-        # ONLY guarantee runtime_checkable provides (attribute-presence).
-        assert issubclass(Protocol, type(Protocol))  # sanity
+        assert getattr(StorageAdapter, "_is_protocol", False) is True
+        # CRS C2 caveat: runtime_checkable provides attribute-presence
+        # checks ONLY — not method/parameter type validation.
         assert StorageAdapter.__name__ == "StorageAdapter"
-        # runtime_checkable is the imported decorator; presence asserted
-        # by attribute on the protocol class itself.
-        _ = runtime_checkable  # silence unused
 
 
 @pytest.mark.unit
@@ -164,34 +160,36 @@ class TestProtocolModuleSourceInvariants:
         / "protocol.py"
     )
 
-    # Forbidden remote/Git tokens. Pattern words are anchored to import-like
-    # boundaries OR appear as bare identifiers in code; comments mentioning
-    # the *prohibition* are explicitly allowed.
-    _REMOTE_TOKENS = (
-        re.compile(r"\bRemoteHTTP\b"),
-        re.compile(r"\bGitAdapter\b"),
-        re.compile(r"\bS3Adapter\b"),
-        re.compile(r"\brefs/hestai\b"),
+    # Forbidden remote-adapter usage tokens — anchored to identifier-like
+    # constructs (import, from-import, class definition, function call, or
+    # attribute access). Narrative prose in module docstrings citing the
+    # *prohibition* is permitted (the ADR explicitly enumerates these names
+    # as out-of-scope).
+    _REMOTE_USAGE_PATTERNS = (
+        re.compile(r"\b(?:import|from)\s+\S*RemoteHTTP\b"),
+        re.compile(r"\b(?:import|from)\s+\S*GitAdapter\b"),
+        re.compile(r"\b(?:import|from)\s+\S*S3Adapter\b"),
+        re.compile(r"\bclass\s+(?:RemoteHTTP|GitAdapter|S3Adapter)\b"),
+        re.compile(r"\b(?:RemoteHTTP|GitAdapter|S3Adapter)\s*\("),  # call sites
+        re.compile(r"\.(?:RemoteHTTP|GitAdapter|S3Adapter)\b"),  # attr access
     )
+
+    _GIT_REF_USAGE_PATTERN = re.compile(r"['\"]refs/hestai")
 
     def test_protocol_module_contains_no_remote_adapter_names(self) -> None:
         text = self._SRC.read_text()
-        for pat in self._REMOTE_TOKENS[:3]:
-            # Allow occurrences inside comment lines that announce the rule
-            # (they MUST be inside lines starting with '#').
-            for line in text.splitlines():
-                if pat.search(line) and not line.lstrip().startswith("#"):
-                    raise AssertionError(
-                        f"protocol.py contains forbidden remote token /{pat.pattern}/: {line!r}"
-                    )
+        for pat in self._REMOTE_USAGE_PATTERNS:
+            assert not pat.search(
+                text
+            ), f"protocol.py uses forbidden remote-adapter pattern /{pat.pattern}/"
 
     def test_protocol_module_contains_no_git_ref_storage_language(self) -> None:
         text = self._SRC.read_text()
-        for line in text.splitlines():
-            if self._REMOTE_TOKENS[3].search(line) and not line.lstrip().startswith("#"):
-                raise AssertionError(
-                    "protocol.py uses custom Git ref token outside a comment line"
-                )
+        # Forbid string literals embedding refs/hestai (which would imply
+        # the module uses Git refs as a storage carrier — R11 violation).
+        assert not self._GIT_REF_USAGE_PATTERN.search(
+            text
+        ), "protocol.py contains a 'refs/hestai' string literal — R11 violation"
 
     def test_protocol_module_imports_only_typing_and_storage_types(self) -> None:
         text = self._SRC.read_text()

--- a/tests/storage/test_storage_protocol.py
+++ b/tests/storage/test_storage_protocol.py
@@ -1,0 +1,207 @@
+"""GROUP_002: PROTOCOL — RED-first tests for storage/protocol.py.
+
+Asserts the StorageAdapter @runtime_checkable Protocol contract per
+BUILD-PLAN §PROTOCOL_SIGNATURES, including source-invariants TEST_019
+(no remote adapter names) and TEST_020 (no Git ref language).
+
+Binding rulings exercised here:
+- CRS C1: signatures verbatim — pinned method names + parameter types.
+- CRS C2: ``@runtime_checkable`` is attribute-presence only — tests do
+  NOT rely on Protocol for full type/method validation; they assert
+  attribute presence and signature shape via inspect/get_type_hints.
+- B2_START_BLOCKER_003: no remote adapters, no Git refs.
+
+R-trace: see BUILD-PLAN §TDD_TEST_LIST GROUP_002_PROTOCOL.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import get_type_hints
+
+import pytest
+
+
+@pytest.mark.unit
+class TestStorageAdapterProtocolRuntimeCheckable:
+    """TEST_013: StorageAdapter Protocol exists and is @runtime_checkable."""
+
+    def test_storage_adapter_protocol_is_runtime_checkable(self) -> None:
+        from typing import Protocol, runtime_checkable
+
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+
+        # @runtime_checkable Protocols expose _is_runtime_protocol = True.
+        assert getattr(StorageAdapter, "_is_runtime_protocol", False) is True
+        # Ensure it inherits from Protocol semantics — CRS C2: this is the
+        # ONLY guarantee runtime_checkable provides (attribute-presence).
+        assert issubclass(Protocol, type(Protocol))  # sanity
+        assert StorageAdapter.__name__ == "StorageAdapter"
+        # runtime_checkable is the imported decorator; presence asserted
+        # by attribute on the protocol class itself.
+        _ = runtime_checkable  # silence unused
+
+
+@pytest.mark.unit
+class TestStorageAdapterRequiresCapabilities:
+    """TEST_014: StorageAdapter declares ``capabilities`` attribute."""
+
+    def test_storage_adapter_protocol_requires_capabilities_attribute(self) -> None:
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+
+        hints = get_type_hints(StorageAdapter)
+        assert "capabilities" in hints
+        # The annotation must be StorageCapabilities.
+        from hestai_context_mcp.storage.types import StorageCapabilities
+
+        assert hints["capabilities"] is StorageCapabilities
+
+
+@pytest.mark.unit
+class TestListArtifactsSignature:
+    """TEST_015: list_artifacts(namespace, after_id=None) -> list[ArtifactRef]."""
+
+    def test_storage_adapter_protocol_lists_artifacts_by_namespace(self) -> None:
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+        from hestai_context_mcp.storage.types import ArtifactRef, PortableNamespace
+
+        sig = inspect.signature(StorageAdapter.list_artifacts)
+        params = sig.parameters
+        assert "namespace" in params
+        assert "after_id" in params
+        # default None preserves the signature freedom for fresh-list reads.
+        assert params["after_id"].default is None
+        hints = get_type_hints(StorageAdapter.list_artifacts)
+        assert hints["namespace"] is PortableNamespace
+        # str | None
+        assert hints["after_id"] == str | None
+        assert hints["return"] == list[ArtifactRef]
+
+
+@pytest.mark.unit
+class TestReadArtifactSignature:
+    """TEST_016: read_artifact returns PortableArtifact union (RISK_002)."""
+
+    def test_storage_adapter_protocol_reads_portable_artifact_union(self) -> None:
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactRef,
+            PortableMemoryArtifact,
+            TombstoneArtifact,
+        )
+
+        sig = inspect.signature(StorageAdapter.read_artifact)
+        assert "ref" in sig.parameters
+        hints = get_type_hints(StorageAdapter.read_artifact)
+        assert hints["ref"] is ArtifactRef
+        # Return type is the discriminated union — RISK_002 (no separate
+        # read_tombstone). Accept both runtime alias forms.
+        rt = hints["return"]
+        # PortableArtifact alias resolves to a Union at runtime.
+        assert PortableMemoryArtifact in getattr(rt, "__args__", (rt,)) or rt == (
+            PortableMemoryArtifact | TombstoneArtifact
+        )
+        assert TombstoneArtifact in getattr(rt, "__args__", (rt,)) or rt == (
+            PortableMemoryArtifact | TombstoneArtifact
+        )
+
+
+@pytest.mark.unit
+class TestWriteArtifactSignature:
+    """TEST_017: write_artifact requires precondition + provenance gate."""
+
+    def test_storage_adapter_protocol_writes_memory_artifact_with_precondition(self) -> None:
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactRef,
+            PortableMemoryArtifact,
+            PublishAck,
+            WritePrecondition,
+        )
+
+        sig = inspect.signature(StorageAdapter.write_artifact)
+        assert {"ref", "artifact", "precondition"}.issubset(sig.parameters)
+        hints = get_type_hints(StorageAdapter.write_artifact)
+        assert hints["ref"] is ArtifactRef
+        assert hints["artifact"] is PortableMemoryArtifact
+        assert hints["precondition"] is WritePrecondition
+        assert hints["return"] is PublishAck
+
+
+@pytest.mark.unit
+class TestWriteTombstoneSignature:
+    """TEST_018: write_tombstone appends without overwrite."""
+
+    def test_storage_adapter_protocol_writes_tombstone_with_precondition(self) -> None:
+        from hestai_context_mcp.storage.protocol import StorageAdapter
+        from hestai_context_mcp.storage.types import (
+            ArtifactRef,
+            PublishAck,
+            TombstoneArtifact,
+            WritePrecondition,
+        )
+
+        sig = inspect.signature(StorageAdapter.write_tombstone)
+        assert {"ref", "tombstone", "precondition"}.issubset(sig.parameters)
+        hints = get_type_hints(StorageAdapter.write_tombstone)
+        assert hints["ref"] is ArtifactRef
+        assert hints["tombstone"] is TombstoneArtifact
+        assert hints["precondition"] is WritePrecondition
+        assert hints["return"] is PublishAck
+
+
+@pytest.mark.unit
+class TestProtocolModuleSourceInvariants:
+    """TEST_019/TEST_020 + TEST_165 (G1): protocol module is provider-neutral."""
+
+    _SRC = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "hestai_context_mcp"
+        / "storage"
+        / "protocol.py"
+    )
+
+    # Forbidden remote/Git tokens. Pattern words are anchored to import-like
+    # boundaries OR appear as bare identifiers in code; comments mentioning
+    # the *prohibition* are explicitly allowed.
+    _REMOTE_TOKENS = (
+        re.compile(r"\bRemoteHTTP\b"),
+        re.compile(r"\bGitAdapter\b"),
+        re.compile(r"\bS3Adapter\b"),
+        re.compile(r"\brefs/hestai\b"),
+    )
+
+    def test_protocol_module_contains_no_remote_adapter_names(self) -> None:
+        text = self._SRC.read_text()
+        for pat in self._REMOTE_TOKENS[:3]:
+            # Allow occurrences inside comment lines that announce the rule
+            # (they MUST be inside lines starting with '#').
+            for line in text.splitlines():
+                if pat.search(line) and not line.lstrip().startswith("#"):
+                    raise AssertionError(
+                        f"protocol.py contains forbidden remote token /{pat.pattern}/: {line!r}"
+                    )
+
+    def test_protocol_module_contains_no_git_ref_storage_language(self) -> None:
+        text = self._SRC.read_text()
+        for line in text.splitlines():
+            if self._REMOTE_TOKENS[3].search(line) and not line.lstrip().startswith("#"):
+                raise AssertionError(
+                    "protocol.py uses custom Git ref token outside a comment line"
+                )
+
+    def test_protocol_module_imports_only_typing_and_storage_types(self) -> None:
+        text = self._SRC.read_text()
+        forbidden = (
+            "import requests",
+            "import httpx",
+            "import boto",
+            "import git",
+            "from git ",
+            "import keyring",
+        )
+        for token in forbidden:
+            assert token not in text, f"protocol.py imports forbidden module: {token}"

--- a/tests/storage/test_types_contract.py
+++ b/tests/storage/test_types_contract.py
@@ -388,6 +388,4 @@ class TestTypesModuleHasNoIo:
         )
         text = types_src.read_text()
         for forbidden in ("requests", "httpx", "boto", "urllib.request", "git "):
-            assert forbidden not in text, (
-                f"types.py imported forbidden token: {forbidden}"
-            )
+            assert forbidden not in text, f"types.py imported forbidden token: {forbidden}"

--- a/tests/storage/test_types_contract.py
+++ b/tests/storage/test_types_contract.py
@@ -1,0 +1,393 @@
+"""GROUP_001: TYPES_CONTRACT — RED-first tests for storage/types.py.
+
+These tests assert the dataclass and enum contract described in
+BUILD-PLAN §PROTOCOL_SIGNATURES (verbatim, per CRS C1) and ADR-0013 R1..R9.
+
+Binding rulings exercised here:
+- RISK_002: PortableArtifact = PortableMemoryArtifact | TombstoneArtifact (union).
+- RISK_005: v1 payload keys (asserted via PortableMemoryArtifact.payload typing only;
+  the concrete payload-key contract is asserted at the build site in clock_out
+  later — here we only check the artifact carries a JSON-shaped payload field).
+- CRS C1: signatures verbatim — these tests pin the exact field names/types.
+- CRS C3: frozen+slots dataclasses preserve effective immutability of leaf
+  fields. (Nested JSON payload immutability is enforced at construction site,
+  see provenance/clock_out groups.)
+- G5: PortableArtifact discriminated union — TypeGuard helpers + match
+  exhaustiveness covered in test_artifact_union exhaustiveness section below.
+
+R-trace mapping: see BUILD-PLAN §TDD_TEST_LIST GROUP_001_TYPES_CONTRACT.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import Literal, get_args, get_origin
+
+import pytest
+
+
+@pytest.mark.unit
+class TestStorageCapabilitiesContract:
+    """TEST_001: StorageCapabilities matrix fields (R2)."""
+
+    def test_storage_capabilities_has_required_matrix_fields(self) -> None:
+        from hestai_context_mcp.storage.types import StorageCapabilities
+
+        names = {f.name for f in dataclasses.fields(StorageCapabilities)}
+        required = {
+            "strong_list_consistency",
+            "atomic_compare_and_swap",
+            "conditional_writes",
+            "advisory_locking",
+            "streaming_writes",
+            "encryption_at_rest",
+            "encryption_in_transit",
+            "hard_delete",
+            "read_only",
+        }
+        assert required.issubset(names)
+        # CRS C3: frozen + slots so capabilities cannot be mutated post-init.
+        assert StorageCapabilities.__dataclass_params__.frozen is True
+        assert "__slots__" in StorageCapabilities.__dict__
+
+
+@pytest.mark.unit
+class TestIdentityTupleContract:
+    """TEST_002: IdentityTuple R3 fields."""
+
+    def test_identity_tuple_contains_all_r3_fields(self) -> None:
+        from hestai_context_mcp.storage.types import IdentityTuple
+
+        names = [f.name for f in dataclasses.fields(IdentityTuple)]
+        assert names == [
+            "project_id",
+            "workspace_id",
+            "user_id",
+            "state_schema_version",
+            "carrier_namespace",
+        ]
+        assert IdentityTuple.__dataclass_params__.frozen is True
+        assert "__slots__" in IdentityTuple.__dict__
+
+
+@pytest.mark.unit
+class TestPortableNamespaceContract:
+    """TEST_003: PortableNamespace shadow of IdentityTuple (NOTE_006)."""
+
+    def test_portable_namespace_contains_all_adapter_scope_fields(self) -> None:
+        from hestai_context_mcp.storage.types import PortableNamespace
+
+        names = [f.name for f in dataclasses.fields(PortableNamespace)]
+        assert names == [
+            "project_id",
+            "workspace_id",
+            "user_id",
+            "state_schema_version",
+            "carrier_namespace",
+        ]
+        assert PortableNamespace.__dataclass_params__.frozen is True
+        assert "__slots__" in PortableNamespace.__dict__
+
+
+@pytest.mark.unit
+class TestRedactionProvenanceContract:
+    """TEST_004: RedactionProvenance R6 fields."""
+
+    def test_redaction_provenance_contains_all_r6_fields(self) -> None:
+        from hestai_context_mcp.storage.types import RedactionProvenance
+
+        names = {f.name for f in dataclasses.fields(RedactionProvenance)}
+        required = {
+            "engine_name",
+            "engine_version",
+            "ruleset_hash",
+            "input_artifact_hash",
+            "output_artifact_hash",
+            "redacted_at",
+            "classification_label",
+            "redacted_credential_categories",
+        }
+        assert required == names
+        assert RedactionProvenance.__dataclass_params__.frozen is True
+        assert "__slots__" in RedactionProvenance.__dict__
+
+
+@pytest.mark.unit
+class TestArtifactRefContract:
+    """TEST_005: ArtifactRef carries identity + sequence + kind + hash (R2/R3/R9)."""
+
+    def test_artifact_ref_contains_sequence_identity_kind_and_hash(self) -> None:
+        from hestai_context_mcp.storage.types import ArtifactRef
+
+        names = {f.name for f in dataclasses.fields(ArtifactRef)}
+        for required in (
+            "artifact_id",
+            "identity",
+            "artifact_kind",
+            "sequence_id",
+            "created_at",
+            "payload_hash",
+            "carrier_path",
+        ):
+            assert required in names
+
+
+@pytest.mark.unit
+class TestPortableMemoryArtifactContract:
+    """TEST_006: PortableMemoryArtifact R4 fields."""
+
+    def test_portable_memory_artifact_contains_all_r4_fields(self) -> None:
+        from hestai_context_mcp.storage.types import PortableMemoryArtifact
+
+        names = {f.name for f in dataclasses.fields(PortableMemoryArtifact)}
+        for required in (
+            "artifact_id",
+            "artifact_kind",
+            "identity",
+            "schema_version",
+            "producer_version",
+            "minimum_reader_version",
+            "created_at",
+            "sequence_id",
+            "parent_ids",
+            "redaction_provenance",
+            "classification_label",
+            "payload_hash",
+            "payload",
+        ):
+            assert required in names
+
+
+@pytest.mark.unit
+class TestTombstoneArtifactContract:
+    """TEST_007: TombstoneArtifact R8 shape."""
+
+    def test_tombstone_artifact_contains_target_reason_publisher_and_hash(self) -> None:
+        from hestai_context_mcp.storage.types import TombstoneArtifact
+
+        names = {f.name for f in dataclasses.fields(TombstoneArtifact)}
+        for required in (
+            "artifact_id",
+            "artifact_kind",
+            "identity",
+            "schema_version",
+            "producer_version",
+            "minimum_reader_version",
+            "created_at",
+            "sequence_id",
+            "parent_ids",
+            "target_artifact_id",
+            "reason",
+            "publisher_identity",
+            "redaction_provenance",
+            "classification_label",
+            "payload_hash",
+        ):
+            assert required in names
+
+
+@pytest.mark.unit
+class TestPublishAckContract:
+    """TEST_008: PublishAck R7 acknowledgement and queue fields."""
+
+    def test_publish_ack_contains_acknowledgement_and_queue_fields(self) -> None:
+        from hestai_context_mcp.storage.types import PublishAck
+
+        names = {f.name for f in dataclasses.fields(PublishAck)}
+        for required in (
+            "artifact_id",
+            "identity",
+            "carrier_namespace",
+            "sequence_id",
+            "status",
+            "durable_carrier_receipt",
+            "queued_path",
+            "published_at",
+            "error_code",
+            "error_message",
+        ):
+            assert required in names
+
+
+@pytest.mark.unit
+class TestWritePreconditionContract:
+    """TEST_009: WritePrecondition default to append/create-only (NOTE_012)."""
+
+    def test_write_precondition_defaults_to_append_create_only(self) -> None:
+        from hestai_context_mcp.storage.types import WritePrecondition
+
+        precondition = WritePrecondition()
+        assert precondition.if_absent is True
+        assert precondition.expected_current_hash is None
+        assert precondition.expected_parent_ids == ()
+
+
+@pytest.mark.unit
+class TestPortableArtifactUnionContract:
+    """TEST_010 + G5: PortableArtifact discriminated union (RISK_002)."""
+
+    def test_portable_artifact_union_accepts_memory_or_tombstone(self) -> None:
+        from hestai_context_mcp.storage.types import (
+            PortableArtifact,
+            PortableMemoryArtifact,
+            TombstoneArtifact,
+        )
+
+        # PortableArtifact is a typing alias; assert via get_args resolution.
+        args = get_args(PortableArtifact)
+        # TypeAlias in 3.11 may strip union origin in get_args; fallback OK.
+        if get_origin(PortableArtifact) is not None:
+            assert PortableMemoryArtifact in args
+            assert TombstoneArtifact in args
+        else:
+            # If runtime alias resolves to a union itself, args will hold both.
+            assert any(a is PortableMemoryArtifact for a in args) or args == ()
+
+
+@pytest.mark.unit
+class TestStateClassificationEnumContract:
+    """TEST_011: StateClassification three R1 tiers."""
+
+    def test_classification_enum_contains_three_r1_tiers(self) -> None:
+        from hestai_context_mcp.storage.types import StateClassification
+
+        values = {member.value for member in StateClassification}
+        assert values == {"LOCAL_MUTABLE", "PORTABLE_MEMORY", "DERIVED_PROJECTION"}
+
+
+@pytest.mark.unit
+class TestPublishStatusEnumContract:
+    """TEST_012: PublishStatus four-state enum (R7)."""
+
+    def test_publish_status_enum_contains_published_queued_duplicate_failed(self) -> None:
+        from hestai_context_mcp.storage.types import PublishStatus
+
+        values = {member.value for member in PublishStatus}
+        assert values == {"published", "queued", "duplicate", "failed"}
+
+
+@pytest.mark.unit
+class TestPortableArtifactExhaustiveness:
+    """G5: assert_never exhaustiveness on PortableArtifact union (RISK_002)."""
+
+    def test_portable_artifact_match_is_exhaustive(self) -> None:
+        from typing import assert_never
+
+        from hestai_context_mcp.storage.types import (
+            ArtifactKind,
+            IdentityTuple,
+            PortableArtifact,
+            PortableMemoryArtifact,
+            RedactionProvenance,
+            TombstoneArtifact,
+        )
+
+        identity = IdentityTuple(
+            project_id="p",
+            workspace_id="w",
+            user_id="u",
+            state_schema_version=1,
+            carrier_namespace="personal",
+        )
+        provenance = RedactionProvenance(
+            engine_name="hestai-context-mcp.redaction",
+            engine_version="1",
+            ruleset_hash="r",
+            input_artifact_hash="i",
+            output_artifact_hash="o",
+            redacted_at=datetime.now(UTC),
+            classification_label="PORTABLE_MEMORY",
+            redacted_credential_categories=(),
+        )
+        memory: PortableArtifact = PortableMemoryArtifact(
+            artifact_id="a1",
+            artifact_kind=ArtifactKind.PORTABLE_MEMORY,
+            identity=identity,
+            schema_version=1,
+            producer_version="0.1.0",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=1,
+            parent_ids=(),
+            redaction_provenance=provenance,
+            classification_label="PORTABLE_MEMORY",
+            payload_hash="p1",
+            payload={"k": "v"},
+        )
+        tomb: PortableArtifact = TombstoneArtifact(
+            artifact_id="t1",
+            artifact_kind=ArtifactKind.TOMBSTONE,
+            identity=identity,
+            schema_version=1,
+            producer_version="0.1.0",
+            minimum_reader_version=1,
+            created_at=datetime.now(UTC),
+            sequence_id=2,
+            parent_ids=("a1",),
+            target_artifact_id="a1",
+            reason="user request",
+            publisher_identity=identity,
+            redaction_provenance=None,
+            classification_label="PORTABLE_MEMORY",
+            payload_hash="t1h",
+        )
+
+        def label(artifact: PortableArtifact) -> str:
+            match artifact:
+                case PortableMemoryArtifact():
+                    return "memory"
+                case TombstoneArtifact():
+                    return "tombstone"
+                case _ as unreachable:  # pragma: no cover — exhaustiveness guard
+                    assert_never(unreachable)
+
+        assert label(memory) == "memory"
+        assert label(tomb) == "tombstone"
+
+
+@pytest.mark.unit
+class TestArtifactKindEnum:
+    """RISK_002: ArtifactKind discriminator values aligned with Literal narrowing."""
+
+    def test_artifact_kind_enum_values(self) -> None:
+        from hestai_context_mcp.storage.types import ArtifactKind
+
+        assert ArtifactKind.PORTABLE_MEMORY.value == "portable_memory"
+        assert ArtifactKind.TOMBSTONE.value == "tombstone"
+
+
+@pytest.mark.unit
+class TestClassificationLabelLiteral:
+    """CRS C1: classification_label remains Literal['PORTABLE_MEMORY']."""
+
+    def test_classification_label_is_literal_portable_memory(self) -> None:
+        import typing
+
+        from hestai_context_mcp.storage.types import RedactionProvenance
+
+        hints = typing.get_type_hints(RedactionProvenance, include_extras=True)
+        annotation = hints["classification_label"]
+        assert get_origin(annotation) is Literal
+        assert get_args(annotation) == ("PORTABLE_MEMORY",)
+
+
+@pytest.mark.unit
+class TestTypesModuleHasNoIo:
+    """STRUCTURE: types module is pure — no filesystem or network imports."""
+
+    def test_types_module_has_no_filesystem_or_network_imports(self) -> None:
+        from pathlib import Path
+
+        types_src = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "hestai_context_mcp"
+            / "storage"
+            / "types.py"
+        )
+        text = types_src.read_text()
+        for forbidden in ("requests", "httpx", "boto", "urllib.request", "git "):
+            assert forbidden not in text, (
+                f"types.py imported forbidden token: {forbidden}"
+            )


### PR DESCRIPTION
## Summary

Implements ADR-0013 B1 (Portable Session State via Storage Adapters) — LocalFilesystemAdapter only. R12-deferred items (RemoteHTTP, S3, Git, auth, wire format) are explicitly out of scope and tracked separately.

- 37 atomic commits preserving RED→GREEN TDD cadence across 15 GROUPs (~120 tests) plus 6 rework commits resolving two CE-flagged blockers.
- 33 files changed, 7,768 insertions.
- New `src/hestai_context_mcp/storage/` package: types, protocol, identity, identity_resolver, schema, provenance, local_filesystem, outbox, snapshots, classification, projection.
- Modified: `tools/{clock_in,clock_out,get_context}.py`, `core/{session,redaction}.py`, `server.py` (registration unchanged — 4 tools).

## Quality state

- **pytest**: 807 passed in 16.08s, no skips.
- **mypy strict**: no issues across 40 source files.
- **ruff check + black --check**: clean.
- **coverage**: 91.20% (gate ≥85%, baseline ~89% improved).

## Governance trail

This PR was orchestrated end-to-end through a Holistic Orchestrator gate chain. Documents are LOCAL_MUTABLE (gitignored) and live in the parent repo at `.hestai/state/sessions/phase-pss-b1/`:

- **BUILD-PLAN** — `BUILD-PLAN.oct.md` (2095 lines): scope, file layout, §PROTOCOL_SIGNATURES, §TDD_TEST_LIST (15 groups), §INTEGRATION_PLAN (25 steps), §RISKS_AND_OPEN_QUESTIONS (10 risks), §HANDOFF.
- **Arbitration record** — `arbitration-1-b1-gate-review.oct.md`: full pre/post-impl gate verdicts (TMG, CRS, CE, CIV), CE risk rulings, IL deviations and justifications, rework cycle log, MERGE_AUTHORIZED status.

### Pre-implementation gate (B1→B2)

- TMG (goose/test-methodology-guardian) = GO
- CE (codex/critical-engineer) = GO with rulings on all 10 risks
- CRS (codex/codereviewer fallback for gemini trust-folder issue) = CONDITIONAL (3 conditions)
- CIV (goose/critical-implementation-validator) = CONDITIONAL with B2_HANDOFF_READY=YES contingent on 7 G-guardrails + 4 A-guardrails landing as RED tests

### Post-implementation gate (Stage C)

- TMG = GO (RED-first cadence + R10-as-acceptance + integration-after-unit verified across 31 commits)
- CRS first pass = CONDITIONAL → IL rework → CRS = GO (exception-swallow fixed)
- CE first pass = NO-GO (RISK_010 swallow-and-publish reproduced; RISK_006 path drift) → IL rework (6 commits) → CE = GO (HONORED, MIRRORED, RESOLVED, PRESENT, no regressions)
- CIV final = GO, MERGE_READY=YES (10/11 guardrails PRESENT; G5 PARTIAL — minor TypeGuard helper gap tracked as follow-up #16)

## Binding rulings honored

- RISK_002: discriminated `PortableArtifact = PortableMemoryArtifact | TombstoneArtifact`.
- RISK_003 OPTION_C: `get_context` signature unchanged; session-bound snapshot exposed only via `clock_in.portable_state.snapshot`. Source-level guard asserts no `StorageAdapter` / `LocalFilesystemAdapter` imports in `get_context.py`.
- RISK_004: `REDACTION_ENGINE_VERSION='1'` constant in `core.redaction`, persisted in artifact metadata, contract test asserts bump on PATTERNS edit.
- RISK_005: v1 payload exactly `{session_id, role, focus, archive_path, decisions, blockers, learnings, description}`.
- RISK_006: local path mirrors ADR abstract: `pss/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/artifacts/{artifact_id}.json` (rooted under `.hestai/state/portable/`).
- RISK_007: no compaction.
- RISK_008: outbox status-only, no retry orchestration.
- RISK_010: fail-closed publish — redaction failure raises `redaction_failure` error_code, blocks publish, writes durable outbox skip status. CE reproducer scenario explicitly covered by integration test.
- RISK_001: identity unavailable → structured fail-closed `restore_error` (no auth invention).

## Out of scope (preserved)

- No new MCP tool registration — server.py still registers exactly 4 tools (clock_in, clock_out, get_context, submit_review).
- No new runtime dependencies — stdlib only.
- No remote adapters, no Git refs, no wire schemas.
- B2_START_BLOCKERS 1–5 honored throughout.

## Follow-ups

- #15 — Post-ADR-0013 follow-up ADRs (4 deferred decisions): explicit identity config schema, outbox retry orchestration, public session snapshot API decision, compaction policy.
- #16 — TypeGuard helpers for PortableArtifact union (G5 partial — minor implementation polish).

Closes #13 (ADR-0013 B1 implementation).

## Test plan

- [ ] CI (lint + typecheck + test on Python 3.11 and 3.12) passes.
- [ ] Coverage ≥85% (current 91.20%).
- [ ] Source invariants assert: no remote adapter imports, no Git ref tokens, no adapter symbols in get_context.py, storage layering acyclic.
- [ ] CE-flagged reproducer (patch RedactionEngine.copy_and_redact to raise) is empirically blocked: `tests/integration/test_clock_out_rework_redaction_failclose.py`.
- [ ] Path layout regression: `tests/storage/test_local_filesystem_path_layout_rework.py` asserts `^pss/[^/]+/[^/]+/[^/]+/[^/]+/artifacts/[^/]+\.json$`.
- [ ] No squash on merge — preserve atomic 37-commit history per HO directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ADR‑0013 B1 portable session state with a local filesystem adapter. Adds snapshot-based restore and fail‑closed publish with a durable outbox, keeps `get_context` pure, and hardens edge cases found in rework.

- **New Features**
  - New `hestai_context_mcp/storage/` package: `types`, `protocol` (`StorageAdapter`), provenance, schema, projection, snapshots, outbox, identity, identity_resolver.
  - `LocalFilesystemAdapter`: local-only PSS at `.hestai/state/portable/pss/{carrier_namespace}/{project_id}/{workspace_id}/{user_id}/artifacts/{artifact_id}.json`; append‑first; idempotent duplicates; content-validated reads.
  - `clock_in`: resolves optional identity from `.hestai/state/portable/identity.json`, restores artifacts, applies tombstones, writes named snapshot under `.hestai/state/portable/snapshots/{session_id}/`, and returns a `portable_state` block.
  - `clock_out`: builds v1 payload, requires complete redaction provenance, publishes via `LocalFilesystemAdapter`, enqueues status-only outbox entries under `.hestai/state/portable/outbox/`, and returns `portable_publication` + `unpublished_memory_exists`.
  - Redaction provenance: `REDACTION_ENGINE_NAME` and `REDACTION_ENGINE_VERSION='1'` embedded in artifact metadata.
  - Deterministic projection builder and schema v1 with fail‑closed restore.

- **Bug Fixes**
  - Fail‑closed publish on redaction errors (no artifact write), durable outbox status on skips, and no same input/output hash fallback.
  - Snapshot write failures are surfaced as `portable_state.snapshot_error` (no exception); `artifact_count` now reflects post‑tombstone projection even when snapshot build fails.
  - Identity validation hardened: non‑string components rejected; `state_schema_version` rejects bool; resolver treats non‑string fields as “no identity configured.”
  - `list_artifacts(after_id)` paginates by canonical `(sequence_id, artifact_id)` cursor.
  - Strict PSS path classification: only the exact 8‑segment `portable/pss/{ns}/{proj}/{ws}/{user}/{leaf}/{id}.json` shape maps to portable memory.
  - Outbox parsing wraps UnicodeDecodeError as `OutboxParseError` (fail‑closed).
  - Path layout aligned to ADR: `pss/.../artifacts/{id}.json` (removes `v{schema}` segment).
  - `clock_out` cleanup no longer leaks `UnboundLocalError` when `dest` is unset.
  - `get_context` remains a pure read (no storage adapter imports or portable dir writes).

<sup>Written for commit cbc5eb802aceb65f499085d98edfef9185722fd8. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/17?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

