### PR TITLE
docs: update octave-mcp to v1.13.0 with format_style guidance

### DIFF
--- a/.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md
+++ b/.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md
@@ -78,6 +78,7 @@ Mac B#1 surfaced three RDs from their ledger that carry durable binding content.
 - **Substance**: `octave_write` currently collapses multi-envelope Facet ABI cards to META-only via `TN_RECONCILE_CANONICAL`. Direct-write is the project-accepted workaround for FRAME_CARD / CONCEPT_CARD authoring until octave-mcp #420 lands. Two empirical reproductions on record (PR #39 × 5 cards, PR #42 × 2 reproductions on one card). OCTAVE_WRITE_GATE remains binding for all other `.oct.md` authoring.
 - **Cross-refs**: octave-mcp #420, PR #39, PR #42.
 - **Status**: provisional. Token should be `VOID`'d or `SUPERSEDED` when #420 lands.
+- **v1.13.0 addendum (2026-05-28)**: octave-mcp v1.13.0 ships `format_style='preserve'` (Strategy A, GH#377) — span-aware mode that keeps clean nodes verbatim and only re-emits dirty/repaired nodes. This is the most likely path to resolving the multi-envelope collapse. **Retest required**: author a FRAME_CARD or CONCEPT_CARD with multiple envelopes using `octave_write(format_style='preserve')` and verify all envelopes survive. If confirmed fixed, VOID this token. Until confirmed, workaround remains active. See `.hestai/decisions/tooling/octave-preserve-mode-upgrade.md`.
 
 ### Candidate 3 — RD15: Decisions-as-Context is Platform-Scope (historical)
 

--- a/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
+++ b/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
@@ -1,0 +1,44 @@
+---
+topic: octave-mcp upgrade
+octave_version: "1.13.0"
+date: "2026-05-28"
+branch: update-octave-1-13-1
+status: active
+---
+
+# octave-mcp Upgrade: preserve Mode
+
+octave-mcp upgraded to v1.13.0. Key change: `format_style='preserve'` (Strategy A, GH#377) is now the recommended write mode. The default will flip from full canonical re-emit to `preserve` in v1.14.0.
+
+## Changes in v1.13.0
+
+### `format_style` parameter (octave_write)
+
+| Value | Behaviour |
+|---|---|
+| `'preserve'` | Span-aware mode. Clean nodes slice verbatim from baseline bytes; dirty/repaired nodes re-emit canonically. Diff footprint ≤0.5% on single-key edits. **New recommended default.** |
+| `'expanded'` | Full canonical re-emit (former default behaviour). Use if you need deterministic full-normalisation. |
+| `'compact'` | Collapses atom-only Blocks to inline-map form. Comment-bearing subtrees vetoed with `W_COMPACT_REFUSED`. |
+| `null` (explicit) | DeprecationWarning in v1.13.0. Will be removed or changed in v1.14.0. |
+| omitted | Silently accepts the v1.14.0 default (`preserve`). Safe, but not explicit. |
+
+**Guidance for this project**: Always pass `format_style='preserve'` explicitly in new octave_write calls.
+
+### Deprecation path
+
+- **v1.13.0**: `format_style=null` (explicit) emits `DeprecationWarning`.
+- **v1.14.0**: Default flips to `preserve`. To keep old behaviour past v1.14.0, pass `format_style='expanded'`.
+
+## Impact on RD18 — Multi-envelope workaround
+
+**Token**: `HO-OCTAVE-WRITE-MULTI-ENVELOPE-WORKAROUND-20260513`
+
+The RD18 workaround (direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring) was needed because `octave_write` collapsed multi-envelope content to META-only via `TN_RECONCILE_CANONICAL`. The `preserve` mode's span-aware approach is the most likely fix for this pattern.
+
+**Current status**: Needs testing. The workaround remains active until `preserve` mode is empirically confirmed to resolve the multi-envelope collapse. Test procedure:
+
+1. Author a FRAME_CARD or CONCEPT_CARD with multiple envelopes using `octave_write(format_style='preserve')`.
+2. Verify all envelopes survive (not collapsed to META-only).
+3. If confirmed fixed: `VOID` the RD18 token and remove the direct-write exception from CLAUDE.md.
+
+**References**: octave-mcp #420, `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` (RD18 candidate).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,20 @@ Current coverage: ~89%.
 - Branch from `main`
 - Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
 - PRs require CI green
+
+## Octave Tooling
+
+**octave-mcp version in use: v1.13.0**
+
+All `.oct.md` files must be written via `mcp__octave__octave_write` (OCTAVE_WRITE_GATE — never use Write/Edit tools on `.oct.md` files).
+
+**v1.13.0 key changes:**
+
+- `format_style='preserve'` is now available (Strategy A, GH#377). Span-aware mode that keeps clean nodes verbatim and only re-emits dirty/repaired nodes. Diff footprint ≤0.5% of file size on single-key edits. **Use this going forward.**
+- `format_style='expanded'` retains the old full canonical re-emit behaviour.
+- `format_style=null` (explicit) now emits a `DeprecationWarning`. Omitting the parameter silently accepts the future default.
+- **v1.14.0 will flip the default** from full canonical re-emit to `preserve`. To be safe: always pass `format_style='preserve'` explicitly in new octave_write calls.
+
+**Multi-envelope workaround (RD18 token `HO-OCTAVE-WRITE-MULTI-ENVELOPE-WORKAROUND-20260513`):**
+
+`octave_write` with older defaults collapsed multi-envelope Facet ABI cards to META-only via `TN_RECONCILE_CANONICAL`. The workaround was to use direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring. With v1.13.0 `preserve` mode landing, this should be **retested** — `preserve` mode's span-aware approach may resolve the collapse. Until confirmed fixed, treat the workaround as still active. See `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` and octave-mcp #420.


### PR DESCRIPTION
## Summary
- Updated octave-mcp documentation to v1.13.0 with new format_style preserve mode guidance
- Added comprehensive upgrade documentation for preserve mode functionality
- Ensured all relevant docs and version info reflect the latest release

## Changes
- **octave-preserve-mode-upgrade.md**: New guide documenting preserve mode upgrade path and usage patterns
- **CLAUDE.md**: Updated with v1.13.0 version information and relevant context
- **2026-05-16-rfc-40-mac-b1-carry-forward.md**: Added reference to octave v1.13.0 updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs to `octave-mcp` v1.13.0 and adds clear guidance for using `format_style='preserve'` with `octave_write`. Includes an upgrade note and retest plan for the multi-envelope collapse workaround (RD18).

- **Migration**
  - Pass `format_style='preserve'` explicitly in all new `octave_write` calls.
  - Use `format_style='expanded'` if you need the old full canonical re-emit.
  - Retest FRAME_CARD/CONCEPT_CARD multi-envelope writes with `preserve`; if envelopes survive, VOID the RD18 token and remove the direct-write exception.
  - Avoid `format_style=null`; default flips to `preserve` in v1.14.0.

<sup>Written for commit 93f91647bb5cd22309f19c17b0f88d91119ae0cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/55?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

