### PR TITLE
docs: modernize north-star post-ADR-0013

### DIFF
--- a/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md
+++ b/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md
@@ -7,6 +7,7 @@ META:
   APPROVED_BY::"Human operator (2026-04-17)"
   FULL_DOCUMENT::"000-HESTAI-CONTEXT-MCP-NORTH-STAR.md"
   COMPRESSION::"311 to 95 lines (3.3:1)"
+  LAST_UPDATED::"2026-04-30"
 §1::IDENTITY
 PURPOSE::"Persistent memory and environmental context for AI-assisted development sessions"
 ROLE_IN_ECOSYSTEM::"Memory and Environment in Three-Service Model (ADR-0353)"
@@ -23,17 +24,17 @@ I6::"LEGACY_INDEPENDENCE<PRINCIPLE::no_runtime_or_install_dependency_on_hestai_m
 A1::"STDIO_TRANSPORT_SUFFICIENT[85%] HIGH_CONFIDENCE"
 A2::"JSONL_LEARNINGS_SCALES[80%] MEDIUM_CONFIDENCE"
 A3::"ADAPTER_PATTERN_COVERS_PROVIDERS[90%] HIGH_CONFIDENCE"
-A4::"REDACTION_PATTERN_COVERAGE[75%] CRITICAL"
+A4::"REDACTION_PATTERN_COVERAGE[80%] CRITICAL<CADENCE::adversarial_review_each_minor_release_or_on_new_provider_adapter>"
 A5::"GET_CONTEXT_SUFFICIENT_FOR_POSITION_3[80%] CRITICAL"
