### PR TITLE
fix: migrate North Star summary to UPOG grammar

### DIFF
--- a/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md
+++ b/.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md
@@ -8,100 +8,103 @@ META:
   FULL_DOCUMENT::"000-HESTAI-CONTEXT-MCP-NORTH-STAR.md"
   COMPRESSION::"311 to 95 lines (3.3:1)"
   LAST_UPDATED::"2026-04-30"
+  CONTRACT::HOLOGRAPHIC<parse_only_governance>
+  CANONICAL::".hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md"
+  SOURCE::".hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md"
 §1::IDENTITY
-PURPOSE::"Persistent memory and environmental context for AI-assisted development sessions"
-ROLE_IN_ECOSYSTEM::"Memory and Environment in Three-Service Model (ADR-0353)"
-TRANSPORT::"stdio JSON-RPC (python -m hestai_context_mcp)"
-PHASE::B1_FOUNDATION_COMPLETE
+  PURPOSE::"Persistent memory and environmental context for AI-assisted development sessions"
+  ROLE_IN_ECOSYSTEM::"Memory and Environment in Three-Service Model (ADR-0353)"
+  TRANSPORT::"stdio JSON-RPC (python -m hestai_context_mcp)"
+  PHASE::B1_FOUNDATION_COMPLETE
 §2::IMMUTABLES
-I1::"SESSION_LIFECYCLE_INTEGRITY<PRINCIPLE::every_session_has_clean_create_and_archive_lifecycle,WHY::memory_accumulation_collapses_if_sessions_orphan_or_lose_provenance,STATUS::IMPLEMENTED>"
-I2::"CREDENTIAL_SAFETY<PRINCIPLE::zero_credentials_persist_in_archives_fail_closed_redaction,WHY::single_leaked_credential_is_security_incident_data_loss_over_data_exposure,STATUS::IMPLEMENTED>"
-I3::"PROVIDER_AGNOSTIC_CONTEXT<PRINCIPLE::context_synthesis_identical_regardless_of_AI_provider_or_CLI,WHY::three_service_separation_collapses_if_context_engine_couples_to_provider,STATUS::IMPLEMENTED>"
-I4::"STRUCTURED_RETURN_SHAPES<PRINCIPLE::all_tools_return_structured_dicts_with_defined_fields_not_blobs,WHY::Payload_Compiler_programmatically_extracts_fields_for_KVAEPH_Position_3,STATUS::IMPLEMENTED>"
-I5::"READ_ONLY_CONTEXT_QUERY<PRINCIPLE::get_context_has_zero_side_effects_pure_read,WHY::Payload_Compiler_calls_freely_repeatedly_in_parallel_must_be_safe,STATUS::IMPLEMENTED>"
-I6::"LEGACY_INDEPENDENCE<PRINCIPLE::no_runtime_or_install_dependency_on_hestai_mcp,WHY::A_B_comparison_impossible_if_dependency_exists_deprecation_cascades,STATUS::IMPLEMENTED>"
+  I1::"SESSION_LIFECYCLE_INTEGRITY<PRINCIPLE::every_session_has_clean_create_and_archive_lifecycle,WHY::memory_accumulation_collapses_if_sessions_orphan_or_lose_provenance,STATUS::IMPLEMENTED>"
+  I2::"CREDENTIAL_SAFETY<PRINCIPLE::zero_credentials_persist_in_archives_fail_closed_redaction,WHY::single_leaked_credential_is_security_incident_data_loss_over_data_exposure,STATUS::IMPLEMENTED>"
+  I3::"PROVIDER_AGNOSTIC_CONTEXT<PRINCIPLE::context_synthesis_identical_regardless_of_AI_provider_or_CLI,WHY::three_service_separation_collapses_if_context_engine_couples_to_provider,STATUS::IMPLEMENTED>"
+  I4::"STRUCTURED_RETURN_SHAPES<PRINCIPLE::all_tools_return_structured_dicts_with_defined_fields_not_blobs,WHY::Payload_Compiler_programmatically_extracts_fields_for_KVAEPH_Position_3,STATUS::IMPLEMENTED>"
+  I5::"READ_ONLY_CONTEXT_QUERY<PRINCIPLE::get_context_has_zero_side_effects_pure_read,WHY::Payload_Compiler_calls_freely_repeatedly_in_parallel_must_be_safe,STATUS::IMPLEMENTED>"
+  I6::"LEGACY_INDEPENDENCE<PRINCIPLE::no_runtime_or_install_dependency_on_hestai_mcp,WHY::A_B_comparison_impossible_if_dependency_exists_deprecation_cascades,STATUS::IMPLEMENTED>"
 §3::ASSUMPTIONS
