### PR TITLE
chore: ignore .env in gitignore for worktree symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ build/
 venv/
 ENV/
 
+# Environment variables (worktree-symlinked from main repo by SessionStart hook)
+.env
+.env.local
+.env.*.local
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## Summary
- Added .env to .gitignore to prevent worktree symlinks from surfacing as untracked files
- Resolves noise in git status when using git worktrees with environment configuration files

## Changes
- Updated .gitignore with .env entry to exclude environment files from version control tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignored `.env`, `.env.local`, and `.env.*.local` in `.gitignore` to prevent worktree-symlinked env files from appearing as untracked. This removes git status noise and keeps env config out of version control.

<sup>Written for commit e10116fc146392c689c1dd71edcb2b07e4c5fa99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