-A6::"SINGLE_HESTAI_DIR_WORKS[75%] MEDIUM_CONFIDENCE"
-A7::"PHASE_1_IS_MINIMUM_VIABLE[85%] HIGH_CONFIDENCE"
-A8::"BRANCH_FOCUS_RESOLUTION_USEFUL[70%] LOW_CONFIDENCE"
+A6::"PORTABLE_STATE_DEFAULT_LOCAL_FILESYSTEM[90%] HIGH_CONFIDENCE"
+A7::"BRANCH_FOCUS_RESOLUTION_USEFUL[70%] LOW_CONFIDENCE"
 §4::SCOPE_BOUNDARIES
 IS::[
   "session lifecycle management (clock_in, clock_out)",
   "context synthesis engine (.hestai state, North Stars, git state)",
   "learnings extraction pipeline (transcript parsing, redaction, indexing)",
-  "review infrastructure (structured PR verdicts, CI gate clearing)"
+  "review infrastructure (structured PR verdicts, CI gate clearing)",
+  "portable session state (StorageAdapter, IdentityTuple, PortableArtifact union) per ADR-0013"
 ]
 IS_NOT::[
   "agent identity or governance (Vault owns)",
@@ -59,8 +60,13 @@ COVERAGE::[
   IMMUTABLE::"85_percent_minimum_CI_enforced",
   FLEXIBLE::test_strategies
 ]
+STORAGE_BACKEND::[
+  IMMUTABLE::StorageAdapter_protocol,
+  FLEXIBLE::adapter_implementation,
+  NEGOTIABLE::carrier_namespace_layout
+]
 §6::GATES
-GATES::"D1[DONE] B1[DONE_Phase_1] B2[PENDING_Phase_2_workbench_integration] B3[FUTURE] B4[FUTURE]"
+GATES::"D1[DONE] B1[DONE_Phase_1+Phase_1.5+PSS_B1_2026-04-29] B2[PENDING_workbench_Phase_3C_integration] B3[FUTURE_NS_injection_unification] B4[FUTURE_git_hooks_legacy_deprecation]"
 §7::ESCALATION
 ESCALATION_ROUTING::[
   requirements_steward::[
@@ -87,7 +93,8 @@ LOAD_FULL_NORTH_STAR_IF::[
   "side effect or mutation or get_context writes = I5 purity violation",
   "import hestai_mcp or legacy dependency = I6 independence breach",
   "scope boundary or feature creep = identity boundary question",
-  "B2 or Phase 2 or workbench integration = decision gate approaching"
+  "B2 or Phase 2 or workbench integration = decision gate approaching",
+  "identity tuple or carrier_namespace or storage adapter or multi_directory = ADR-0013 boundary question"
 ]
 §9::PROTECTION
 IF::agent_detects_work_contradicting_North_Star

--- a/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR.md
+++ b/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR.md
@@ -216,11 +216,10 @@ These aspects are important but negotiable within the constraints of the immutab
 | A1 | Stdio subprocess transport is sufficient for all consumers | ADR-0353 | Need daemon/network transport, adds operational complexity | 85% | HIGH | Workbench integration testing |
 | A2 | JSONL learnings index scales to hundreds of sessions | Implementation choice | Need database or indexed storage | 80% | MEDIUM | Load test at 500+ sessions |
 | A3 | Transcript parsing adapter pattern covers future providers | Architecture decision | New provider requires new parser, but pattern supports it | 90% | LOW | Add parser when new provider appears |
-| A4 | RedactionEngine credential patterns cover real-world leaks | Security design | Undetected credential type persists in archive | 75% | CRITICAL | Periodic audit against new credential formats |
+| A4 | RedactionEngine credential patterns cover real-world leaks | Security design | Undetected credential type persists in archive | 80% | CRITICAL | Periodic audit against new credential formats Adversarial review cadence: each minor release OR on new provider adapter. |
 | A5 | get_context response is sufficient for Payload Compiler Position 3 | Interface contract | Compiler needs fields not provided, requires contract revision | 80% | HIGH | First Payload Compiler integration |
-| A6 | Single .hestai/ directory structure works for all project layouts | Convention | Monorepo or non-standard layouts need different discovery | 75% | MEDIUM | Test with 3+ project structures |
-| A7 | Phase 1 (4 tools) covers the minimum viable context engine | Harvest scope | Missing tool blocks Workbench integration | 85% | HIGH | Workbench Step 3A integration |
-| A8 | Focus resolution from branch names provides useful session context | Implementation | Branch names are not meaningful, focus is always "general" | 70% | LOW | Observe focus values in real sessions |
+| A6 | Portable state default is LocalFilesystem; multi-dir continuity provided by StorageAdapter protocol + IdentityTuple per ADR-0013 | ADR-0013 | Single-dir default fails for forks/worktrees/cross-machine — but ADR-0013 covers those cases | 90% | HIGH | Production exercise via PR #17 (853 tests, 91.20% coverage) |
+| A7 | Focus resolution from branch names provides useful session context | Implementation | Branch names are not meaningful, focus is always "general" | 70% | LOW | Observe focus values in real sessions |
 
 ### CRITICAL ASSUMPTIONS (Must validate before next phase)
 
@@ -254,13 +253,14 @@ These aspects are important but negotiable within the constraints of the immutab
 
 ## SECTION 6: CURRENT PHASE ASSESSMENT
 
-**Phase**: B1 (First functional build complete)
+**Phase**: B1 (Phase 1 + Phase 1.5 + PSS B1 complete; Phase 2 pending workbench integration)
 
 **What exists**:
 - 4 MCP tools operational: clock_in, clock_out, get_context, submit_review
 - Core modules: SessionManager, ContextSteward, RedactionEngine, FocusResolver, GitStateDetector
 - Transcript parsing with provider adapter pattern
-- 361 tests, 89% coverage, Python 3.11/3.12 CI
+- Portable session state (StorageAdapter, IdentityTuple, PortableArtifact union) per ADR-0013 B1 (PR #17, merged 2026-04-29)
+- 853 tests, 91.20% coverage, Python 3.11/3.12 CI
 - All quality gates green (ruff, black, mypy, pytest)
 - Product North Star (this document) established
 


### PR DESCRIPTION
## Summary
- Updated HESTAI Context MCP North Star documentation to reflect ADR-0013 decisions
- Restated A4/A6 architectural assumptions with current clarity and retired A7 per decision record
- Aligned north-star summary and detailed docs for consistency across ecosystem standards

## Changes
- `.hestai-sys/standards/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md`: Modernized summary with A4/A6 restatement and A7 retirement (21 insertions, 13 deletions)
- `.hestai-sys/standards/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR.md`: Updated detailed north-star doc for consistency with ADR-0013 outcomes (12 insertions, 6 deletions)