### PR TITLE
fix: add server entry point and script entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "keyring>=25.0.0",
 ]
 
+[project.scripts]
+hestai-context = "hestai_context_mcp.server:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4.0",

--- a/src/hestai_context_mcp/server.py
+++ b/src/hestai_context_mcp/server.py
@@ -33,3 +33,7 @@ mcp.tool(submit_review)
 def main() -> None:
     """Run the MCP server over stdio transport."""
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 """Smoke tests for the MCP server skeleton."""
 
+import subprocess
+import sys
+
 import pytest
 
 
@@ -32,6 +35,77 @@ class TestServerImport:
 
         assert isinstance(__version__, str)
         assert __version__ == "0.1.0"
+
+
+@pytest.mark.smoke
+class TestServerExecution:
+    """Test the new if __name__ == '__main__' entry point and script invocation."""
+
+    def test_module_execution_via_main_guard(self):
+        """The module should execute main() when run as a script (if __name__ check)."""
+        from unittest.mock import MagicMock, patch
+
+        # Test that the if __name__ == "__main__" guard properly calls main()
+        with patch("hestai_context_mcp.server.mcp.run") as mock_run:
+            # Import the module fresh to trigger the guard
+            import importlib
+            import hestai_context_mcp.server as server_module
+
+            # Re-execute the if __name__ == "__main__" block by calling main directly
+            # (This verifies that main() is the correct entry point)
+            server_module.main()
+            mock_run.assert_called_once()
+
+    def test_module_execution_via_subprocess(self):
+        """The module should handle subprocess invocation without crashing."""
+        result = subprocess.run(
+            [sys.executable, "-m", "hestai_context_mcp.server"],
+            input=b"",
+            capture_output=True,
+            timeout=2,
+        )
+        # Process should not crash during import or setup
+        # Exit code may be non-zero due to MCP protocol expectations, but should not be a crash
+        assert result.returncode in (0, 1)
+        # Should not have unexpected errors in stderr (socket/import errors would indicate failure)
+        assert b"Traceback" not in result.stderr or b"No module named" not in result.stderr
+
+    def test_script_entry_point_resolves(self):
+        """The [project.scripts] entry point should resolve to server:main."""
+        # Verify the entry point is correctly configured in package metadata
+        import importlib.metadata
+
+        entry_points = importlib.metadata.entry_points()
+        scripts = entry_points.select(group="console_scripts")
+        script_names = [ep.name for ep in scripts]
+        assert "hestai-context" in script_names
+
+        # Verify the entry point points to the correct function
+        hestai_context_ep = next(
+            (ep for ep in scripts if ep.name == "hestai-context"), None
+        )
+        assert hestai_context_ep is not None
+        assert hestai_context_ep.value == "hestai_context_mcp.server:main"
+
+    def test_script_entry_point_callable(self):
+        """The script entry point should resolve to a callable function."""
+        import importlib.metadata
+
+        entry_points = importlib.metadata.entry_points()
+        scripts = entry_points.select(group="console_scripts")
+        hestai_context_ep = next(
+            (ep for ep in scripts if ep.name == "hestai-context"), None
+        )
+
+        # Load the entry point and verify it's callable
+        assert hestai_context_ep is not None
+        loaded_fn = hestai_context_ep.load()
+        assert callable(loaded_fn)
+
+        # Verify it's the same main function from server
+        from hestai_context_mcp.server import main
+
+        assert loaded_fn is main
 
 
 @pytest.mark.smoke

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,12 @@
 """Smoke tests for the MCP server skeleton."""
 
+import contextlib
+import runpy
 import subprocess
 import sys
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -41,19 +46,14 @@ class TestServerImport:
 class TestServerExecution:
     """Test the new if __name__ == '__main__' entry point and script invocation."""
 
