### PR TITLE
feat: add GitHub auth token fallback for submit_review

### DIFF
--- a/src/hestai_context_mcp/tools/submit_review.py
+++ b/src/hestai_context_mcp/tools/submit_review.py
@@ -56,12 +56,18 @@ _AUTH_ERROR_MESSAGE = (
 #     ghp_ (personal), gho_ (OAuth), ghu_ (user-to-server),
 #     ghs_ (server-to-server), ghr_ (refresh) followed by ≥20
 #     [A-Za-z0-9_] characters.
+#   - Fine-grained personal access tokens (2022+): github_pat_ prefix
+#     followed by ≥20 [A-Za-z0-9_] characters. Added per cubic P1
+#     finding on PR #35 — without this alternation, ``gh auth token``
+#     returning a valid fine-grained PAT would be silently rejected.
 #   - Classic 40-char lowercase hex personal access tokens for
 #     accounts that have not rotated since the prefix scheme rolled
 #     out.
 #
 # Compiled once at import time to avoid per-call recompilation.
-_TOKEN_SHAPE_RE = re.compile(r"^(?:gh[pousr]_[A-Za-z0-9_]{20,}|[a-f0-9]{40})$")
+_TOKEN_SHAPE_RE = re.compile(
+    r"^(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|[a-f0-9]{40})$"
+)
 
 
 def _resolve_github_token() -> str | None:

--- a/src/hestai_context_mcp/tools/submit_review.py
+++ b/src/hestai_context_mcp/tools/submit_review.py
@@ -28,6 +28,68 @@ from hestai_context_mcp.tools.shared.review_formats import (
     has_tmg_approval,
 )
 
+# Timeout for the ``gh auth token`` precondition gate. Short by design:
+# the call is a local CLI invocation, not a network request, and a hang
+# here would block every submit_review call until the global gh-api
+# timeout (30 s) fires for an unrelated reason.
+_GH_AUTH_TIMEOUT_SECONDS = 5
+
+# Auth error message lists ALL three lookup tiers so operators can
+# diagnose which one needs configuring. The token value itself is NEVER
+# included in this message (security invariant — see _resolve_github_token).
+_AUTH_ERROR_MESSAGE = (
+    "GitHub credentials not found. Set GITHUB_TOKEN or GH_TOKEN environment "
+    "variable, or authenticate the gh CLI (so `gh auth token` returns a token)."
+)
+
+
+def _resolve_github_token() -> str | None:
+    """Resolve a GitHub token via three-tier lookup.
+
+    Lookup order (first hit wins):
+      1. ``GITHUB_TOKEN`` environment variable.
+      2. ``GH_TOKEN`` environment variable.
+      3. ``gh auth token`` subprocess (5 s timeout) — uses the operator's
+         authenticated ``gh`` CLI keyring. The MCP server runs as a stdio
+         subprocess and does NOT inherit gh keyring credentials, so this
+         tier is what makes the tool usable for agents who have not
+         exported a token into the launch environment. (Issue #34)
+
+    Returns:
+        The resolved token string, or ``None`` if no tier supplied a token.
+
+    Security:
+        The returned value is opaque — callers MUST NOT log it, embed it
+        in error messages, or include it in any structured response. This
+        helper exists precisely so that token handling is funneled through
+        a single audited code path.
+    """
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+
+    # Tier 3: ``gh auth token``. Catch ``Exception`` so any failure mode
+    # here (gh missing → FileNotFoundError, gh hung → TimeoutExpired,
+    # gh corrupted → OSError, anything else → unhandled) becomes a clean
+    # None return rather than an exception that would crash the stdio
+    # MCP server. ``BaseException`` is intentionally NOT caught — a
+    # KeyboardInterrupt or SystemExit during this call should propagate.
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_AUTH_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    candidate = (result.stdout or "").strip()
+    return candidate or None
+
 
 def _validate_inputs(
     repo: str,
@@ -167,11 +229,10 @@ def _post_comment(repo: str, pr_number: int, comment: str) -> dict[str, Any]:
     Returns:
         Dict with success status and comment URL or error info.
     """
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if not token:
+    if _resolve_github_token() is None:
         return {
             "success": False,
-            "error": "GITHUB_TOKEN or GH_TOKEN environment variable not set",
+            "error": _AUTH_ERROR_MESSAGE,
             "error_type": "auth",
         }
 
@@ -263,6 +324,24 @@ def submit_review(
     Supports dry-run validation without posting.
 
     Fail-closed: if format validation fails, the comment is NOT posted.
+
+    Authentication (issue #34):
+        When posting (``dry_run=False``), the tool resolves a GitHub token
+        via three-tier lookup, in order:
+
+          1. ``GITHUB_TOKEN`` environment variable.
+          2. ``GH_TOKEN`` environment variable.
+          3. ``gh auth token`` subprocess (5 s timeout) — uses the
+             operator's authenticated ``gh`` CLI keyring.
+
+        The MCP server runs as a stdio subprocess and does NOT inherit
+        the operator's ``gh`` keyring, so tier 3 is what makes the tool
+        usable for agents that have not exported a token into the launch
+        environment. The resolved token is opaque to the caller — it is
+        never logged, returned, or embedded in error messages. If all
+        three tiers fail, the call returns an ``auth`` error whose
+        message names all three lookup paths so the operator can
+        diagnose which tier needs configuring.
 
     Args:
         repo: Repository in owner/name format (e.g., 'elevanaltd/HestAI-MCP').

--- a/src/hestai_context_mcp/tools/submit_review.py
+++ b/src/hestai_context_mcp/tools/submit_review.py
@@ -11,6 +11,7 @@ Fail-closed: validates format before posting.
 
 import json
 import os
+import re
 import subprocess
 from typing import Any
 
@@ -41,6 +42,26 @@ _AUTH_ERROR_MESSAGE = (
     "GitHub credentials not found. Set GITHUB_TOKEN or GH_TOKEN environment "
     "variable, or authenticate the gh CLI (so `gh auth token` returns a token)."
 )
+
+# Token-shape sanity guard for the ``gh auth token`` tier (issue #34
+# CE rework). The aim is NOT cryptographic validation — it is to reject
+# obviously-malformed payloads (error text echoed to stdout, HTML
+# wrappers, multi-line junk) so the failure-mode contract collapses
+# inside _resolve_github_token rather than propagating to the GitHub
+# API. PERMISSIVE on accepts: a false negative breaks the user's
+# workflow on a perfectly valid credential.
+#
+# Accepted shapes:
+#   - Modern gh prefixes (per GitHub's published taxonomy, 2021-04+):
+#     ghp_ (personal), gho_ (OAuth), ghu_ (user-to-server),
+#     ghs_ (server-to-server), ghr_ (refresh) followed by ≥20
+#     [A-Za-z0-9_] characters.
+#   - Classic 40-char lowercase hex personal access tokens for
+#     accounts that have not rotated since the prefix scheme rolled
+#     out.
+#
+# Compiled once at import time to avoid per-call recompilation.
+_TOKEN_SHAPE_RE = re.compile(r"^(?:gh[pousr]_[A-Za-z0-9_]{20,}|[a-f0-9]{40})$")
 
 
 def _resolve_github_token() -> str | None:
@@ -88,7 +109,16 @@ def _resolve_github_token() -> str | None:
         return None
 
     candidate = (result.stdout or "").strip()
-    return candidate or None
+    if not candidate:
+        return None
+
+    # Shape sanity guard (CE rework): reject malformed payloads BEFORE
+    # they reach the GitHub API. Silent rejection — the candidate is
+    # NEVER logged or surfaced (security invariant).
+    if not _TOKEN_SHAPE_RE.match(candidate):
+        return None
+
+    return candidate
 
 
 def _validate_inputs(

--- a/tests/tools/test_submit_review.py
+++ b/tests/tools/test_submit_review.py
@@ -1429,3 +1429,43 @@ class TestTokenResolution:
                 dry_run=False,
             )
         assert result["status"] == "ok"
+
+    def test_resolve_accepts_fine_grained_pat_prefix(self):
+        """Fine-grained personal access tokens (github_pat_, 2022+) MUST resolve.
+
+        Per cubic P1 finding on PR #35 HEAD e6382a7: the original guard
+        ``^(?:gh[pousr]_[A-Za-z0-9_]{20,}|[a-f0-9]{40})$`` rejected the
+        ``github_pat_`` prefix entirely, so ``gh auth token`` returning
+        a valid fine-grained PAT would be silently dropped — exactly
+        the false-negative failure mode the PERMISSIVE-on-accepts
+        directive was meant to prevent.
+        """
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        # github_pat_ + 30 [A-Za-z0-9_] chars; well above the 20-char
+        # minimum the alternation requires.
+        fine_grained_pat = "github_pat_" + "A" * 30
+
+        class _AuthCP:
+            returncode = 0
+            stdout = fine_grained_pat + "\n"
+            stderr = ""
+
+        def _router(cmd, *args, **kwargs):
+            if list(cmd[:3]) == ["gh", "auth", "token"]:
+                return _AuthCP()
+            return TestTokenResolution._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_router),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "ok"

--- a/tests/tools/test_submit_review.py
+++ b/tests/tools/test_submit_review.py
@@ -1104,6 +1104,32 @@ class TestTokenResolution:
         assert result["status"] == "error"
         assert result["error_type"] == "auth"
 
+    def test_gh_auth_unexpected_exception_returns_auth_error(self):
+        """env empty + ``gh auth token`` raises unexpected exception ->
+        auth error (NOT an unhandled crash that would kill the MCP server).
+
+        Per TMG verdict on 73f2672 (continuation 961b3109-72e1-4084-a370-
+        edf70824fa22): the gh-auth-token call is a precondition gate; any
+        failure mode there must produce a structured auth error, not bubble
+        up as an unhandled exception that crashes the stdio subprocess.
+        """
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        with (
+            patch("subprocess.run", side_effect=RuntimeError("gh binary corrupted")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
     def test_gh_auth_timeout_returns_auth_error(self):
         """env empty + ``gh auth token`` times out -> auth error (NOT network).
 

--- a/tests/tools/test_submit_review.py
+++ b/tests/tools/test_submit_review.py
@@ -1232,3 +1232,200 @@ class TestTokenResolution:
         assert "GITHUB_TOKEN" in message
         assert "GH_TOKEN" in message
         assert "gh auth token" in message
+
+    # ------------------------------------------------------------------
+    # Token-shape validation (CE rework on PR #35).
+    #
+    # Per CE CONDITIONAL verdict on commit 8732750: the helper must
+    # collapse a malformed ``gh auth token`` payload (error text echoed
+    # to stdout, HTML wrapper, multi-line junk, too-short candidate) to
+    # ``None`` BEFORE the precondition gate proceeds, rather than
+    # passing the malformed string through and letting it fail
+    # downstream at the GitHub API. Permissive on accepts (false
+    # negatives on a real token break the user's workflow); strict on
+    # obvious garbage.
+    #
+    # Accepted shapes:
+    #   - Modern gh prefixes: ghp_, gho_, ghu_, ghs_, ghr_ + ≥20
+    #     [A-Za-z0-9_] chars (covers ghp_ personal tokens, gho_ OAuth
+    #     tokens, ghu_ user-to-server, ghs_ server-to-server, ghr_
+    #     refresh tokens — per GitHub's published prefix taxonomy).
+    #   - Classic 40-char hex personal access tokens for accounts that
+    #     have not rotated since the prefix scheme rolled out.
+    # ------------------------------------------------------------------
+    def test_gh_auth_malformed_error_text_rejected(self):
+        """``gh auth token`` returning error text on stdout collapses to auth error."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _MalformedCP:
+            returncode = 0  # gh erroneously exited 0 with junk on stdout
+            stdout = "error: not authenticated. Run `gh auth login`.\n"
+            stderr = ""
+
+        with (
+            patch("subprocess.run", return_value=_MalformedCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_html_payload_rejected(self):
+        """``gh auth token`` returning an HTML wrapper collapses to auth error.
+
+        Defensive case: a misconfigured proxy or man-in-the-middle could
+        in principle cause gh to surface HTML on stdout. Token-shape
+        validation MUST reject it.
+        """
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _HtmlCP:
+            returncode = 0
+            stdout = "<html><body>401 Unauthorized</body></html>"
+            stderr = ""
+
+        with (
+            patch("subprocess.run", return_value=_HtmlCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_multiline_payload_rejected(self):
+        """A multi-line stdout (token plus diagnostic chatter) collapses to
+        auth error — the helper must not echo a multi-line credential."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _MultilineCP:
+            returncode = 0
+            stdout = "ghp_validlookingtokenxxxxxxxxxxxxxxxx\nWARN: refresh recommended\n"
+            stderr = ""
+
+        with (
+            patch("subprocess.run", return_value=_MultilineCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_too_short_candidate_rejected(self):
+        """A candidate shorter than the minimum modern-prefix length is rejected."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _ShortCP:
+            returncode = 0
+            stdout = "ghp_short\n"  # ghp_ + 5 chars; modern prefix needs ≥20 trailing
+            stderr = ""
+
+        with (
+            patch("subprocess.run", return_value=_ShortCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_classic_40hex_pat_accepted(self):
+        """Classic 40-char hex personal access tokens MUST still resolve.
+
+        Older gh installs that have not rotated credentials since the
+        prefix scheme rolled out (2021-04) still emit 40-hex PATs. We
+        MUST accept these; a false negative here breaks the user's
+        workflow on a perfectly valid credential.
+        """
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        classic_pat = "0123456789abcdef0123456789abcdef01234567"  # 40 hex chars
+        assert len(classic_pat) == 40
+
+        class _AuthCP:
+            returncode = 0
+            stdout = classic_pat + "\n"
+            stderr = ""
+
+        def _router(cmd, *args, **kwargs):
+            if list(cmd[:3]) == ["gh", "auth", "token"]:
+                return _AuthCP()
+            return TestTokenResolution._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_router),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "ok"
+
+    def test_gh_auth_modern_prefix_accepted(self):
+        """A canonical modern ``ghp_…`` token MUST resolve cleanly.
+
+        Belt-and-braces with the existing fallback success test, which
+        also uses a ghp_-prefixed sentinel; this test pins the contract
+        explicitly so a future change to the sentinel value does not
+        silently weaken the modern-prefix accept path.
+        """
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        # ghp_ + 36 [A-Za-z0-9_] chars — comfortably above the 20-char
+        # minimum and within the realistic published shape.
+        modern_token = "ghp_" + "A" * 36
+
+        class _AuthCP:
+            returncode = 0
+            stdout = modern_token + "\n"
+            stderr = ""
+
+        def _router(cmd, *args, **kwargs):
+            if list(cmd[:3]) == ["gh", "auth", "token"]:
+                return _AuthCP()
+            return TestTokenResolution._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_router),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "ok"

--- a/tests/tools/test_submit_review.py
+++ b/tests/tools/test_submit_review.py
@@ -926,9 +926,7 @@ class TestTokenResolution:
 
         class _CP:
             returncode = 0
-            stdout = (
-                "HTTP/2 201 Created\ncontent-type: application/json\n\n" + stdout_body
-            )
+            stdout = "HTTP/2 201 Created\ncontent-type: application/json\n\n" + stdout_body
             stderr = ""
 
         return _CP()

--- a/tests/tools/test_submit_review.py
+++ b/tests/tools/test_submit_review.py
@@ -469,10 +469,21 @@ class TestGitHubPosting:
         assert "github.com" in result["comment_url"]
 
     def test_missing_github_token_returns_error(self):
-        """Without GITHUB_TOKEN, posting should fail with auth error."""
+        """Without GITHUB_TOKEN/GH_TOKEN AND no usable ``gh auth token``,
+        posting should fail with an auth error.
+
+        Patches subprocess so the test is deterministic regardless of
+        whether the test host has ``gh`` installed and authenticated.
+        Issue #34 introduces a third lookup tier (``gh auth token``); this
+        test asserts the auth-error contract still holds when ALL three
+        tiers fail.
+        """
         from hestai_context_mcp.tools.submit_review import submit_review
 
-        with patch.dict("os.environ", {}, clear=True):
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("gh not installed")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
             result = submit_review(
                 repo="owner/repo",
                 pr_number=1,
@@ -776,10 +787,18 @@ class TestReturnShape:
         assert result["error_type"] == "validation"
 
     def test_error_path_missing_token_includes_top_level_commit_sha(self):
-        """Missing-token auth error exposes commit_sha at top level (echo)."""
+        """Missing-token auth error exposes commit_sha at top level (echo).
+
+        Patches subprocess to deterministically simulate ``gh`` being absent
+        so the third lookup tier (issue #34) cannot accidentally satisfy
+        the precondition on hosts where ``gh auth token`` would succeed.
+        """
         from hestai_context_mcp.tools.submit_review import submit_review
 
-        with patch.dict("os.environ", {}, clear=True):
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("gh not installed")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
             result = submit_review(
                 repo="owner/repo",
                 pr_number=1,
@@ -794,10 +813,17 @@ class TestReturnShape:
         assert result["commit_sha"] == "authtest456"
 
     def test_error_path_missing_token_includes_top_level_error_type(self):
-        """Missing-token auth error exposes error_type='auth' at top level."""
+        """Missing-token auth error exposes error_type='auth' at top level.
+
+        Patches subprocess to deterministically simulate ``gh`` being absent
+        (see sibling test for rationale).
+        """
         from hestai_context_mcp.tools.submit_review import submit_review
 
-        with patch.dict("os.environ", {}, clear=True):
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("gh not installed")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
             result = submit_review(
                 repo="owner/repo",
                 pr_number=1,
@@ -869,3 +895,316 @@ class TestReturnShape:
         )
         assert result["status"] == "ok"
         assert "error_type" not in result
+
+
+# ---------------------------------------------------------------------------
+# Token-resolution tests (issue #34)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTokenResolution:
+    """Three-tier token lookup: GITHUB_TOKEN -> GH_TOKEN -> ``gh auth token``.
+
+    Per issue #34: the MCP server runs as a stdio subprocess and does not
+    inherit the operator's ``gh`` keyring credentials. Falling back to
+    ``gh auth token`` lets ``submit_review`` work whenever the operator has
+    authenticated their CLI, without requiring a manual env-var export.
+
+    Security invariants (must hold across ALL tests in this class):
+      - The resolved token MUST NOT appear in any returned dict field.
+      - The resolved token MUST NOT appear in any error message.
+      - Subprocess calls to the real ``gh`` binary MUST be mocked.
+    """
+
+    # The sentinel token value used across this class. Any test that
+    # exercises a successful resolution path MUST assert this string does
+    # NOT appear in the returned result.
+    SENSITIVE_TOKEN = "ghp_SENSITIVE_TOKEN_NEVER_LEAK_xxxxxxxxxxxxxxxx"
+
+    @staticmethod
+    def _post_success_completed(stdout_body: str = '{"html_url": "https://x/y"}'):
+        """Build a CompletedProcess-like double for a successful API post."""
+
+        class _CP:
+            returncode = 0
+            stdout = (
+                "HTTP/2 201 Created\ncontent-type: application/json\n\n" + stdout_body
+            )
+            stderr = ""
+
+        return _CP()
+
+    # ------------------------------------------------------------------
+    # Tier 1: GITHUB_TOKEN env wins; gh subprocess never invoked.
+    # ------------------------------------------------------------------
+    def test_github_token_env_skips_gh_auth_subprocess(self):
+        """When GITHUB_TOKEN is set, the gh-auth-token fallback MUST NOT run."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        recorded_calls: list[list[str]] = []
+
+        def _spy(cmd, *args, **kwargs):
+            recorded_calls.append(list(cmd))
+            return self._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_spy),
+            patch.dict("os.environ", {"GITHUB_TOKEN": self.SENSITIVE_TOKEN}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+
+        # Only the gh-api post call should be made; never `gh auth token`.
+        assert all(call[:3] != ["gh", "auth", "token"] for call in recorded_calls), (
+            f"gh auth token was unexpectedly invoked when GITHUB_TOKEN was set: "
+            f"{recorded_calls}"
+        )
+        assert result["status"] == "ok"
+
+    # ------------------------------------------------------------------
+    # Tier 2: GH_TOKEN env wins; gh subprocess never invoked.
+    # ------------------------------------------------------------------
+    def test_gh_token_env_skips_gh_auth_subprocess(self):
+        """When GH_TOKEN is set, the gh-auth-token fallback MUST NOT run."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        recorded_calls: list[list[str]] = []
+
+        def _spy(cmd, *args, **kwargs):
+            recorded_calls.append(list(cmd))
+            return self._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_spy),
+            patch.dict("os.environ", {"GH_TOKEN": self.SENSITIVE_TOKEN}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+
+        assert all(call[:3] != ["gh", "auth", "token"] for call in recorded_calls)
+        assert result["status"] == "ok"
+
+    # ------------------------------------------------------------------
+    # Tier 3: env empty, gh present, gh auth token succeeds.
+    # ------------------------------------------------------------------
+    def test_gh_auth_fallback_succeeds_when_env_empty(self):
+        """env empty + ``gh auth token`` returns 0 with token -> posting proceeds."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        gh_auth_returned = False
+
+        class _AuthCP:
+            returncode = 0
+            stdout = TestTokenResolution.SENSITIVE_TOKEN + "\n"
+            stderr = ""
+
+        def _router(cmd, *args, **kwargs):
+            nonlocal gh_auth_returned
+            if list(cmd[:3]) == ["gh", "auth", "token"]:
+                gh_auth_returned = True
+                return _AuthCP()
+            # API post call
+            return TestTokenResolution._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_router),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+
+        assert gh_auth_returned, "gh auth token fallback was not invoked"
+        assert result["status"] == "ok"
+
+    # ------------------------------------------------------------------
+    # Tier 3 failures: each should produce the auth error.
+    # ------------------------------------------------------------------
+    def test_gh_not_installed_returns_auth_error(self):
+        """env empty + gh not on PATH -> auth error (FileNotFoundError handled)."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("gh not found")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_nonzero_returns_auth_error(self):
+        """env empty + ``gh auth token`` returns non-zero -> auth error."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _AuthFailCP:
+            returncode = 1
+            stdout = ""
+            stderr = "not logged in"
+
+        with (
+            patch("subprocess.run", return_value=_AuthFailCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_empty_stdout_returns_auth_error(self):
+        """env empty + ``gh auth token`` returns 0 but stdout is whitespace
+        only -> auth error (empty token is not a valid credential)."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _EmptyCP:
+            returncode = 0
+            stdout = "   \n\t  "
+            stderr = ""
+
+        with (
+            patch("subprocess.run", return_value=_EmptyCP()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    def test_gh_auth_timeout_returns_auth_error(self):
+        """env empty + ``gh auth token`` times out -> auth error (NOT network).
+
+        The gh-auth-token call is a precondition gate, not the network
+        request; classifying its timeout as ``auth`` keeps retry strategies
+        from hammering an unreachable token resolver.
+        """
+        import subprocess as sp
+
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=sp.TimeoutExpired("gh", 5),
+            ),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        assert result["error_type"] == "auth"
+
+    # ------------------------------------------------------------------
+    # Security: the resolved token must NEVER leak into the response.
+    # ------------------------------------------------------------------
+    def test_resolved_token_does_not_leak_into_response_env_path(self):
+        """Token from GITHUB_TOKEN env MUST NOT appear anywhere in the result."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        with (
+            patch("subprocess.run", return_value=self._post_success_completed()),
+            patch.dict("os.environ", {"GITHUB_TOKEN": self.SENSITIVE_TOKEN}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert self.SENSITIVE_TOKEN not in repr(result)
+
+    def test_resolved_token_does_not_leak_into_response_gh_path(self):
+        """Token from ``gh auth token`` MUST NOT appear anywhere in the result."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        class _AuthCP:
+            returncode = 0
+            stdout = TestTokenResolution.SENSITIVE_TOKEN + "\n"
+            stderr = ""
+
+        def _router(cmd, *args, **kwargs):
+            if list(cmd[:3]) == ["gh", "auth", "token"]:
+                return _AuthCP()
+            return TestTokenResolution._post_success_completed()
+
+        with (
+            patch("subprocess.run", side_effect=_router),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert self.SENSITIVE_TOKEN not in repr(result)
+
+    # ------------------------------------------------------------------
+    # UX: auth error message names all three lookup paths so operators
+    # can fix the right one.
+    # ------------------------------------------------------------------
+    def test_auth_error_message_names_all_three_lookup_paths(self):
+        """The auth-error message must mention GITHUB_TOKEN, GH_TOKEN, and
+        ``gh auth token`` so operators can diagnose which tier failed."""
+        from hestai_context_mcp.tools.submit_review import submit_review
+
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("gh not found")),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            result = submit_review(
+                repo="owner/repo",
+                pr_number=1,
+                role="CE",
+                verdict="APPROVED",
+                assessment="LGTM.",
+                dry_run=False,
+            )
+        assert result["status"] == "error"
+        message = result["validation"]["error"]
+        assert "GITHUB_TOKEN" in message
+        assert "GH_TOKEN" in message
+        assert "gh auth token" in message


### PR DESCRIPTION
## Summary
- Implement fallback to GitHub CLI auth token when `GITHUB_TOKEN` environment variable is unset, enabling graceful degradation in CI/local environments
- Extend `submit_review` token resolution with defensive exception handling and comprehensive test coverage for both success and error paths
- Addresses issue #34 (P0 Phase-2 critical path) with full TDD approach and T2 quality chain compliance

## Changes
- **src/hestai_context_mcp/tools/submit_review.py**: Add `_resolve_gh_token()` helper with env-var-first strategy, fallback to `gh auth token` CLI invocation, and structured error messaging
- **tests/tools/test_submit_review.py**: New `TestTokenResolution` class driving fallback behavior (RED→GREEN); add exception coverage for CLI failures and missing credentials; expand `TestReturnShape` assertions to validate token resolution on both success and error paths
- Token resolution now returns early with clear error context rather than propagating upstream, improving debuggability in token-absent scenarios

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a three-tier GitHub token resolver for `submit_review` with `GITHUB_TOKEN`, then `GH_TOKEN`, then `gh auth token` (5s timeout). Validates `gh` output shape (including `github_pat_…`) and returns a clear auth error if all fail; the token is never exposed. Addresses issue #34 and improves CI/local usability.

- **New Features**
  - Added `_resolve_github_token()` with env-first strategy and `gh auth token` fallback (5s); `submit_review` now reports one auth error that names all three lookup paths.

- **Bug Fixes**
  - Shape-validate `gh auth token` output: accept modern `gh[pousr]_…`, `github_pat_…`, and classic 40-hex PATs; reject error text, HTML, multiline, and too-short payloads.
  - Tests cover shape rejection, timeouts, unexpected exceptions, and token non-leak; legacy tests patched to mock subprocess deterministically.

<sup>Written for commit 2abf1271a4ed89539e5daeecd1f496ec52b161de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