-A1::"STDIO_TRANSPORT_SUFFICIENT[85%] HIGH_CONFIDENCE"
-A2::"JSONL_LEARNINGS_SCALES[80%] MEDIUM_CONFIDENCE"
-A3::"ADAPTER_PATTERN_COVERS_PROVIDERS[90%] HIGH_CONFIDENCE"
-A4::"REDACTION_PATTERN_COVERAGE[80%] CRITICAL<CADENCE::adversarial_review_each_minor_release_or_on_new_provider_adapter>"
-A5::"GET_CONTEXT_SUFFICIENT_FOR_POSITION_3[80%] CRITICAL"
-A6::"PORTABLE_STATE_DEFAULT_LOCAL_FILESYSTEM[90%] HIGH_CONFIDENCE"
-A7::"BRANCH_FOCUS_RESOLUTION_USEFUL[70%] LOW_CONFIDENCE"
+  A1::"STDIO_TRANSPORT_SUFFICIENT[85%] HIGH_CONFIDENCE"
+  A2::"JSONL_LEARNINGS_SCALES[80%] MEDIUM_CONFIDENCE"
+  A3::"ADAPTER_PATTERN_COVERS_PROVIDERS[90%] HIGH_CONFIDENCE"
+  A4::"REDACTION_PATTERN_COVERAGE[80%] CRITICAL<CADENCE::adversarial_review_each_minor_release_or_on_new_provider_adapter>"
+  A5::"GET_CONTEXT_SUFFICIENT_FOR_POSITION_3[80%] CRITICAL"
+  A6::"PORTABLE_STATE_DEFAULT_LOCAL_FILESYSTEM[90%] HIGH_CONFIDENCE"
+  A7::"BRANCH_FOCUS_RESOLUTION_USEFUL[70%] LOW_CONFIDENCE"
 §4::SCOPE_BOUNDARIES
