### PR TITLE
test(governance): stop GitGuardian false positives on fixture record IDs

### DIFF
--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -35,6 +35,12 @@ from hestai_context_mcp.tools.governance.type_checker import ValidationResult
 
 _LINKER = "hestai_context_mcp.tools.governance.linker"
 
+# Fake AGR record identifier for fixtures. Referenced via this constant rather
+# than inlined as a secret-keyword + string-literal adjacency, so secret
+# scanners don't read it as a credential. The value is a non-secret governance
+# identifier.
+_LIVE_RECORD_ID = "HO-CONTEXT-MCP-LIVE-20260101"
+
 
 def _fake_completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
     """Build a stand-in for subprocess.CompletedProcess."""
@@ -373,7 +379,7 @@ def _valid_decision(target: Path) -> ValidationResult:
     return ValidationResult(
         valid=True,
         errors=[],
-        token="HO-CONTEXT-MCP-LIVE-20260101",
+        token=_LIVE_RECORD_ID,
         card_type="DECISION_RECORD",
         target_path=target,
     )
@@ -396,7 +402,7 @@ class TestRunLinkerLivePath:
         validation = ValidationResult(
             valid=True,
             errors=[],
-            token="HO-CONTEXT-MCP-LIVE-20260101",
+            token=_LIVE_RECORD_ID,
             card_type="DECISION_RECORD",
             target_path=None,
         )

--- a/tests/unit/tools/test_submit_governance.py
+++ b/tests/unit/tools/test_submit_governance.py
@@ -19,6 +19,12 @@ from unittest.mock import patch
 
 import pytest
 
+# Fake AGR record identifier for fixtures. Referenced via this constant rather
+# than inlined as a secret-keyword + string-literal adjacency, so secret
+# scanners don't read it as a credential. The value is a non-secret governance
+# identifier.
+_ESCAPE_RECORD_ID = "HO-ESCAPE-20260101"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -714,7 +720,7 @@ class TestPathTraversalGuard:
         fake_validation = ValidationResult(
             valid=True,
             errors=[],
-            token="HO-ESCAPE-20260101",
+            token=_ESCAPE_RECORD_ID,
             card_type="DECISION_RECORD",
             target_path=outside_path,
         )


### PR DESCRIPTION
## Problem

GitGuardian's App repeatedly flags governance test fixtures as **Generic High Entropy Secret**. Root cause: a secret-named identifier (`token=`) assigned a string literal — e.g. `token="HO-CONTEXT-MCP-LIVE-20260101"`. The detector keys on the `token=<literal>` **keyword-adjacency**, not on the value's actual entropy. The flagged values are non-secret governance (AGR) record identifiers, not credentials.

## Fix

Reference each fixture value through a module-level constant that is **not** named like a secret (no `token`/`key`/`secret`/`password` in the name), so no `token="<literal>"` adjacency remains:

- `tests/unit/tools/governance/test_linker.py` — added `_LIVE_RECORD_ID = "HO-CONTEXT-MCP-LIVE-20260101"`; both fixture sites now use `token=_LIVE_RECORD_ID`.
- `tests/unit/tools/test_submit_governance.py` — added `_ESCAPE_RECORD_ID = "HO-ESCAPE-20260101"`; fixture now uses `token=_ESCAPE_RECORD_ID`.

**Behavior is unchanged** — the same string values flow through; no test logic changed (1029 tests pass, 92% coverage).

## Why no path-ignore

This deliberately does **not** add a `.gitguardian.yaml` path-ignore or dashboard ignore. Removing the keyword-adjacency keeps GitGuardian **live** on these files, so it can still catch a genuine secret literal added here later (per PROD::I2 CREDENTIAL_SAFETY). The existing `.gitguardian.yaml` (ggshield CLI config) is untouched. `tests/unit/tools/test_clock_out.py` (intentional `sk-TESTONLY...` redaction fixture with `# nosec`) is also untouched.

## CI note

GitGuardian App is **not** a required check — only `final_gate` is required. This change removes the recurring false-positive noise without weakening real detection.

## Verification

- `grep -rn 'token="' tests/unit/tools/` → empty
- `ruff check src tests` → all checks passed
- `black --check src tests` → 128 files unchanged
- `mypy src` → no issues in 46 source files
- `pytest` → 1029 passed, 92% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops GitGuardian false positives in governance tests by referencing record IDs via module-level constants instead of inline token="..." strings. No behavior change; this only removes noisy alerts.

- **Bug Fixes**
  - Replaced inline token strings with constants `_LIVE_RECORD_ID` and `_ESCAPE_RECORD_ID` in `tests/unit/tools/governance/test_linker.py` and `tests/unit/tools/test_submit_governance.py`.
  - No logic changes; tests still pass. GitGuardian config unchanged (no path ignores).

<sup>Written for commit 2061aeb87412e9a6cce5fa1881c1401aa6c7363e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

