### PR TITLE
chore: upgrade octave to v1.15.0 and assess validator dependency

### DIFF
--- a/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
+++ b/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
@@ -167,7 +167,42 @@ Take Option 1 now (done). When Gate B is actually scheduled, prefer **Option 2**
 stdio-subprocess sketch: same capability, no subprocess management, and it keeps the default
 install free of octave-mcp so PROD::I6 independence holds for anyone not opting into
 validation. Option 3 should not be adopted without an explicit requirements-steward decision
-recorded against §4.
+recorded against §4. The dependency *declaration* (Options 1–3) is orthogonal to the
+integration *transport* analysed next — decide both.
+
+### Gate B integration shape (transport) — do NOT cargo-cult "over stdio"
+
+`type_checker.py`, `submit_governance.py`, and `governance/__init__.py` all carry the comment
+"Gate B (future) will wire the REAL OCTAVE validator to octave-mcp **over stdio**." That phrase
+predates the fact that octave-mcp ships a clean importable library API, and as written it means
+*this MCP server spawning the octave-mcp MCP server as a subprocess and speaking JSON-RPC to it*
+— one MCP server calling another. For a pure, deterministic, CPU-bound `text → result`
+validation function that is the **worst option**, and it should not be carried forward
+unexamined. Three shapes, ranked:
+
+1. **Client-side composition (PREFERRED default).** Neither server calls the other. The host/
+   agent already has both `mcp__octave__*` and `mcp__hestai-context__*` connected, so the
+   orchestrator calls `octave_validate` first and `submit_governance` only on a clean result.
+   Zero new coupling in this repo; §4-purest (octave-mcp owns validation, this server owns
+   placement/commit). Trade-off: not a self-guarding commit boundary — a caller can skip the
+   validate step.
+2. **In-process library import behind a port (use IF the commit boundary must self-guard).**
+   `submit_governance` calls `octave_mcp.Validator` / `parse_with_warnings` in-process for
+   defense-in-depth, via a thin internal `OctaveValidator` protocol (mirroring the existing
+   `ports/ai_client.py` adapter seam) so the rest of the code never imports `octave_mcp`
+   directly. Pairs with Option 2's optional `validation` extra + fail-soft. One process, one
+   failure domain, typed returns, trivially testable.
+3. **stdio server-to-server subprocess (REJECT).** Worst of both worlds: octave-mcp must still
+   be installed to be spawned (so the dependency is NOT avoided), *plus* you take on subprocess
+   lifecycle, stdio framing, JSON-RPC handshake, timeouts/hangs, and zombie cleanup — while
+   gaining none of MCP's actual value (capability discovery, host-mediated consent/auth), which
+   only applies at a host↔server boundary, not server↔server. More cost, more failure surface,
+   harder tests, for a plain function call.
+
+**Decision rule:** validation as a caller-orchestrated pre-step → Shape 1; validation as an
+enforced invariant of the commit boundary → Shape 2 (+ optional extra, behind a port); never
+Shape 3. When Gate B is scheduled, update the three `over stdio` code comments to match the
+chosen shape.
 
 ## Impact on RD18 — Multi-envelope workaround (still active)
 

--- a/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
+++ b/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
@@ -118,6 +118,33 @@ full CST node set (`Document`, `Section`, `Block`, `Assignment`, …). So the va
 available **in-process as a library**, not only over MCP/stdio. The "Gate B over stdio" plan
 predates this and is now only one of two viable integration shapes.
 