-    def test_module_execution_via_main_guard(self):
-        """The module should execute main() when run as a script (if __name__ check)."""
-        from unittest.mock import MagicMock, patch
-
-        # Test that the if __name__ == "__main__" guard properly calls main()
-        with patch("hestai_context_mcp.server.mcp.run") as mock_run:
-            # Import the module fresh to trigger the guard
-            import importlib
-            import hestai_context_mcp.server as server_module
-
-            # Re-execute the if __name__ == "__main__" block by calling main directly
-            # (This verifies that main() is the correct entry point)
-            server_module.main()
+    def test_main_guard_invokes_entry_point(self):
+        """The if __name__ == '__main__' guard should invoke main() when run as script."""
+        # Patch mcp.run before running the module to prevent it from actually starting the server
+        with patch("fastmcp.FastMCP.run") as mock_run:
+            # Use runpy to execute the module with __name__ == "__main__"
+            # This directly tests the if __name__ == "__main__" guard
+            with contextlib.suppress(SystemExit):
+                runpy.run_module("hestai_context_mcp.server", run_name="__main__", alter_sys=False)
             mock_run.assert_called_once()
 
     def test_module_execution_via_subprocess(self):
@@ -70,42 +70,23 @@ class TestServerExecution:
         # Should not have unexpected errors in stderr (socket/import errors would indicate failure)
         assert b"Traceback" not in result.stderr or b"No module named" not in result.stderr
 
-    def test_script_entry_point_resolves(self):
-        """The [project.scripts] entry point should resolve to server:main."""
-        # Verify the entry point is correctly configured in package metadata
-        import importlib.metadata
+    def test_script_entry_point_in_pyproject(self):
+        """The [project.scripts] entry point should be configured in pyproject.toml."""
+        project_root = Path(__file__).parent.parent
+        pyproject_path = project_root / "pyproject.toml"
 
-        entry_points = importlib.metadata.entry_points()
-        scripts = entry_points.select(group="console_scripts")
-        script_names = [ep.name for ep in scripts]
-        assert "hestai-context" in script_names
+        with open(pyproject_path, "rb") as f:
+            config = tomllib.load(f)
 
-        # Verify the entry point points to the correct function
-        hestai_context_ep = next(
-            (ep for ep in scripts if ep.name == "hestai-context"), None
-        )
-        assert hestai_context_ep is not None
-        assert hestai_context_ep.value == "hestai_context_mcp.server:main"
+        scripts = config.get("project", {}).get("scripts", {})
+        assert "hestai-context" in scripts
+        assert scripts["hestai-context"] == "hestai_context_mcp.server:main"
 
     def test_script_entry_point_callable(self):
-        """The script entry point should resolve to a callable function."""
-        import importlib.metadata
-
-        entry_points = importlib.metadata.entry_points()
-        scripts = entry_points.select(group="console_scripts")
-        hestai_context_ep = next(
-            (ep for ep in scripts if ep.name == "hestai-context"), None
-        )
-
-        # Load the entry point and verify it's callable
-        assert hestai_context_ep is not None
-        loaded_fn = hestai_context_ep.load()
-        assert callable(loaded_fn)
-
-        # Verify it's the same main function from server
+        """The script entry point should reference a callable main function."""
         from hestai_context_mcp.server import main
 
-        assert loaded_fn is main
+        assert callable(main)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Adds the missing `if __name__ == '__main__'` guard to `server.py` so the module can be invoked directly as a script.

Also adds `[project.scripts]` entry in `pyproject.toml` to expose the `hestai-context` command when the package is installed.

## Motivation

When invoking the server directly as `python server.py`, the module would load, register tools, then exit with code 0 because `main()` was never called. The installed entry point works correctly because the entry-point launcher calls `main()`.

This fix ensures both invocation methods work properly.

## Testing

- CI will validate that linting, type checking, and tests pass
- Verify server starts correctly when invoked directly or via installed entry point

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `__main__` guard in `server.py` and register a `[project.scripts]` entry to expose the `hestai-context` command, so the server starts when run directly or via the installed entry point. Add smoke tests that use `runpy` to trigger the `__main__` guard, run the module via subprocess, and parse `pyproject.toml` with `tomllib` to confirm the console script targets `hestai_context_mcp.server:main`.

<sup>Written for commit 09f073dc97305df758e20a3f096a398dfd5e05c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

