### PR TITLE
feat(governance): first dogfooded AGR — adopt AGRs for hestai-context-mcp's own decisions

### DIFF
--- a/.hestai/MANIFEST.md
+++ b/.hestai/MANIFEST.md
@@ -1,0 +1,3 @@
+| TOKEN/ID | path |
+| --- | --- |
+| HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611 | .hestai/decisions/HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611.oct.md |

--- a/.hestai/decisions/HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611.oct.md
+++ b/.hestai/decisions/HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611.oct.md
@@ -1,0 +1,16 @@
+===DECISION_RECORD===
+META:
+  TYPE::DECISION_RECORD
+  VERSION::"1.0"
+  TOKEN::HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611
+  STATUS::RATIFIED
+  TIER::STRATEGIC
+  AUTHORED_AT::"2026-06-11T00:00:00Z"
+  RATIFIED_BY::"human:operator"
+  RATIFIED_AT::"2026-06-11T00:00:00Z"
+  ISSUE_REF::"repo:hestai-context-mcp#53"
+  HUMAN_ADR_REF::".hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md"
+  SCOPE::"hestai-context-mcp"
+  DECISION::"hestai-context-mcp dogfoods its own AGR standard: durable architectural decisions are authored as DECISION_RECORD AGRs under .hestai/decisions/ via the Symbiotic Intake Engine."
+  BECAUSE::"This repository owns the AGR standard (ADR-RFC-ARCH-004) and completed the write-side intake engine end-to-end (Gate A, ADR-004 ratification, Gate B, Gate C); dogfooding validates the engine, relieves authoring friction, and seeds the autocatalytic few-shot corpus the engine learns from."
+===END===


### PR DESCRIPTION
## What

The **first Agent-Readable Governance Record (AGR) authored via the Symbiotic Intake Engine** (RFC #53), recording the decision that this repository will dogfood its own AGR standard.

`HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611` — STRATEGIC / RATIFIED — placed at `.hestai/decisions/` per ADR-RFC-ARCH-004 (ratified, #69).

## How it was produced (live engine dogfood)

- The Gate C prose engine ran **end-to-end** (Stage 1 context assembler → Stage 2 OpenRouter compile → Stage 3 validate): the LLM call worked (~7k tokens), and Stage 3 **correctly rejected** the model's first output (it emitted a multi-envelope *facet card* instead of a single-envelope `DECISION_RECORD`, because the cold N=1 corpus has no on-disk AGR exemplar) → structured failure, **no write, no PR** (hallucination immunity confirmed).
- Per the RFC's N=1 protocol, this record is the **human-corrected** first AGR. It now seeds the few-shot corpus so subsequent prose calls have a correct exemplar to copy.
- Gate A (regex) + Gate B (octave-mcp real validator, `available:true`) both PASS on this record.

## Findings from the dogfood (filed separately)

1. **`run_linker` does not `git push` before `gh pr create`** → PR creation fails in real use (this PR was pushed manually). Real Stage-4 bug.
2. N=1 cold-corpus steers the model to the facet-card schema — this AGR seeds the corpus; a JIT-prompt nudge toward single-envelope DECISION_RECORD would also help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first Agent-Readable Governance Record (AGR) and adopts AGRs for this repo’s future decisions, generated via the Symbiotic Intake Engine. This dogfoods the standard and seeds the few-shot corpus.

- **New Features**
  - Added `DECISION_RECORD` `HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611` under `.hestai/decisions/`.
  - Added `.hestai/MANIFEST.md` mapping the token to the record path.
  - Record is STRATEGIC/RATIFIED; cites ADR-RFC-ARCH-004 and issue `#53`.
  - Produced end-to-end by the intake engine; validated by Gate A/B/C (`octave-mcp`).

<sup>Written for commit 9749ec345e56a7cd999d2506cefce33be786489a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