+### Runtime OCTAVE usage map (review findings, 2026-06-01)
+
+The system consumes the OCTAVE **format** at runtime in five places, but depends on the
+octave-mcp **library** in none of them — it hand-rolls regex extractors. Distinguish "uses
+the format" (a notation we read) from "depends on the implementation" (the library). The
+table below records which consumers would genuinely benefit from the real parser:
+
+| Runtime consumer | OCTAVE operation | Needs octave-mcp? | Why |
+|---|---|---|---|
+| `core/north_star_parser.py` | Extract `IMMUTABLES` / `SCOPE_BOUNDARIES` | No | Shallow field extraction on project-controlled docs already canonicalized by `octave_write`. |
+| `core/context_steward.py` | Extract phase constraints from workflow docs | No | Same — targeted `KEY::value` / `[…]` pulls, not full AST. |
+| `core/phase.py` | Extract `PHASE::` declaration | No | Single line read. |
+| `tools/governance/lexer.py` | Token/ID existence lookup across `.oct.md` | No | String/regex search, not parsing. |
+| `tools/governance/type_checker.py` → **`submit_governance` (LIVE MCP tool)** | **Validate** operator-submitted OCTAVE (sentinel/TYPE/TOKEN, regex-only) | **YES** | Self-documented as "intentionally dumb by design"; defers real validation to "Gate B → octave-mcp over stdio". |
+
+**Conclusion:** exactly one runtime concern genuinely needs the real parser — **trustworthy
+validation of operator-submitted governance content** (`submit_governance` Gate A → Gate B).
+The four extraction consumers do not; regex is defensible there because inputs are
+project-authored (written through the OCTAVE_WRITE_GATE) and the extractions are shallow.
+
+**Live risk:** `submit_governance` is a registered, shipping MCP tool (`mcp.tool(submit_governance)`
+in `server.py`). Its Gate A checker can pass a regex-valid-but-semantically-broken OCTAVE doc
+and commit it — the same false-green class the pyproject test comment warns about ("the
+bundled regex validator … reports the data-losing legacy form as valid"). No North Star
+violation today (Gate A is documented as approximate), but this is the concrete motivation for
+scheduling Gate B, and Gate B is the point at which octave-mcp must leave the `test` extra.
+
 ### Options (decision deferred — not taken this pass)
 
 1. **Test-only pin bump (DONE this pass).** Keep octave-mcp test-only, pinned `>=1.15`.
@@ -163,5 +190,3 @@ claim to fix #420.
 
 **References**: octave-mcp #420, #460, #487, #488;
 `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` (RD18 candidate).
-</content>
-</invoke>

--- a/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
+++ b/.hestai/decisions/tooling/octave-preserve-mode-upgrade.md
@@ -1,48 +1,167 @@
 ---
 topic: octave-mcp upgrade
-octave_version: "1.13.1"
-date: "2026-05-28"
-branch: update-octave-1-13-1
+octave_version: "1.15.0"
+date: "2026-06-01"
+branch: update-octave-dependency
 status: active
 ---
 
-# octave-mcp Upgrade: preserve Mode
+# octave-mcp Upgrade: v1.15.0
 
-octave-mcp upgraded to v1.13.0, then to v1.13.1. Key change: `format_style='preserve'` (Strategy A, GH#377) is now the recommended write mode. The default will flip from full canonical re-emit to `preserve` in v1.14.0.
+octave-mcp has moved 1.13.0 → 1.13.1 → 1.14.0 → 1.15.0 (latest, 2026-05-31). This
+project now pins `octave-mcp>=1.15` (test extra). The headline change since v1.13.x is
+a **hard break** to `octave_write` `changes`-mode value semantics in v1.15.0, plus
+anchored-path and literal-zone fidelity fixes in v1.14.0. `format_style='preserve'`
+remains the recommended write mode and must still be passed explicitly (see below).
 
-## v1.13.1 (no behaviour change)
+## v1.15.0 (2026-05-31) — ⚠️ HARD BREAK: `changes`-mode value semantics (GH#487)
 
-v1.13.1 (2026-05-28) is a pure internal refactor: the `write.py` god-object (4887 LOC) was decomposed into five peer modules (`write_detection`, `write_metrics`, `write_format`, `write_mutation`), down to 3197 LOC. **Zero behaviour change, byte-identical output, unchanged `octave_write` API** — all 3614 tests preserved byte-identically. The only addition is octave-mcp's own skill docs (`TELEGRAPHIC_PHRASE`), which do not affect this project. Everything below (the v1.13.0 changes) remains current.
+STRATEGY_S3 extracted a single `DocumentMutator` layer that now owns all transition
+logic and structural AST synthesis; the emitter stays the sole canonicalizer-to-bytes.
+The behavioural break only affects callers that pass `changes=` to `octave_write`:
 
-## Changes in v1.13.0
+| Pattern | Old behaviour | New behaviour (v1.15.0) |
+|---|---|---|
+| Bare dict at a `changes` KEY | Implicit MERGE — unmentioned children preserved, new child appended | **FULL REPLACE** — unmentioned children **DROPPED** |
+| Bare scalar over a nested BLOCK | Duplicate-keys footgun (block left in place AND flat scalar appended) | **FULL REPLACE in place** — exactly one key emitted |
+| `$op:MERGE` of a scalar over a child BLOCK | (silently honoured in places) | **REJECT** with `E_OP_TARGET_MISMATCH` |
+| Bare dict with a **nested** dict value | `dict→InlineMap` coercion (re-parsed to `E_NESTED_INLINE_MAP`) | Emits canonical **BLOCK** form; logged `TRANSFORM::INLINE_MAP_TO_BLOCK` |
+| `$op:APPEND`/`$op:PREPEND` of nested list/dict element (#488) | Python repr that failed strict re-parse (E005) but reported success | Normalised to re-parseable OCTAVE |
 
-### `format_style` parameter (octave_write)
+**Migration (one line):** to MERGE into an existing block you **MUST** now send an
+explicit `{"$op": "MERGE", "value": {…}}`. A bare dict replaces the whole key. Flat
+dicts (all scalar/list values) still emit as a re-parseable inline map — unchanged.
+
+**Read path unchanged:** `octave_validate` still ACCEPTs inline maps and reports
+`W_INLINE_ARRAY_ROOT` without mutating source (PROD::I5).
+
+**Project impact:** This project does not currently call `octave_write` with `changes=`
+mode in source code (all `.oct.md` authoring goes through full-document
+`mcp__octave__octave_write`). The break is guidance for agents/skills doing surgical
+key edits — never rely on bare-dict merge; pass `$op:MERGE` explicitly.
+
+## v1.14.0 (2026-05-30) — anchored paths + literal-zone fidelity
+
+- **`ANCHOR/KEY` anchored-path syntax (#460).** Disambiguates duplicate sibling keys
+  (e.g. five sibling `RATIONALE` keys) by targeting "the `KEY` assignment following the
+  `ANCHOR` key in document order": `changes={"I2/RATIONALE": …}`. Resolution is local to a
+  sibling list and never crosses a container boundary. Resolve-literal-first keeps a real
+  key containing `/` mutated in place. Indexed `KEY[N]` addressing stays rejected with
+  `E_UNRESOLVABLE_PATH`. Anchored paths accept the full `$op` surface with the same
+  target-type validation as bare keys.
+- **Literal-zone fence form preserved on content edits and `$op MERGE` (#460).** Editing a
+  child whose value is a fenced (```` ``` ````) literal zone now re-wraps to preserve the
+  fence form (marker + info tag retained, only inner content changed) instead of
+  downgrading to a quoted scalar. Content-only edits round-trip **byte-identical** under
+  `format_style="preserve"`. Restores PROD::I1 (Syntactic Fidelity).
+- **Anchored-path `$op` descriptors are executed, not written as data (#460).** `$op DELETE`
+  on an anchored sibling actually removes it (was a silent-success no-op); `$op APPEND`/
+  `PREPEND`/`MERGE` apply with loud `E_OP_TARGET_MISMATCH` on type mismatch.
+- **Worktree `.venv` dev toolchain (#462).** octave-mcp added a PEP-735
+  `[dependency-groups].dev` group so `uv sync` installs the dev toolchain by default. (Their
+  repo hygiene; no action for this project — we already use `uv sync --all-extras`.)
+
+### Note on the predicted v1.14.0 default flip
+
+Earlier guidance (from the v1.13.0 notes) predicted v1.14.0 would **flip the default
+`format_style` from full canonical re-emit to `preserve`**. That flip does **not** appear in
+the published v1.14.0 or v1.15.0 changelogs. Treat the default as **unconfirmed** and
+continue to pass `format_style='preserve'` **explicitly** on every `octave_write` call.
+`format_style='expanded'` retains full canonical re-emit if deterministic full-normalisation
+is ever needed.
+
+## v1.13.1 (2026-05-28) — internal refactor, no behaviour change
+
+Pure internal refactor: `write.py` god-object decomposed into peer modules
+(`write_detection`, `write_metrics`, `write_format`, `write_mutation`). Zero behaviour
+change, byte-identical output, unchanged `octave_write` API. Retained here for the version
+trail.
+
+## `format_style` reference (still current)
 
 | Value | Behaviour |
 |---|---|
-| `'preserve'` | Span-aware mode. Clean nodes slice verbatim from baseline bytes; dirty/repaired nodes re-emit canonically. Diff footprint ≤0.5% on single-key edits. **New recommended default.** |
-| `'expanded'` | Full canonical re-emit (former default behaviour). Use if you need deterministic full-normalisation. |
+| `'preserve'` | Span-aware. Clean nodes slice verbatim from baseline bytes; dirty/repaired nodes re-emit canonically. Diff footprint ≤0.5% on single-key edits. **Recommended — pass explicitly.** |
+| `'expanded'` | Full canonical re-emit (former default). Use for deterministic full-normalisation. |
 | `'compact'` | Collapses atom-only Blocks to inline-map form. Comment-bearing subtrees vetoed with `W_COMPACT_REFUSED`. |
-| `null` (explicit) | DeprecationWarning in v1.13.0. Will be removed or changed in v1.14.0. |
-| omitted | Silently accepts the v1.14.0 default (`preserve`). Safe, but not explicit. |
+| `null` (explicit) | DeprecationWarning. Avoid. |
+| omitted | Silently accepts the package default. Not explicit — prefer passing `'preserve'`. |
 
-**Guidance for this project**: Always pass `format_style='preserve'` explicitly in new octave_write calls.
+## Dependency status & validator-integration assessment
 
-### Deprecation path
+### Current state
 
-- **v1.13.0**: `format_style=null` (explicit) emits `DeprecationWarning`.
-- **v1.14.0**: Default flips to `preserve`. To keep old behaviour past v1.14.0, pass `format_style='expanded'`.
+octave-mcp is a **test-only** optional dependency:
 
-## Impact on RD18 — Multi-envelope workaround
+```toml
+[project.optional-dependencies]
+test = ["octave-mcp>=1.15"]
+```
+
+It is imported only by `tests/unit/governance/test_north_star_upog_compliance.py`
+(`octave_mcp.parse_with_warnings`, `octave_mcp.LexerError`) — the strict lexer is the only
+reliable detector for North Star UPOG grammar regressions. Runtime source code does **not**
+import octave-mcp. The governance modules (`type_checker.py`, `linker.py`, `manifest.py`,
+`submit_governance.py`) explicitly document this and defer real OCTAVE validation to a
+planned **"Gate B"** (wire the octave-mcp validator over stdio). This is deliberate, anchored
+to:
+
+- **North Star §4 SCOPE_BOUNDARIES — IS_NOT** "document format system (octave-mcp owns)".
+- **PROD::I6 LEGACY_INDEPENDENCE** (interpreted as scope-boundary discipline per §4).
+
+### What "use the validator and other aspects" would need
+
+octave-mcp ships a rich, importable Python API (verified against the installed 1.15.0):
+`Validator`, `ValidationError`, `parse` / `parse_with_warnings`, `tokenize`, `emit`,
+`project`, `repair`, `extract_schema_from_document`, `seal_document` / `verify_seal`, plus the
+full CST node set (`Document`, `Section`, `Block`, `Assignment`, …). So the validator is
+available **in-process as a library**, not only over MCP/stdio. The "Gate B over stdio" plan
+predates this and is now only one of two viable integration shapes.
+
+### Options (decision deferred — not taken this pass)
+
+1. **Test-only pin bump (DONE this pass).** Keep octave-mcp test-only, pinned `>=1.15`.
+   Zero runtime coupling. Preserves §4 / PROD::I6 exactly as written. **Chosen for this
+   pass** — promotes nothing without requirements-steward sign-off.
+2. **Optional `validation` extra.** Add octave-mcp to a NEW
+   `[project.optional-dependencies].validation` group; runtime code imports the validator
+   only when the extra is installed (feature-detect / fail-soft when absent). Soft coupling;
+   keeps the default install provider-agnostic and §4-clean. Lowest-risk path to a real
+   Gate B.
+3. **Hard runtime dependency.** Move octave-mcp into `[project].dependencies`. Validator
+   always in-process. **Strongest coupling — directly crosses the §4 scope boundary and the
+   Gate B plan; requires requirements-steward sign-off** before adoption (per North Star §7
+   escalation: immutable / scope-boundary question → requirements_steward).
+
+### Recommendation
+
+Take Option 1 now (done). When Gate B is actually scheduled, prefer **Option 2** (optional
+`validation` extra with in-process library import and fail-soft) over the original
+stdio-subprocess sketch: same capability, no subprocess management, and it keeps the default
+install free of octave-mcp so PROD::I6 independence holds for anyone not opting into
+validation. Option 3 should not be adopted without an explicit requirements-steward decision
+recorded against §4.
+
+## Impact on RD18 — Multi-envelope workaround (still active)
 
 **Token**: `HO-OCTAVE-WRITE-MULTI-ENVELOPE-WORKAROUND-20260513`
 
-The RD18 workaround (direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring) was needed because `octave_write` collapsed multi-envelope content to META-only via `TN_RECONCILE_CANONICAL`. The `preserve` mode's span-aware approach is the most likely fix for this pattern.
+The RD18 workaround (direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring) was needed
+because `octave_write` collapsed multi-envelope content to META-only via
+`TN_RECONCILE_CANONICAL` (octave-mcp #420). Neither the v1.14.0 nor v1.15.0 changelog
+mentions #420 as resolved, so **the workaround remains active**. v1.14.0's literal-zone fence
+preservation and v1.15.0's DocumentMutator extraction are adjacent improvements but do not
+claim to fix #420.
 
-**Current status**: Needs testing. The workaround remains active until `preserve` mode is empirically confirmed to resolve the multi-envelope collapse. Test procedure:
+**Current status**: Still pending. Re-test procedure when ready:
 
-1. Author a FRAME_CARD or CONCEPT_CARD with multiple envelopes using `octave_write(format_style='preserve')`.
+1. Author a FRAME_CARD or CONCEPT_CARD with multiple envelopes using
+   `octave_write(format_style='preserve')`.
 2. Verify all envelopes survive (not collapsed to META-only).
-3. If confirmed fixed: `VOID` the RD18 token and remove the direct-write exception from CLAUDE.md.
+3. If confirmed fixed: `VOID` the RD18 token and remove the direct-write exception from
+   CLAUDE.md.
 
-**References**: octave-mcp #420, `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` (RD18 candidate).
+**References**: octave-mcp #420, #460, #487, #488;
+`.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` (RD18 candidate).
+</content>
+</invoke>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,19 +74,35 @@ Current coverage: ~89%.
 
 ## Octave Tooling
 
-**octave-mcp version in use: v1.13.1**
+**octave-mcp version in use: v1.15.0**
 
 All `.oct.md` files must be written via `mcp__octave__octave_write` (OCTAVE_WRITE_GATE — never use Write/Edit tools on `.oct.md` files).
 
-**v1.13.1 note:** v1.13.1 is a pure internal refactor — the `write.py` god-object was decomposed into five peer modules (`write_detection`, `write_metrics`, `write_format`, `write_mutation`) with **zero behaviour change, byte-identical output, and an unchanged `octave_write` API**. No project usage changes; all v1.13.0 guidance below still applies verbatim.
+Full upgrade detail: `.hestai/decisions/tooling/octave-preserve-mode-upgrade.md`.
 
-**v1.13.0 key changes (still current):**
+**Dependency status:** octave-mcp is a **test-only** optional dependency (`[project.optional-dependencies].test`, `octave-mcp>=1.15`), used only by `tests/unit/governance/test_north_star_upog_compliance.py`. Runtime code does **not** import it — real OCTAVE validation is deferred to a planned "Gate B", per North Star §4 (`document format system — octave-mcp owns`) and PROD::I6. The validator-integration options (test-only / optional `validation` extra / hard runtime dep) are assessed in the decision doc; promoting beyond test-only needs requirements-steward sign-off.
 
-- `format_style='preserve'` is now available (Strategy A, GH#377). Span-aware mode that keeps clean nodes verbatim and only re-emits dirty/repaired nodes. Diff footprint ≤0.5% of file size on single-key edits. **Use this going forward.**
-- `format_style='expanded'` retains the old full canonical re-emit behaviour.
-- `format_style=null` (explicit) now emits a `DeprecationWarning`. Omitting the parameter silently accepts the future default.
-- **v1.14.0 will flip the default** from full canonical re-emit to `preserve`. To be safe: always pass `format_style='preserve'` explicitly in new octave_write calls.
+**v1.15.0 (2026-05-31) — ⚠️ HARD BREAK to `octave_write` `changes`-mode value semantics (GH#487):**
 
-**Multi-envelope workaround (RD18 token `HO-OCTAVE-WRITE-MULTI-ENVELOPE-WORKAROUND-20260513`):**
+- A **bare dict** at a `changes` KEY now **fully replaces** that key — unmentioned children are **DROPPED**. To merge into an existing block you **MUST** send an explicit `{"$op": "MERGE", "value": {…}}`.
+- A **bare scalar** over a nested BLOCK = full replace in place (cures the old duplicate-keys footgun).
+- A `$op:MERGE` of a scalar over a child BLOCK is **rejected** with `E_OP_TARGET_MISMATCH`.
+- Bare dict with a **nested** dict value now emits canonical **BLOCK** form (no more `dict→InlineMap` coercion).
+- `$op:APPEND`/`$op:PREPEND` of nested list/dict elements now emit re-parseable OCTAVE (#488).
+- Read path (`octave_validate`) is unchanged. This project does not call `changes=` mode in source code, so the break is guidance for agents/skills doing surgical key edits.
 
-`octave_write` with older defaults collapsed multi-envelope Facet ABI cards to META-only via `TN_RECONCILE_CANONICAL`. The workaround was to use direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring. With v1.13.0 `preserve` mode landing, this should be **retested** — `preserve` mode's span-aware approach may resolve the collapse. Until confirmed fixed, treat the workaround as still active. See `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` and octave-mcp #420.
+**v1.14.0 (2026-05-30) — anchored paths + literal-zone fidelity (#460):**
+
+- `ANCHOR/KEY` anchored-path syntax disambiguates duplicate sibling keys (e.g. `changes={"I2/RATIONALE": …}`).
+- Literal-zone fence form is preserved on content edits and `$op MERGE` — content-only edits round-trip byte-identical under `format_style="preserve"` (PROD::I1).
+- Anchored-path `$op` descriptors are executed (e.g. `$op DELETE` actually removes), not written as data.
+
+**`format_style` (still current):**
+
+- `format_style='preserve'` is span-aware (clean nodes verbatim, dirty/repaired nodes re-emitted; ≤0.5% diff footprint on single-key edits). **Always pass it explicitly** in `octave_write` calls.
+- `format_style='expanded'` retains full canonical re-emit.
+- The predicted v1.14.0 "flip the default to `preserve`" did **not** land in the v1.14.0 or v1.15.0 changelogs — the default is unconfirmed, so do not rely on it; pass `'preserve'` explicitly.
+
+**Multi-envelope workaround (RD18 token `HO-OCTAVE-WRITE-MULTI-ENVELOPE-WORKAROUND-20260513`) — still active:**
+
+`octave_write` with older defaults collapsed multi-envelope Facet ABI cards to META-only via `TN_RECONCILE_CANONICAL` (octave-mcp #420). The workaround is to use the direct `Write` tool for FRAME_CARD / CONCEPT_CARD authoring. Neither v1.14.0 nor v1.15.0 claims to fix #420, so treat the workaround as **still active** until empirically retested with `format_style='preserve'`. See `.hestai/decisions/handoff/2026-05-16-rfc-40-mac-b1-carry-forward.md` and octave-mcp #420.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
 # tests/unit/governance/test_north_star_upog_compliance.py. Not a runtime dep —
 # keeps PROD::I6 LEGACY_INDEPENDENCE / provider-agnostic runtime intact.
 test = [
-    "octave-mcp>=1.13",
+    "octave-mcp>=1.15",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "octave-mcp", marker = "extra == 'test'", specifier = ">=1.13" },
+    { name = "octave-mcp", marker = "extra == 'test'", specifier = ">=1.15" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.13.1"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -958,9 +958,9 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/ff/c41e8e64c942b09f327b30dc4ea6482a36c5552399c74833e0f9bcbf0ed4/octave_mcp-1.13.1.tar.gz", hash = "sha256:8110136797f0bd1c7ff293268018d418eda6d3378646abd048902d15b127aedd", size = 366847, upload-time = "2026-05-28T22:05:13.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a6/3472a5bc8b3689b745817eeb9b3fa6792699e9dc8aacbbd2ed7cc293a5a7/octave_mcp-1.15.0.tar.gz", hash = "sha256:660c8969b61fb0df473de8934e26f1ed463b6ed92fec542aaab5ccf736509a9a", size = 387208, upload-time = "2026-06-01T08:22:44.371Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/3e11f0f92c331cf2254453c44ff149fd355dc3bee3e854291e51686817ff/octave_mcp-1.13.1-py3-none-any.whl", hash = "sha256:f0acb6005be87683d57328e060c4b9d3d17c340b5caa630fd9accbb23d9efdfd", size = 394772, upload-time = "2026-05-28T22:05:12.527Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3a/9b351a30bd1af1f27013b587a4bd244d2b2345c2e0bd9b0023cf315a304c/octave_mcp-1.15.0-py3-none-any.whl", hash = "sha256:e5212e673c3fcd609e488f61223a05e8fe4520f22609c9cde1de4d182210d551", size = 415089, upload-time = "2026-06-01T08:22:42.615Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Updated octave-mcp dependency from v1.14 to v1.15.0 across configuration and lock files
- Analyzed Gate B integration transport requirements and rejected server-over-stdio approach
- Mapped runtime OCTAVE usage patterns to identify validator and other dependency needs for system integration

## Changes
- **Documentation**: Expanded octave-preserve-mode-upgrade.md with detailed Gate B integration analysis, transport mechanism evaluation, and runtime dependency assessment
- **Configuration**: Updated CLAUDE.md and pyproject.toml to reflect octave v1.15.0 upgrade
- **Dependencies**: Updated uv.lock to align with new octave version constraints and validator dependency considerations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `octave-mcp` to v1.15.0 (test extra) and refined the Gate B validator plan while keeping runtime decoupled. Docs cover the v1.15.0 `changes`-mode break, v1.14 anchored paths/literal fidelity, and why server-over-stdio is rejected.

- **Dependencies**
  - Bumped test extra pin to `octave-mcp>=1.15`; updated `uv.lock` to 1.15.0.
  - No runtime dependency change; validator stays test-only. Gate B integration assessed; stdio subprocess is rejected.
  - Updated `pyproject.toml`, `CLAUDE.md`, and the decision doc with upgrade and validator guidance.

- **Migration**
  - `octave_write(changes=...)`: a bare dict now fully replaces; use `{"$op":"MERGE","value":{...}}` to merge.
  - Pass `format_style='preserve'` explicitly; the default flip did not land.
  - v1.14.0 adds `ANCHOR/KEY` paths and preserves literal-zone fences on edits.

<sup>Written for commit 37a6b2546fcd3838777d6a60f453fd82f8dea556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