-IS::[
-  "session lifecycle management (clock_in, clock_out)",
-  "context synthesis engine (.hestai state, North Stars, git state)",
-  "learnings extraction pipeline (transcript parsing, redaction, indexing)",
-  "review infrastructure (structured PR verdicts, CI gate clearing)",
-  "portable session state (StorageAdapter, IdentityTuple, PortableArtifact union) per ADR-0013"
-]
-IS_NOT::[
-  "agent identity or governance (Vault owns)",
-  "UI or dispatch system (Workbench owns)",
-  "deliberation system (Debate Hall owns)",
-  "document format system (octave-mcp owns)"
-]
-§5::CONSTRAINED_VARIABLES
-TRANSPORT::[
-  IMMUTABLE::stdio_JSON_RPC,
-  FLEXIBLE::protocol_version,
-  NEGOTIABLE::additional_transports
-]
-TRANSCRIPT_PARSING::[
-  IMMUTABLE::provider_agnostic_adapter_pattern,
-  FLEXIBLE::specific_parser_implementations
-]
-ARCHIVAL_FORMAT::[
-  IMMUTABLE::redacted_structured_persistent,
-  FLEXIBLE::JSONL_vs_OCTAVE
-]
-COVERAGE::[
-  IMMUTABLE::"85_percent_minimum_CI_enforced",
-  FLEXIBLE::test_strategies
-]
-STORAGE_BACKEND::[
-  IMMUTABLE::StorageAdapter_protocol,
-  FLEXIBLE::adapter_implementation,
-  NEGOTIABLE::carrier_namespace_layout
-]
-§6::GATES
-GATES::"D1[DONE] B1[DONE_Phase_1+Phase_1.5+PSS_B1_2026-04-29] B2[PENDING_workbench_Phase_3C_integration] B3[FUTURE_NS_injection_unification] B4[FUTURE_git_hooks_legacy_deprecation]"
-§7::ESCALATION
-ESCALATION_ROUTING::[
-  requirements_steward::[
-    "violates PROD I#",
-    scope_boundary_question,
-    immutable_change
-  ],
-  technical_architect::[
-    transport_design,
-    adapter_architecture,
-    cross_service_integration
-  ],
-  implementation_lead::[
-    "assumption A# validation",
-    Phase_2_execution,
-    new_provider_adapter
+  IS::[
+    "session lifecycle management (clock_in, clock_out)",
+    "context synthesis engine (.hestai state, North Stars, git state)",
+    "learnings extraction pipeline (transcript parsing, redaction, indexing)",
+    "review infrastructure (structured PR verdicts, CI gate clearing)",
+    "portable session state (StorageAdapter, IdentityTuple, PortableArtifact union) per ADR-0013"
   ]
-]
+  IS_NOT::[
+    "agent identity or governance (Vault owns)",
+    "UI or dispatch system (Workbench owns)",
+    "deliberation system (Debate Hall owns)",
+    "document format system (octave-mcp owns)"
+  ]
+§5::CONSTRAINED_VARIABLES
+  TRANSPORT::[
+    IMMUTABLE::stdio_JSON_RPC,
+    FLEXIBLE::protocol_version,
+    NEGOTIABLE::additional_transports
+  ]
+  TRANSCRIPT_PARSING::[
+    IMMUTABLE::provider_agnostic_adapter_pattern,
+    FLEXIBLE::specific_parser_implementations
+  ]
+  ARCHIVAL_FORMAT::[
+    IMMUTABLE::redacted_structured_persistent,
+    FLEXIBLE::JSONL∨OCTAVE
+  ]
+  COVERAGE::[
+    IMMUTABLE::"85_percent_minimum_CI_enforced",
+    FLEXIBLE::test_strategies
+  ]
+  STORAGE_BACKEND::[
+    IMMUTABLE::StorageAdapter_protocol,
+    FLEXIBLE::adapter_implementation,
+    NEGOTIABLE::carrier_namespace_layout
+  ]
+§6::GATES
+  GATES::"D1[DONE] B1[DONE_Phase_1+Phase_1.5+PSS_B1_2026-04-29] B2[PENDING_workbench_Phase_3C_integration] B3[FUTURE_NS_injection_unification] B4[FUTURE_git_hooks_legacy_deprecation]"
+§7::ESCALATION
+  ESCALATION_ROUTING::[
+    requirements_steward::[
+      "violates PROD I#",
+      scope_boundary_question,
+      immutable_change
+    ],
+    technical_architect::[
+      transport_design,
+      adapter_architecture,
+      cross_service_integration
+    ],
+    implementation_lead::[
+      "assumption A# validation",
+      Phase_2_execution,
+      new_provider_adapter
+    ]
+  ]
 §8::TRIGGERS
-LOAD_FULL_NORTH_STAR_IF::[
-  "violates PROD I1 through I6 = immutable conflict",
-  "credential or redaction or security = I2 safety critical",
-  "provider specific or Claude only or format assumption = I3 coupling risk",
-  "side effect or mutation or get_context writes = I5 purity violation",
-  "import hestai_mcp or legacy dependency = I6 independence breach",
-  "scope boundary or feature creep = identity boundary question",
-  "B2 or Phase 2 or workbench integration = decision gate approaching",
-  "identity tuple or carrier_namespace or storage adapter or multi_directory = ADR-0013 boundary question"
-]
+  LOAD_FULL_NORTH_STAR_IF::[
+    "violates PROD I1 through I6 = immutable conflict",
+    "credential or redaction or security = I2 safety critical",
+    "provider specific or Claude only or format assumption = I3 coupling risk",
+    "side effect or mutation or get_context writes = I5 purity violation",
+    "import hestai_mcp or legacy dependency = I6 independence breach",
+    "scope boundary or feature creep = identity boundary question",
+    "B2 or Phase 2 or workbench integration = decision gate approaching",
+    "identity tuple or carrier_namespace or storage adapter or multi_directory = ADR-0013 boundary question"
+  ]
 §9::PROTECTION
-IF::agent_detects_work_contradicting_North_Star
-THEN::[
-  STOP::current_work_immediately,
-  CITE::"specific requirement violated (PROD I#)",
-  ESCALATE::to_requirements_steward
-]
-FORMAT::"NORTH_STAR_VIOLATION: [work] violates [PROD I#] because [evidence]"
+  IF::agent_detects_work_contradicting_North_Star
+  THEN::[
+    STOP::current_work_immediately,
+    CITE::"specific requirement violated (PROD I#)",
+    ESCALATE::to_requirements_steward
+  ]
+  FORMAT::"NORTH_STAR_VIOLATION: [work] violates [PROD I#] because [evidence]"
 ===END===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,14 @@ dev = [
     "ruff~=0.15.0",
     "black==26.1.0",
 ]
+# Test-only dependency: the strict OCTAVE lexer is the ONLY reliable detector
+# for North Star UPOG grammar regressions (the bundled regex validator and the
+# `octave validate` CLI report the data-losing legacy form as "valid"). Used by
+# tests/unit/governance/test_north_star_upog_compliance.py. Not a runtime dep —
+# keeps PROD::I6 LEGACY_INDEPENDENCE / provider-agnostic runtime intact.
+test = [
+    "octave-mcp>=1.13",
+]
 
 [project.urls]
 Homepage = "https://github.com/elevanaltd/hestai-context-mcp"

--- a/tests/unit/governance/test_north_star_upog_compliance.py
+++ b/tests/unit/governance/test_north_star_upog_compliance.py
@@ -1,0 +1,155 @@
+"""Persistent regression guard: North Star OCTAVE summaries MUST stay UPOG-clean.
+
+Why this guard exists
+---------------------
+The legacy immutable container forms silently LOSE DATA under octave-mcp's
+strict lexer (>=1.13):
+
+* chained ``I#::NAME::[KEY::v, ...]`` parses as an assignment that hoists the
+  inner keys to file-top-level, so ``PRINCIPLE`` / ``WHY`` / ``STATUS`` collide
+  across ``I1..IN`` (duplicate-key, last-write-wins);
+* flat section keys repeated across ``§N`` sections (e.g. a ``TRANSPORT`` under
+  both ``§1`` and ``§5``) collide the same way;
+* markdown ``## headings`` inside the ``===ENVELOPE===`` fail tokenisation
+  (``E_TOKENIZE`` / ``E005``).
+
+The bundled regex validator and the ``octave validate`` CLI report the broken
+form as "valid" (exit 0) and silently canonicalise the data away -- that false
+confidence is exactly what let the bug live. The ONLY reliable detector is the
+strict lexer, exercised here via :func:`octave_mcp.parse_with_warnings`.
+
+Anti-rot: the negative-control tests prove the detector still FIRES on a
+known-bad legacy fixture and RAISES on a ``## heading`` fixture, so this guard
+cannot silently degrade into a no-op. The discovery test fails if the North
+Star glob is empty.
+
+Reference implementation: ``elevanaltd/HestAI-MCP``
+``tests/unit/governance/test_north_star_upog_compliance.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import octave_mcp
+import pytest
+
+# tests/unit/governance/test_*.py -> parents[3] == repository root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Strict-lexer warning subtypes that each indicate silent data loss. These are
+# the ``subtype`` values emitted in the warning dicts from parse_with_warnings.
+REGRESSION_SUBTYPES = {
+    "duplicate_key",
+    "bare_line_dropped",
+    "bare_flow",
+    "multi_word_coalesce",
+}
+
+
+def _discover_ns_summaries() -> list[Path]:
+    """Return every committed North Star OCTAVE summary in this repository.
+
+    Skips the gitignored ``.hestai-sys/`` delivery tree (regenerated from the
+    Vault on restart -- not a source artefact this repo governs).
+    """
+    return sorted(
+        p for p in REPO_ROOT.glob("**/*NORTH-STAR-SUMMARY.oct.md") if ".hestai-sys" not in p.parts
+    )
+
+
+NS_SUMMARIES = _discover_ns_summaries()
+
+
+def _regression_subtypes(warnings: list[dict]) -> set[str]:
+    """Intersection of observed warning subtypes with the data-loss set."""
+    return {w.get("subtype") for w in warnings if w.get("subtype")} & REGRESSION_SUBTYPES
+
+
+@pytest.mark.unit
+class TestDiscovery:
+    """A guard that passes over zero files is a silent no-op."""
+
+    def test_at_least_one_north_star_summary_found(self) -> None:
+        assert NS_SUMMARIES, (
+            f"No *NORTH-STAR-SUMMARY.oct.md found under {REPO_ROOT}. "
+            "The UPOG guard would silently pass over nothing -- check the glob."
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "ns_path",
+    NS_SUMMARIES,
+    ids=lambda p: str(p.relative_to(REPO_ROOT)),
+)
+class TestNorthStarUpogCompliance:
+    """Every North Star summary must parse cleanly under the strict lexer."""
+
+    def test_parses_without_lexer_error(self, ns_path: Path) -> None:
+        """Strict lexer must accept the document (no markdown / E_TOKENIZE)."""
+        try:
+            octave_mcp.parse_with_warnings(ns_path.read_text())
+        except octave_mcp.LexerError as exc:
+            pytest.fail(
+                f"{ns_path.relative_to(REPO_ROOT)} fails the strict lexer "
+                f"(markdown heading or bad token?): {exc}"
+            )
+
+    def test_no_regression_subtypes(self, ns_path: Path) -> None:
+        """Zero silent-data-loss subtypes in the strict-lexer warnings."""
+        _doc, warnings = octave_mcp.parse_with_warnings(ns_path.read_text())
+        offending = _regression_subtypes(warnings)
+        assert not offending, (
+            f"{ns_path.relative_to(REPO_ROOT)} regressed to a data-losing form: "
+            f"{sorted(offending)}. Full warnings: {warnings}"
+        )
+
+
+# --- Negative controls: prove the detector still works (anti-rot) -----------
+
+_LEGACY_BROKEN = """===NORTH_STAR_SUMMARY===
+META:
+  TYPE::NORTH_STAR_SUMMARY
+  VERSION::"1.0"
+§1::IDENTITY
+TRANSPORT::"stdio JSON-RPC"
+§2::IMMUTABLES
+I1::SESSION_LIFECYCLE::[PRINCIPLE::a,WHY::b,STATUS::c]
+I2::CREDENTIAL_SAFETY::[PRINCIPLE::d,WHY::e,STATUS::f]
+§5::CONSTRAINED_VARIABLES
+TRANSPORT::[IMMUTABLE::x]
+===END===
+"""
+
+_MARKDOWN_HEADING = """===NORTH_STAR_SUMMARY===
+META:
+  TYPE::NORTH_STAR_SUMMARY
+  VERSION::"1.0"
+## IMMUTABLES (6 Total)
+I1::"X<PRINCIPLE::a>"
+===END===
+"""
+
+
+@pytest.mark.unit
+class TestDetectorAntiRot:
+    """The detector itself is tested, so the guard cannot silently rot."""
+
+    def test_detector_fires_on_legacy_duplicate_key_form(self) -> None:
+        """Chained ``I#::NAME::[...]`` plus a flat repeated section key MUST
+        surface ``duplicate_key`` -- if this stops firing, the guard is a
+        no-op masquerading as protection.
+        """
+        _doc, warnings = octave_mcp.parse_with_warnings(_LEGACY_BROKEN)
+        offending = _regression_subtypes(warnings)
+        assert offending, (
+            "Strict lexer failed to flag the known-bad legacy form. "
+            f"Guard has rotted. Warnings: {warnings}"
+        )
+        assert "duplicate_key" in offending
+
+    def test_detector_raises_on_markdown_heading(self) -> None:
+        """A markdown ``## heading`` inside the envelope MUST fail tokenisation."""
+        with pytest.raises(octave_mcp.LexerError):
+            octave_mcp.parse_with_warnings(_MARKDOWN_HEADING)

--- a/uv.lock
+++ b/uv.lock
@@ -352,61 +352,61 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -510,6 +510,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -547,6 +556,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+test = [
+    { name = "octave-mcp" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -555,13 +567,14 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
+    { name = "octave-mcp", marker = "extra == 'test'", specifier = ">=1.13" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.15.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "httpcore"
@@ -931,6 +944,26 @@ wheels = [
 ]
 
 [[package]]
+name = "octave-mcp"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cryptography" },
+    { name = "filelock" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/ff/c41e8e64c942b09f327b30dc4ea6482a36c5552399c74833e0f9bcbf0ed4/octave_mcp-1.13.1.tar.gz", hash = "sha256:8110136797f0bd1c7ff293268018d418eda6d3378646abd048902d15b127aedd", size = 366847, upload-time = "2026-05-28T22:05:13.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/3e11f0f92c331cf2254453c44ff149fd355dc3bee3e854291e51686817ff/octave_mcp-1.13.1-py3-none-any.whl", hash = "sha256:f0acb6005be87683d57328e060c4b9d3d17c340b5caa630fd9accbb23d9efdfd", size = 394772, upload-time = "2026-05-28T22:05:12.527Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1256,11 +1289,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Migrated North Star OCTAVE document to UPOG grammar for consistency with anchor process standards
- Added regression guard test suite to prevent future grammar drift and ensure compliance
- Updated project dependencies to support octave-mcp>=1.13

## Changes
- **Grammar Migration**: Updated `00-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md` to conform to UPOG grammar standards (175 lines refactored)
- **Regression Testing**: Added `tests/unit/governance/test_north_star_upog_compliance.py` with 155 lines of compliance validation tests
- **Dependencies**: Updated `pyproject.toml` and `uv.lock` to include octave-mcp>=1.13 as dev/test dependency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the North Star OCTAVE summary to UPOG grammar to stop strict-lexer data loss and keep governance docs consistent. Added a strict regression guard to prevent future drift.

- **Bug Fixes**
  - Migrated `.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR-SUMMARY.oct.md` to UPOG (scoped section bodies, `JSONL∨OCTAVE`, META fields) to eliminate duplicate-key collisions under the strict lexer.
  - Added a regression guard: unit tests parse all North Star summaries with the strict lexer and fail on known-bad fixtures; also verifies discovery.

- **Dependencies**
  - Added test-only extra `octave-mcp>=1.13` and refreshed `uv.lock`; runtime stays provider-agnostic with no `octave-mcp` dependency (PROD I6).

<sup>Written for commit 4a67ef428efa011797addf37d2b3ffdf4b24b508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/57?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

