### PR TITLE
chore: upgrade octave-mcp to v1.13.1

### DIFF
--- a/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
+++ b/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
@@ -1,6 +1,6 @@
 ---
 topic: octave-mcp upgrade
-octave_version: "1.13.0"
+octave_version: "1.13.1"
 date: "2026-05-28"
 branch: update-octave-1-13-1
 status: active
@@ -8,7 +8,11 @@ status: active
 
 # octave-mcp Upgrade: preserve Mode
 
-octave-mcp upgraded to v1.13.0. Key change: `format_style='preserve'` (Strategy A, GH#377) is now the recommended write mode. The default will flip from full canonical re-emit to `preserve` in v1.14.0.
+octave-mcp upgraded to v1.13.0, then to v1.13.1. Key change: `format_style='preserve'` (Strategy A, GH#377) is now the recommended write mode. The default will flip from full canonical re-emit to `preserve` in v1.14.0.
+
+## v1.13.1 (no behaviour change)
+
+v1.13.1 (2026-05-28) is a pure internal refactor: the `write.py` god-object (4887 LOC) was decomposed into five peer modules (`write_detection`, `write_metrics`, `write_format`, `write_mutation`), down to 3197 LOC. **Zero behaviour change, byte-identical output, unchanged `octave_write` API** — all 3614 tests preserved byte-identically. The only addition is octave-mcp's own skill docs (`TELEGRAPHIC_PHRASE`), which do not affect this project. Everything below (the v1.13.0 changes) remains current.
 
 ## Changes in v1.13.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,13 @@ Current coverage: ~89%.
 
 ## Octave Tooling
 
-**octave-mcp version in use: v1.13.0**
+**octave-mcp version in use: v1.13.1**
 
 All `.oct.md` files must be written via `mcp__octave__octave_write` (OCTAVE_WRITE_GATE — never use Write/Edit tools on `.oct.md` files).
 
-**v1.13.0 key changes:**
+**v1.13.1 note:** v1.13.1 is a pure internal refactor — the `write.py` god-object was decomposed into five peer modules (`write_detection`, `write_metrics`, `write_format`, `write_mutation`) with **zero behaviour change, byte-identical output, and an unchanged `octave_write` API**. No project usage changes; all v1.13.0 guidance below still applies verbatim.
+
+**v1.13.0 key changes (still current):**
 
 - `format_style='preserve'` is now available (Strategy A, GH#377). Span-aware mode that keeps clean nodes verbatim and only re-emits dirty/repaired nodes. Diff footprint ≤0.5% of file size on single-key edits. **Use this going forward.**
 - `format_style='expanded'` retains the old full canonical re-emit behaviour.


### PR DESCRIPTION
## Summary
- Update octave-mcp dependency to v1.13.1, following recent 1.13.0 upgrade
- Internal refactor with no behavioral changes to existing functionality
- Documentation updates to reflect the new version and preserve-mode upgrade context

## Changes
- Update version references in CLAUDE.md
- Refine octave-preserve-mode-upgrade decision documentation with v1.13.1 details

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `octave-mcp` to v1.13.1 to track the upstream internal refactor. No behavior changes; existing `preserve` mode guidance from v1.13.0 remains valid.

- **Dependencies**
  - Bump `octave-mcp` to v1.13.1 (pure internal refactor, byte-identical output, unchanged `octave_write` API).

- **Documentation**
  - Update CLAUDE.md version and note the v1.13.1 no-op refactor.
  - Add v1.13.1 section to `.hestai/decisions/tooling/octave-preserve-mode-upgrade.md`.

<sup>Written for commit 0722a2344347645c3a4df8f793b1f68147ff659e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/56?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

