### PR TITLE
feat(rfc-53): Gate B — wire octave-mcp real validator behind OctaveValidator port

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,18 @@ dev = [
 test = [
     "octave-mcp>=1.15",
 ]
+# Optional runtime extra (RFC #53 Gate B): promotes octave-mcp from a test-only
+# tool to an OPTIONAL real-validation backend behind the OctaveValidator port
+# (hestai_context_mcp.ports.octave_validator). The port is feature-detected and
+# fail-soft: with this extra installed, submit_governance runs octave-mcp's REAL
+# in-process AST validator alongside the regex Gate A; WITHOUT it, the tool
+# degrades gracefully to regex-only. NEVER a hard runtime dependency — the
+# default install stays octave-mcp-free, preserving PROD::I6 LEGACY_INDEPENDENCE
+# and North Star §4 (octave-mcp owns the OCTAVE format; this repo never reinvents
+# an OCTAVE AST).
+validation = [
+    "octave-mcp>=1.15",
+]
 
 [project.urls]
 Homepage = "https://github.com/elevanaltd/hestai-context-mcp"

--- a/src/hestai_context_mcp/ports/octave_validator.py
+++ b/src/hestai_context_mcp/ports/octave_validator.py
@@ -1,0 +1,255 @@
+"""OCTAVE validation port (RFC #53 Gate B).
+
+This module defines the :class:`OctaveValidator` Protocol and a small family of
+adapters, mirroring the port/adapter/fail-soft pattern established in
+:mod:`hestai_context_mcp.ports.ai_client`.
+
+**Why a port** (North Star §4; PROD I6 LEGACY_INDEPENDENCE):
+    octave-mcp *owns* the OCTAVE format. This repository never reinvents an
+    OCTAVE AST and never depends on octave-mcp at runtime. The real validator is
+    reached only through this feature-detected, fail-soft seam, gated by the
+    optional ``validation`` extra. The default install stays octave-mcp-free.
+
+**Integration shape** (library-behind-a-port, IN-PROCESS):
+    The real adapter imports octave-mcp and calls its public validate API
+    *in-process* — never a server over stdio. The flow is:
+
+        doc, warnings = octave_mcp.parse_with_warnings(content, strict_structure=True)
+        errors = octave_mcp.Validator().validate(doc, strict=False)
+
+    ``parse_with_warnings`` raises ``LexerError``/``ParserError`` on syntactic /
+    structural defects (the class of bug the regex Gate A is blind to);
+    ``Validator.validate`` returns a list of ``ValidationError`` dataclasses
+    (``code``/``message``/``field_path``/``line``/``severity``).
+
+**Structured result** (PROD I4 STRUCTURED_RETURN_SHAPES):
+    Every adapter returns an :class:`OctaveValidationResult` — never a raw
+    report blob. ``to_dict`` exposes exactly ``{ok, errors, warnings,
+    available}`` so the caller can merge fields programmatically.
+
+**Fail-soft** (never crash, never block):
+    When octave-mcp is not importable, :func:`get_octave_validator` returns an
+    :class:`UnavailableOctaveValidator`. Its result is ``ok=True`` (so the tool
+    is NOT blocked) with ``available=False`` and a structured
+    ``REAL_VALIDATION_UNAVAILABLE`` warning (so the degrade is auditable, not
+    silent). The regex Gate A continues to run regardless.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "OctaveValidationResult",
+    "OctaveValidator",
+    "RealOctaveValidator",
+    "UnavailableOctaveValidator",
+    "get_octave_validator",
+]
+
+# Stable warning code surfaced when the optional ``validation`` extra is absent.
+REAL_VALIDATION_UNAVAILABLE = "REAL_VALIDATION_UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class OctaveValidationResult:
+    """Structured outcome of a real-OCTAVE validation pass (PROD I4).
+
+    Fields:
+        ok: True when the document passed real validation (no error-severity
+            findings). Note the fail-soft adapter also reports ``ok=True`` —
+            inspect ``available`` to distinguish "validated clean" from
+            "could not validate".
+        errors: Error-severity findings, each a structured dict with at least
+            ``code`` and ``message`` (plus ``field_path``/``line`` when known).
+        warnings: Non-blocking findings (lenient-parse repairs, schema
+            warnings, or the degrade signal), same dict shape.
+        available: True when the real octave-mcp backend actually ran; False
+            when the ``validation`` extra was absent and the pass degraded.
+    """
+
+    ok: bool
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[dict[str, Any]] = field(default_factory=list)
+    available: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the I4-conformant dict with all fields present."""
+        return {
+            "ok": self.ok,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "available": self.available,
+        }
+
+
+@runtime_checkable
+class OctaveValidator(Protocol):
+    """Validate OCTAVE content against octave-mcp's real grammar.
+
+    Intentionally a single synchronous method. Backend selection, feature
+    detection, and the fail-soft degrade all live *below* this port (in the
+    adapters and :func:`get_octave_validator`), so callers depend only on the
+    structured contract.
+    """
+
+    def validate(self, content: str) -> OctaveValidationResult:
+        """Return a structured validation result for ``content``.
+
+        Implementations MUST NOT raise on malformed input: a validation failure
+        is data (populated ``errors``), not an exception.
+        """
+        ...
+
+
+def _octave_mcp_available() -> bool:
+    """Feature-detect the optional ``validation`` extra (octave-mcp).
+
+    Uses ``importlib.util.find_spec`` so detection is cheap and does not import
+    the package as a side effect. Isolated in a tiny function so tests can
+    monkeypatch the probe to simulate the extra's absence in any environment.
+    """
+    return importlib.util.find_spec("octave_mcp") is not None
+
+
+class RealOctaveValidator:
+    """In-process adapter over octave-mcp's real validate API.
+
+    Imports octave-mcp lazily inside :meth:`validate` so merely importing this
+    module never requires the optional extra. Translates octave-mcp's parser /
+    lexer exceptions and ``ValidationError`` dataclasses into the structured
+    :class:`OctaveValidationResult` (PROD I4).
+    """
+
+    def validate(self, content: str) -> OctaveValidationResult:
+        # Lazy, in-process import. NEVER a server over stdio; NEVER an in-repo
+        # AST. octave-mcp owns the format (North Star §4).
+        import octave_mcp
+
+        errors: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+
+        try:
+            doc, parse_warnings = octave_mcp.parse_with_warnings(content, strict_structure=True)
+        except (octave_mcp.LexerError, octave_mcp.ParserError) as exc:
+            # Syntactic / structural defect — the regex Gate A cannot see this.
+            errors.append(
+                {
+                    "code": getattr(exc, "code", type(exc).__name__),
+                    "message": str(exc),
+                    "field_path": "",
+                    "line": getattr(exc, "line", 0),
+                }
+            )
+            return OctaveValidationResult(
+                ok=False, errors=errors, warnings=warnings, available=True
+            )
+        except Exception as exc:  # noqa: BLE001 — never propagate; degrade to data.
+            errors.append(
+                {
+                    "code": "OCTAVE_PARSE_ERROR",
+                    "message": str(exc),
+                    "field_path": "",
+                    "line": 0,
+                }
+            )
+            return OctaveValidationResult(
+                ok=False, errors=errors, warnings=warnings, available=True
+            )
+
+        # Lenient-parse repairs / coalescing notes are warnings, not errors.
+        for w in parse_warnings:
+            warnings.append(self._normalise_parse_warning(w))
+
+        try:
+            validation_errors = octave_mcp.Validator().validate(doc, strict=False)
+        except Exception as exc:  # noqa: BLE001 — never propagate; degrade to data.
+            errors.append(
+                {
+                    "code": "OCTAVE_VALIDATE_ERROR",
+                    "message": str(exc),
+                    "field_path": "",
+                    "line": 0,
+                }
+            )
+            return OctaveValidationResult(
+                ok=False, errors=errors, warnings=warnings, available=True
+            )
+
+        for ve in validation_errors:
+            entry = {
+                "code": getattr(ve, "code", ""),
+                "message": getattr(ve, "message", str(ve)),
+                "field_path": getattr(ve, "field_path", ""),
+                "line": getattr(ve, "line", 0),
+            }
+            if getattr(ve, "severity", "error") == "warning":
+                warnings.append(entry)
+            else:
+                errors.append(entry)
+
+        return OctaveValidationResult(
+            ok=not errors, errors=errors, warnings=warnings, available=True
+        )
+
+    @staticmethod
+    def _normalise_parse_warning(raw: Any) -> dict[str, Any]:
+        """Coerce an octave-mcp parse-warning dict into the structured shape."""
+        if isinstance(raw, dict):
+            return {
+                "code": str(raw.get("subtype") or raw.get("type") or "PARSE_WARNING"),
+                "message": str(raw.get("type", "")),
+                "field_path": "",
+                "line": int(raw.get("line", 0) or 0),
+                "detail": raw,
+            }
+        return {
+            "code": "PARSE_WARNING",
+            "message": str(raw),
+            "field_path": "",
+            "line": 0,
+        }
+
+
+class UnavailableOctaveValidator:
+    """Fail-soft adapter used when the ``validation`` extra is absent.
+
+    Returns ``ok=True`` so the tool is never blocked, with ``available=False``
+    and a structured ``REAL_VALIDATION_UNAVAILABLE`` warning so the degrade is
+    auditable rather than silent. Never imports octave-mcp; never raises.
+    """
+
+    def validate(self, content: str) -> OctaveValidationResult:
+        return OctaveValidationResult(
+            ok=True,
+            errors=[],
+            warnings=[
+                {
+                    "code": REAL_VALIDATION_UNAVAILABLE,
+                    "message": (
+                        "Real OCTAVE validation was skipped: the optional "
+                        "'validation' extra (octave-mcp) is not installed. "
+                        "Regex Gate A validation still applied. Install with "
+                        "'pip install hestai-context-mcp[validation]' to enable "
+                        "full in-process AST validation."
+                    ),
+                    "field_path": "",
+                    "line": 0,
+                }
+            ],
+            available=False,
+        )
+
+
+def get_octave_validator() -> OctaveValidator:
+    """Return the active OctaveValidator, feature-detecting the extra.
+
+    Real adapter when octave-mcp is importable; the fail-soft
+    :class:`UnavailableOctaveValidator` otherwise. The return type is the port
+    Protocol, so callers never branch on the concrete adapter.
+    """
+    if _octave_mcp_available():
+        return RealOctaveValidator()
+    return UnavailableOctaveValidator()

--- a/src/hestai_context_mcp/tools/governance/__init__.py
+++ b/src/hestai_context_mcp/tools/governance/__init__.py
@@ -1,8 +1,12 @@
 """Governance intake tools for RFC #53 Symbiotic Intake Engine.
 
 Gate A Rails: regex-only validation, path placement, PR creation.
-Gate B (future): wire octave-mcp validator over stdio.
+Gate B: octave-mcp's real validator runs as an in-process library behind the
+OctaveValidator port (hestai_context_mcp.ports.octave_validator), gated by the
+optional ``validation`` extra — never an in-repo OCTAVE AST, never over stdio.
 
-North Star boundary (PROD §4 IS_NOT): this package does NOT parse OCTAVE AST,
-does NOT invoke octave-mcp, does NOT import any OCTAVE parsing library.
+North Star boundary (PROD §4 IS_NOT): this package does NOT reinvent an OCTAVE
+AST and does NOT depend on octave-mcp at runtime. The real AST validation is
+owned by octave-mcp and reached only through the feature-detected, fail-soft
+port, so the default install remains octave-mcp-free (PROD I6).
 """

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -9,8 +9,11 @@ North Star boundary (PROD §4 IS_NOT: document format system — octave-mcp owns
   - TOKEN field: r'TOKEN::"([^"]+)"' for DECISION_RECORD.
   - ID field: r'ID::"([^"]+)"' for facet cards.
 
-Gate B (future) will wire the REAL OCTAVE validator to octave-mcp over stdio.
-This file is intentionally dumb by design.
+Gate B wires the REAL OCTAVE validator as an in-process library behind the
+OctaveValidator port (hestai_context_mcp.ports.octave_validator), gated by the
+optional ``validation`` extra — not over stdio, and never an in-repo AST. This
+file stays intentionally dumb (regex-only) by design; the real validator is
+additive and runs alongside it at the submit_governance seam.
 """
 
 import re

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -19,6 +19,10 @@ import asyncio
 from functools import partial
 from typing import Any
 
+from hestai_context_mcp.ports.octave_validator import (
+    OctaveValidationResult,
+    get_octave_validator,
+)
 from hestai_context_mcp.tools.clock_in import validate_working_dir
 from hestai_context_mcp.tools.governance.linker import run_linker
 from hestai_context_mcp.tools.governance.type_checker import validate_octave_content
@@ -27,6 +31,7 @@ from hestai_context_mcp.tools.governance.type_checker import validate_octave_con
 def _empty_result(
     dry_run: bool,
     errors: list[str],
+    octave_validation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return the I4-conformant failure shape with all fields present."""
     return {
@@ -37,8 +42,27 @@ def _empty_result(
         "branch": None,
         "pr_url": None,
         "validation_errors": errors,
+        "octave_validation": octave_validation,
         "dry_run": dry_run,
     }
+
+
+def _octave_errors_to_strings(result: OctaveValidationResult) -> list[str]:
+    """Flatten octave-mcp's structured errors into human-readable strings.
+
+    The structured detail is preserved verbatim under the ``octave_validation``
+    return field (PROD I4); this projection only feeds the flat
+    ``validation_errors`` list that callers already consume from Gate A.
+    """
+    messages: list[str] = []
+    for err in result.errors:
+        code = err.get("code", "")
+        message = err.get("message", "")
+        line = err.get("line", 0)
+        prefix = f"[{code}] " if code else ""
+        suffix = f" (line {line})" if line else ""
+        messages.append(f"{prefix}{message}{suffix}".strip())
+    return messages
 
 
 async def submit_governance(
@@ -49,11 +73,14 @@ async def submit_governance(
     """Submit an operator-authored OCTAVE governance artifact.
 
     Gate A Rails: regex sentinel check + path placement + PR creation.
-    No LLM. No OCTAVE AST parsing. No octave-mcp invocation.
+    Gate B: octave-mcp's REAL validator runs in-process behind the
+    OctaveValidator port (additive to Gate A), gated by the optional
+    ``validation`` extra. No LLM. No in-repo OCTAVE AST. No stdio server.
 
-    Blocking I/O (filesystem reads, subprocess calls) is offloaded to
-    the default thread-pool executor via run_in_executor so that the
-    async event loop is never blocked (Bug 5 fix).
+    Blocking I/O (filesystem reads, subprocess calls) and the CPU-bound
+    in-process OCTAVE parse are offloaded to the default thread-pool
+    executor via run_in_executor so that the async event loop is never
+    blocked (Bug 5 fix).
 
     Args:
         working_dir: Absolute path to the project root directory.
@@ -70,6 +97,12 @@ async def submit_governance(
           branch: str | None -- Git branch name that was (or would be) created.
           pr_url: str | None -- PR URL (None for dry_run or on failure).
           validation_errors: list[str] -- Empty on success.
+          octave_validation: dict | None -- Structured real-validation result
+            {ok, errors, warnings, available} from the OctaveValidator port
+            (PROD I4). available=False means the optional ``validation`` extra
+            was absent and the pass degraded to regex-only (fail-soft). None
+            only when failure occurred before the real validator ran (e.g. an
+            invalid working_dir or a regex Gate A rejection).
           dry_run: bool -- Echoes the dry_run parameter.
     """
     loop = asyncio.get_running_loop()
@@ -90,6 +123,30 @@ async def submit_governance(
 
     if not validation.valid:
         return _empty_result(dry_run, validation.errors)
+
+    # --- Gate B: REAL OCTAVE validation (in-process library behind the port) ---
+    # octave-mcp's real validator runs here, ADDITIVE to the regex Gate A above.
+    # It catches AST/lexer defects (e.g. unbalanced brackets, structural errors)
+    # that the regex checker is blind to. The call is offloaded to the executor
+    # because the in-process parse is CPU-bound. The port is feature-detected and
+    # fail-soft: when the optional ``validation`` extra is absent it returns
+    # ok=True/available=False with a structured signal, so the tool degrades to
+    # regex-only rather than crashing or blocking (PROD I6; North Star §4).
+    octave_validator = get_octave_validator()
+    octave_result = await loop.run_in_executor(
+        None,
+        octave_validator.validate,
+        octave_content,
+    )
+    octave_validation = octave_result.to_dict()
+
+    if not octave_result.ok:
+        # Real validation failed: structured error, no PR / no write.
+        return _empty_result(
+            dry_run,
+            _octave_errors_to_strings(octave_result),
+            octave_validation=octave_validation,
+        )
 
     # --- Linker (blocking: git subprocess + file writes) ---
     linker_fn = partial(
@@ -114,5 +171,6 @@ async def submit_governance(
         "branch": linker_output.get("branch"),
         "pr_url": linker_output.get("pr_url"),
         "validation_errors": errors,
+        "octave_validation": octave_validation,
         "dry_run": dry_run,
     }

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -9,7 +9,10 @@ North Star invariants enforced:
   PROD I5: get_context is UNTOUCHED. This tool is additive.
   PROD I6: No hestai_mcp imports. No new PyPI dependencies.
 
-Gate B (future): wire octave-mcp validator over stdio for full OCTAVE validation.
+Gate B: octave-mcp's REAL validator runs in-process as a library behind the
+OctaveValidator port (hestai_context_mcp.ports.octave_validator), gated by the
+optional ``validation`` extra. When the extra is absent the port degrades to a
+structured "real-validation unavailable" signal and the regex Gate A still runs.
 """
 
 import asyncio

--- a/tests/unit/ports/test_octave_validator.py
+++ b/tests/unit/ports/test_octave_validator.py
@@ -1,0 +1,192 @@
+"""Port contract tests for ``hestai_context_mcp.ports.octave_validator``.
+
+RFC #53 Gate B. Locks the OctaveValidator port shape (mirroring ai_client.py):
+
+* A runtime-checkable :class:`typing.Protocol` (``OctaveValidator``) with a
+  single ``validate`` method returning a STRUCTURED result (PROD I4), never a
+  blob.
+* A frozen ``OctaveValidationResult`` dataclass: ``ok: bool``,
+  ``errors: list[...]``, ``warnings: list[...]``, plus an ``available`` flag.
+* A real adapter that wraps octave-mcp's IN-PROCESS validate API
+  (``parse_with_warnings`` + ``Validator().validate``) — never over stdio,
+  never an in-repo AST.
+* A fail-soft path: when the ``validation`` extra (octave-mcp) is not
+  importable, ``get_octave_validator()`` returns a degraded validator whose
+  result is ``ok=True, available=False`` with a structured
+  "real-validation unavailable" warning. It NEVER crashes and NEVER blocks.
+
+The real-adapter tests are skipped when octave-mcp is absent; the fail-soft
+tests simulate absence by monkeypatching the import probe, so they run in BOTH
+environments.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+OCTAVE_MCP_INSTALLED = importlib.util.find_spec("octave_mcp") is not None
+
+requires_octave_mcp = pytest.mark.skipif(
+    not OCTAVE_MCP_INSTALLED,
+    reason="octave-mcp not installed (the 'validation' extra is absent)",
+)
+
+VALID_DECISION = (
+    "===DECISION_RECORD===\n" "META:\n" "  TYPE::DECISION_RECORD\n" "  TOKEN::FOO-BAR-20260101\n"
+)
+
+# Unbalanced bracket — octave-mcp's strict lexer raises (LexerError) where the
+# regex Gate A is blind. This is exactly the class of defect Gate B hardens.
+BROKEN_AST = "===DECISION_RECORD===\nMETA:\n  X::[a, b\n"
+
+
+class TestPortModuleShape:
+    """Module exposes the expected public symbols."""
+
+    def test_module_importable(self):
+        import hestai_context_mcp.ports.octave_validator  # noqa: F401
+
+    def test_exports_protocol_class(self):
+        from hestai_context_mcp.ports.octave_validator import OctaveValidator
+
+        assert getattr(OctaveValidator, "_is_protocol", False)
+
+    def test_protocol_is_runtime_checkable(self):
+        from hestai_context_mcp.ports.octave_validator import OctaveValidator
+
+        # runtime_checkable protocols support isinstance against duck types.
+        class _Dummy:
+            def validate(self, content: str) -> object:  # pragma: no cover
+                return None
+
+        assert isinstance(_Dummy(), OctaveValidator)
+
+    def test_exports_result_dataclass(self):
+        from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
+
+        result = OctaveValidationResult(ok=True, errors=[], warnings=[], available=True)
+        assert result.ok is True
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.available is True
+
+    def test_result_is_frozen(self):
+        from dataclasses import FrozenInstanceError
+
+        from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
+
+        result = OctaveValidationResult(ok=True, errors=[], warnings=[], available=True)
+        with pytest.raises(FrozenInstanceError):
+            result.ok = False  # type: ignore[misc]
+
+    def test_exports_factory(self):
+        from hestai_context_mcp.ports.octave_validator import get_octave_validator
+
+        validator = get_octave_validator()
+        # Whatever it returns, it must satisfy the port.
+        from hestai_context_mcp.ports.octave_validator import OctaveValidator
+
+        assert isinstance(validator, OctaveValidator)
+
+
+class TestResultStructure:
+    """PROD I4: the result is a structured dict-able shape, never a blob."""
+
+    def test_to_dict_has_defined_fields(self):
+        from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
+
+        result = OctaveValidationResult(
+            ok=False,
+            errors=[{"code": "E007", "message": "bad", "line": 3}],
+            warnings=[{"code": "W001", "message": "warn", "line": 0}],
+            available=True,
+        )
+        payload = result.to_dict()
+        assert set(payload) == {"ok", "errors", "warnings", "available"}
+        assert payload["ok"] is False
+        assert payload["errors"][0]["code"] == "E007"
+        assert payload["warnings"][0]["code"] == "W001"
+        assert payload["available"] is True
+
+
+@requires_octave_mcp
+class TestRealAdapter:
+    """The real adapter binds to octave-mcp's IN-PROCESS validate API."""
+
+    def _make(self):
+        from hestai_context_mcp.ports.octave_validator import RealOctaveValidator
+
+        return RealOctaveValidator()
+
+    def test_valid_document_passes(self):
+        result = self._make().validate(VALID_DECISION)
+        assert result.available is True
+        assert result.ok is True
+        assert result.errors == []
+
+    def test_unbalanced_bracket_fails_with_structured_error(self):
+        result = self._make().validate(BROKEN_AST)
+        assert result.available is True
+        assert result.ok is False
+        assert result.errors, "expected at least one structured error"
+        first = result.errors[0]
+        # Structured, not a blob: every error carries a code + message.
+        assert "code" in first
+        assert "message" in first
+        assert isinstance(first["message"], str)
+
+    def test_never_raises_on_garbage(self):
+        # Even total garbage must produce a structured result, never an exception.
+        result = self._make().validate("\x00 not octave at all { ] [")
+        assert result.available is True
+        assert result.ok is False
+        assert isinstance(result.errors, list)
+
+    def test_factory_returns_real_adapter_when_extra_present(self):
+        from hestai_context_mcp.ports.octave_validator import (
+            RealOctaveValidator,
+            get_octave_validator,
+        )
+
+        assert isinstance(get_octave_validator(), RealOctaveValidator)
+
+
+class TestFailSoftWhenExtraAbsent:
+    """Fail-soft: octave-mcp absent -> degrade, never crash, never block."""
+
+    def test_unavailable_validator_is_ok_but_flags_unavailable(self):
+        from hestai_context_mcp.ports.octave_validator import UnavailableOctaveValidator
+
+        result = UnavailableOctaveValidator().validate(VALID_DECISION)
+        # ok=True so it does NOT block the tool; available=False signals degrade.
+        assert result.ok is True
+        assert result.available is False
+        assert result.errors == []
+        # A structured warning surfaces the degraded state (not a silent pass).
+        assert result.warnings, "expected a real-validation-unavailable warning"
+        codes = {w.get("code") for w in result.warnings}
+        assert "REAL_VALIDATION_UNAVAILABLE" in codes
+
+    def test_unavailable_validator_never_raises(self):
+        from hestai_context_mcp.ports.octave_validator import UnavailableOctaveValidator
+
+        # Garbage in, structured degraded result out — no exception.
+        result = UnavailableOctaveValidator().validate("\x00 { ] [ garbage")
+        assert result.available is False
+        assert result.ok is True
+
+    def test_factory_degrades_when_import_probe_reports_absent(self, monkeypatch):
+        import hestai_context_mcp.ports.octave_validator as mod
+
+        # Simulate the 'validation' extra being absent regardless of the real
+        # environment by forcing the feature-detection probe to report False.
+        monkeypatch.setattr(mod, "_octave_mcp_available", lambda: False)
+
+        validator = mod.get_octave_validator()
+        assert isinstance(validator, mod.UnavailableOctaveValidator)
+
+        result = validator.validate(VALID_DECISION)
+        assert result.available is False
+        assert result.ok is True

--- a/tests/unit/tools/test_submit_governance_octave_validator.py
+++ b/tests/unit/tools/test_submit_governance_octave_validator.py
@@ -1,0 +1,204 @@
+"""submit_governance × OctaveValidator wiring tests (RFC #53 Gate B).
+
+Verifies that the real OctaveValidator port is wired at the run_in_executor seam
+in submit_governance, ADDITIVE to the regex Gate A:
+
+* valid OCTAVE -> regex passes AND real validator passes -> proceed (dry_run
+  success), with a structured ``octave_validation`` field present (PROD I4);
+* invalid AST that the regex Gate A cannot see (unbalanced bracket) -> real
+  validator fails -> structured failure, NO PR / NO write, regex-derived fields
+  still present;
+* fail-soft -> when the real validator reports ``available=False`` (the
+  ``validation`` extra is absent), the tool does NOT crash and does NOT block:
+  the regex Gate A still gates, and the structured "real-validation unavailable"
+  signal is surfaced;
+* public input contract is unchanged (still ``octave_content``).
+
+These tests inject the validator by monkeypatching the port factory used inside
+submit_governance, so they are deterministic regardless of whether octave-mcp is
+installed in the running environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
+
+
+@pytest.fixture()
+def decision_record_octave() -> str:
+    """A well-formed DECISION_RECORD that passes the regex Gate A."""
+    return (
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        '  TOKEN::"HO-CONTEXT-MCP-GATEB-DECISION-20260601"\n'
+        "  STATUS::PROPOSED\n"
+        "===END===\n"
+    )
+
+
+class _StubValidator:
+    """Records the content it was asked to validate and returns a canned result."""
+
+    def __init__(self, result: OctaveValidationResult) -> None:
+        self._result = result
+        self.seen: list[str] = []
+
+    def validate(self, content: str) -> OctaveValidationResult:
+        self.seen.append(content)
+        return self._result
+
+
+def _run(working_dir: Path, content: str):
+    from hestai_context_mcp.tools.submit_governance import submit_governance
+
+    return asyncio.run(
+        submit_governance(
+            working_dir=str(working_dir),
+            octave_content=content,
+            dry_run=True,
+        )
+    )
+
+
+class TestRealValidatorPassProceeds:
+    @pytest.mark.unit
+    def test_valid_passes_and_surfaces_structured_octave_validation(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=True)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is True
+        assert result["validation_errors"] == []
+        # Additive structured field (PROD I4), all sub-fields present.
+        assert "octave_validation" in result
+        ov = result["octave_validation"]
+        assert set(ov) == {"ok", "errors", "warnings", "available"}
+        assert ov["ok"] is True
+        assert ov["available"] is True
+        # The REAL validator saw the operator's content (in-process, real wiring).
+        assert stub.seen == [decision_record_octave]
+
+
+class TestRealValidatorFailBlocks:
+    @pytest.mark.unit
+    def test_invalid_ast_fails_with_structured_error_no_pr(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        # The regex Gate A passes (well-formed token/type) but the REAL validator
+        # reports an AST defect the regex is blind to.
+        stub = _StubValidator(
+            OctaveValidationResult(
+                ok=False,
+                errors=[
+                    {
+                        "code": "E_UNBALANCED_BRACKET",
+                        "message": "opening '[' has no matching ']'",
+                        "field_path": "",
+                        "line": 3,
+                    }
+                ],
+                warnings=[],
+                available=True,
+            )
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        # Linker must never run on a real-validation failure.
+        def _boom(*args, **kwargs):  # pragma: no cover - must not be called
+            raise AssertionError("run_linker must not be called when real validation fails")
+
+        monkeypatch.setattr(mod, "run_linker", _boom)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is False
+        assert result["pr_url"] is None
+        # The structured octave-mcp error is merged into validation_errors.
+        assert any(
+            "E_UNBALANCED_BRACKET" in e or "bracket" in e.lower()
+            for e in result["validation_errors"]
+        )
+        # Structured detail preserved (PROD I4).
+        assert result["octave_validation"]["ok"] is False
+        assert result["octave_validation"]["errors"][0]["code"] == "E_UNBALANCED_BRACKET"
+        # Regex-derived fields still present even on real-validation failure.
+        assert "token" in result
+        assert "card_type" in result
+
+
+class TestFailSoftDoesNotBlock:
+    @pytest.mark.unit
+    def test_unavailable_extra_degrades_and_proceeds(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        # Simulate the 'validation' extra being absent: ok=True, available=False.
+        stub = _StubValidator(
+            OctaveValidationResult(
+                ok=True,
+                errors=[],
+                warnings=[
+                    {
+                        "code": "REAL_VALIDATION_UNAVAILABLE",
+                        "message": "octave-mcp not installed; regex Gate A still applied",
+                        "field_path": "",
+                        "line": 0,
+                    }
+                ],
+                available=False,
+            )
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        # Fail-soft: the regex Gate A still gated, so a valid doc proceeds.
+        assert result["success"] is True
+        ov = result["octave_validation"]
+        assert ov["available"] is False
+        # The degrade is surfaced, not silent.
+        assert any(w.get("code") == "REAL_VALIDATION_UNAVAILABLE" for w in ov["warnings"])
+
+    @pytest.mark.unit
+    def test_regex_gate_a_still_blocks_when_extra_absent(self, tmp_path: Path, monkeypatch) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        # Even with the real validator degraded, the regex Gate A must still
+        # reject obviously-malformed content (no OCTAVE sentinel).
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        result = _run(tmp_path, "plain prose, no octave sentinel at all")
+
+        assert result["success"] is False
+        assert result["validation_errors"]
+
+
+class TestPublicContractUnchanged:
+    @pytest.mark.unit
+    def test_input_signature_still_octave_content(self) -> None:
+        import inspect
+
+        from hestai_context_mcp.tools.submit_governance import submit_governance
+
+        params = inspect.signature(submit_governance).parameters
+        # The Gate C prose intake is NOT part of this task.
+        assert set(params) == {"working_dir", "octave_content", "dry_run"}


### PR DESCRIPTION
## What

RFC #53 **Gate B** — hardens Stage 3 (Type Checker) of the Symbiotic Intake Engine by wiring octave-mcp's **real validator in-process behind an `OctaveValidator` port**, behind an optional `validation` extra. Additive to the existing regex Gate A.

## Implements the ratified ReqSteward integration ruling

- **Dependency = optional `validation` extra** (`octave-mcp>=1.15`) — **never** a hard runtime dep (North Star §4 / PROD I6); default install stays octave-mcp-free.
- **Integration = library-behind-a-port, in-process** — `ports/octave_validator.py` mirrors `ports/ai_client.py`; returns a structured `{ok, errors, warnings, available}` (PROD I4). **Never stdio; never an in-repo OCTAVE AST** (octave-mcp owns format).
- **Fail-soft** when the extra is absent — lazy `importlib.util.find_spec` probe; regex Gate A still gates; surfaces `REAL_VALIDATION_UNAVAILABLE`, never crashes.
- **Wired at the `run_in_executor` seam** in `submit_governance.py`; merges structured errors.
- Retired the 3 stale "wire validator OVER STDIO" comments.

## Real API wired (inspected installed octave_mcp 1.15.0, not guessed)

`octave_mcp.parse_with_warnings(content, strict_structure=True)` (raises Lexer/ParserError on structural defects the regex is blind to) + `octave_mcp.Validator().validate(doc, strict=False)` (severity-routed to errors/warnings).

## Commits

- `05ffdf4` deps: optional `validation` extra + retire stdio comments
- `733101f` ports: `OctaveValidator` protocol + real adapter + fail-soft
- `0946844` submit_governance: wire real validator at the executor seam

## Gates

1089 passed; coverage 92% (`submit_governance.py` 100%); ruff/black/mypy clean. Fail-soft path unit + wiring + end-to-end tested (import physically blocked). `get_context` untouched (I5); public input contract unchanged (still `octave_content` — prose intake is Gate C). 2 pre-existing `clock_in` failures are issue #66 (local AI env), green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the real OCTAVE validator from `octave-mcp` behind a new `OctaveValidator` port and runs it in-process during `submit_governance`, additive to the regex-based Gate A. The validator is optional via the `validation` extra, fails soft when absent, and reports structured results under `octave_validation`.

- **New Features**
  - Added `OctaveValidator` protocol with real and fail-soft adapters returning {ok, errors, warnings, available}.
  - `submit_governance` calls the validator at the `run_in_executor` seam; on failure, no PR is created and errors are merged into `validation_errors`; adds a new `octave_validation` field to the result.
  - Fail-soft when the extra is missing: surfaces `REAL_VALIDATION_UNAVAILABLE`; regex Gate A still gates.
  - Unit tests cover the port shape, real adapter behavior, fail-soft path, and wiring.

- **Dependencies**
  - New optional `validation` extra with `octave-mcp>=1.15`; default install stays `octave-mcp`-free.
  - Enable with: pip install `hestai-context-mcp[validation]`.

<sup>Written for commit 09468449f04ebe5a227275009637dac6f3d33697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

