### PR TITLE
feat(server): load .env at startup (enables prose mode via MCP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     # Credential storage for the AIClient adapter (issue #5), including
     # migration from legacy "hestai-mcp" service name.
     "keyring>=25.0.0",
+    # Load .env at server startup so Gate C prose mode can resolve
+    # OPENROUTER_API_KEY / HESTAI_AI_MODEL when launched by an MCP client.
+    # Mirrors the sibling MCP servers (hestai-mcp, debate-hall-mcp).
+    "python-dotenv>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/hestai_context_mcp/server.py
+++ b/src/hestai_context_mcp/server.py
@@ -11,7 +11,18 @@ Architecture:
 - Part of the three-service model (ADR-0353)
 - Communicates via stdio JSON-RPC transport
 - No governance/identity code (that lives in the vault)
+
+Startup .env loading:
+- ``main()`` calls :func:`_load_env` before ``mcp.run()`` so that Gate C prose
+  mode (``submit_governance(prose_input=...)``) can resolve ``OPENROUTER_API_KEY``
+  / ``HESTAI_AI_MODEL`` when the server is launched by an MCP client whose CWD is
+  unrelated to the repo. Mirrors the sibling MCP servers (hestai-mcp,
+  debate-hall-mcp).
+- ``override=False`` (PROD I2): explicit process env vars and the ai_config
+  keyring lookup always win over a ``.env`` file value. No secret value is logged.
 """
+
+from pathlib import Path
 
 from fastmcp import FastMCP
 
@@ -25,6 +36,46 @@ mcp = FastMCP(
     name="hestai-context-mcp",
 )
 
+
+def _project_root_env() -> Path:
+    """Return the expected repo-root ``.env`` path, anchored to this file.
+
+    ``server.py`` lives at ``src/hestai_context_mcp/server.py``; walking three
+    parents reaches the repo root regardless of the process CWD at spawn time.
+    """
+    return Path(__file__).resolve().parents[2] / ".env"
+
+
+def _load_env(dotenv_path: Path | None = None) -> bool:
+    """Load a ``.env`` file into ``os.environ`` at server startup.
+
+    Resolution order (first existing file wins):
+        1. ``dotenv_path`` if explicitly provided.
+        2. ``<repo-root>/.env`` (anchored to this module, CWD-independent).
+        3. ``<cwd>/.env`` fallback.
+
+    Uses ``override=False`` so explicit process env vars and the ai_config
+    keyring lookup are never clobbered by a file value (PROD I2). The import of
+    ``python-dotenv`` is kept import-safe; no secret value is ever logged.
+
+    Returns:
+        ``True`` if a ``.env`` file was found and loaded, ``False`` otherwise.
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:  # pragma: no cover - dotenv is a declared dependency
+        return False
+
+    candidates = (
+        [dotenv_path] if dotenv_path is not None else [_project_root_env(), Path.cwd() / ".env"]
+    )
+    for candidate in candidates:
+        if candidate is not None and candidate.exists():
+            load_dotenv(dotenv_path=candidate, override=False)
+            return True
+    return False
+
+
 # Register tools
 mcp.tool(clock_in)
 mcp.tool(clock_out)
@@ -35,6 +86,7 @@ mcp.tool(submit_governance)
 
 def main() -> None:
     """Run the MCP server over stdio transport."""
+    _load_env()
     mcp.run()
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,136 @@
+"""Tests for .env loading at server startup (Gate C prose mode support).
+
+The MCP server launches via ``python -m hestai_context_mcp`` and must load a
+``.env`` file so that ``submit_governance(prose_input=...)`` (Gate C) can resolve
+``OPENROUTER_API_KEY`` / ``HESTAI_AI_MODEL`` when started by an MCP client whose
+CWD is unrelated to the repo.
+
+Invariants under test:
+- A ``.env`` file is loaded into ``os.environ`` at startup.
+- ``override=False`` is honoured: a pre-set process env var is NEVER overwritten
+  (PROD I2 — never clobber an explicit secret / keyring value with a file value).
+- A missing ``.env`` does not crash; ``_load_env`` returns ``False``.
+- ``main()`` loads .env before ``mcp.run()`` (additive; PROD I5 unaffected).
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def clean_env():
+    """Snapshot and restore os.environ around each test."""
+    saved = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+class TestLoadEnv:
+    """Unit tests for the _load_env startup helper."""
+
+    def test_env_file_loaded_into_environ(self, tmp_path: Path, clean_env):
+        """A .env file at the given path is loaded into os.environ."""
+        from hestai_context_mcp.server import _load_env
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("HESTAI_TEST_LOADED=from_dotenv\n")
+        os.environ.pop("HESTAI_TEST_LOADED", None)
+
+        loaded = _load_env(dotenv_path=env_file)
+
+        assert loaded is True
+        assert os.environ.get("HESTAI_TEST_LOADED") == "from_dotenv"
+
+    def test_override_false_does_not_clobber_existing(self, tmp_path: Path, clean_env):
+        """A pre-set process env var must NOT be overwritten (override=False, PROD I2)."""
+        from hestai_context_mcp.server import _load_env
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENROUTER_API_KEY=value_from_file\n")
+        os.environ["OPENROUTER_API_KEY"] = "value_already_in_process"
+
+        _load_env(dotenv_path=env_file)
+
+        assert os.environ["OPENROUTER_API_KEY"] == "value_already_in_process"
+
+    def test_missing_env_file_does_not_crash(self, tmp_path: Path, clean_env):
+        """A missing .env path returns False and does not raise."""
+        from hestai_context_mcp.server import _load_env
+
+        missing = tmp_path / "does_not_exist.env"
+
+        assert _load_env(dotenv_path=missing) is False
+
+    def test_no_args_resolves_project_root_then_cwd(self, tmp_path: Path, clean_env):
+        """With no explicit path, the CWD/.env fallback is honoured when project-root has none."""
+        from hestai_context_mcp.server import _load_env
+
+        # Point project-root resolution at a dir with no .env so the CWD
+        # fallback is exercised deterministically.
+        empty_root = tmp_path / "no_repo_env"
+        empty_root.mkdir()
+        cwd_dir = tmp_path / "cwd"
+        cwd_dir.mkdir()
+        (cwd_dir / ".env").write_text("HESTAI_TEST_CWD=from_cwd\n")
+        os.environ.pop("HESTAI_TEST_CWD", None)
+
+        with (
+            patch("hestai_context_mcp.server._project_root_env", return_value=empty_root / ".env"),
+            patch("hestai_context_mcp.server.Path.cwd", return_value=cwd_dir),
+        ):
+            loaded = _load_env()
+
+        assert loaded is True
+        assert os.environ.get("HESTAI_TEST_CWD") == "from_cwd"
+
+    def test_project_root_env_preferred_over_cwd(self, tmp_path: Path, clean_env):
+        """Project-root .env takes precedence over CWD/.env when both exist."""
+        from hestai_context_mcp.server import _load_env
+
+        root_dir = tmp_path / "repo_root"
+        root_dir.mkdir()
+        (root_dir / ".env").write_text("HESTAI_TEST_SOURCE=from_root\n")
+        cwd_dir = tmp_path / "cwd"
+        cwd_dir.mkdir()
+        (cwd_dir / ".env").write_text("HESTAI_TEST_SOURCE=from_cwd\n")
+        os.environ.pop("HESTAI_TEST_SOURCE", None)
+
+        with (
+            patch("hestai_context_mcp.server._project_root_env", return_value=root_dir / ".env"),
+            patch("hestai_context_mcp.server.Path.cwd", return_value=cwd_dir),
+        ):
+            loaded = _load_env()
+
+        assert loaded is True
+        assert os.environ.get("HESTAI_TEST_SOURCE") == "from_root"
+
+
+class TestMainLoadsEnv:
+    """main() must load .env before starting the server transport."""
+
+    def test_main_calls_load_env_before_run(self):
+        """main() invokes _load_env, then mcp.run() (load happens before transport starts)."""
+        call_order = []
+
+        def record_load(*args, **kwargs):
+            call_order.append("load_env")
+            return False
+
+        def record_run(*args, **kwargs):
+            call_order.append("run")
+
+        with (
+            patch("hestai_context_mcp.server._load_env", side_effect=record_load),
+            patch("fastmcp.FastMCP.run", side_effect=record_run),
+        ):
+            from hestai_context_mcp.server import main
+
+            main()
+
+        assert call_order == ["load_env", "run"]

--- a/uv.lock
+++ b/uv.lock
@@ -545,6 +545,7 @@ dependencies = [
     { name = "httpx" },
     { name = "keyring" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 
 [package.optional-dependencies]
@@ -559,6 +560,9 @@ dev = [
 test = [
     { name = "octave-mcp" },
 ]
+validation = [
+    { name = "octave-mcp" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -568,13 +572,15 @@ requires-dist = [
     { name = "keyring", specifier = ">=25.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "octave-mcp", marker = "extra == 'test'", specifier = ">=1.15" },
+    { name = "octave-mcp", marker = "extra == 'validation'", specifier = ">=1.15" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.15.0" },
 ]
-provides-extras = ["dev", "test"]
+provides-extras = ["dev", "test", "validation"]
 
 [[package]]
 name = "httpcore"


### PR DESCRIPTION
## What

The MCP server runs `python -m hestai_context_mcp` and did **not** read `.env`, so `submit_governance(prose_input=...)` (Gate C) couldn't resolve `OPENROUTER_API_KEY` / `HESTAI_AI_MODEL` when launched by an MCP client. This makes the server load `.env` itself — mirroring the sibling servers (HestAI-MCP, debate-hall-mcp). Addresses part of #78.

## How

- `main()` calls `_load_env()` before `mcp.run()`.
- Resolution (first existing wins): explicit path (test seam) → `<repo-root>/.env` (anchored to the package, CWD-independent) → `<cwd>/.env`.
- `load_dotenv(..., override=False)` — explicit process env vars and the `ai_config` **keyring** value always win (PROD I2: a keyring secret is never clobbered by a file value).
- Import-safe (dotenv import guarded); no secret ever logged (PROD I2).
- `python-dotenv>=1.0.0` added to dependencies.

## Gates

1146 passed (6 new in `test_server.py`, incl. `test_override_false_does_not_clobber_existing`); coverage 92% (server.py 100%); ruff/black/mypy clean. Tool registration + behaviour unchanged; `get_context` purity (I5) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads `.env` at MCP server startup so Gate C prose mode can resolve required credentials when launched by an MCP client. Aligns with sibling servers and addresses part of Linear #78 (prose mode must read creds without relying on CWD).

- **New Features**
  - Call `_load_env()` in `main()` before starting the transport.
  - Resolution order: explicit path (test seam) → repo-root `.env` → CWD `.env`.
  - `override=False` so existing env or keyring values win; no secrets logged.
  - Repo-root path is anchored to the package (CWD-independent).

- **Dependencies**
  - Add `python-dotenv>=1.0.0`.

<sup>Written for commit 9f6719bbfddfa1f268b80a4773089c17a43985c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

