### PR TITLE
feat(governance): scoped semantic AGR reviewer at the analysis tier (#77 core)

### DIFF
--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -55,6 +55,17 @@ KEYRING_SERVICE: str = "hestai-context-mcp"
 DEFAULT_PROVIDER: str = "openrouter"
 DEFAULT_MODEL: str = "google/gemini-2.0-flash-lite"
 
+# Tier -> env-var name for that tier's model. The ``default`` tier reads the
+# base ``HESTAI_AI_MODEL``; richer tiers read their own var and fall back to
+# the base var, then ``DEFAULT_MODEL`` (see :func:`resolve_model`). Tiers are
+# orthogonal to provider: a tier only changes *which model identifier* is sent
+# to whatever provider is configured (PROD::I3 — no vendor coupling).
+_TIER_ENV_VARS: dict[str, str] = {
+    "default": "HESTAI_AI_MODEL",
+    "analysis": "HESTAI_AI_MODEL_ANALYSIS",
+    "critical": "HESTAI_AI_MODEL_CRITICAL",
+}
+
 # Provider → base URL. Constant (NOT env-configurable) so a rogue env
 # var cannot redirect traffic to an attacker host.
 _PROVIDER_BASE_URLS: dict[str, str] = {
@@ -74,8 +85,36 @@ def resolve_provider() -> str:
     return os.environ.get("HESTAI_AI_PROVIDER", DEFAULT_PROVIDER)
 
 
-def resolve_model() -> str:
-    """Return the configured model identifier."""
+def resolve_model(tier: str = "default") -> str:
+    """Return the configured model identifier for ``tier``.
+
+    Tiers (issue #77):
+        * ``"default"``  -> ``HESTAI_AI_MODEL``
+        * ``"analysis"`` -> ``HESTAI_AI_MODEL_ANALYSIS``
+        * ``"critical"`` -> ``HESTAI_AI_MODEL_CRITICAL``
+
+    Resolution for a tier is a fallback chain: the tier's own env var, then
+    the base ``HESTAI_AI_MODEL``, then :data:`DEFAULT_MODEL`. For the
+    ``"default"`` tier this collapses to the pre-#77 behaviour exactly
+    (``HESTAI_AI_MODEL`` else :data:`DEFAULT_MODEL`), so the zero-arg call
+    remains back-compatible.
+
+    Args:
+        tier: One of ``"default"``, ``"analysis"``, ``"critical"``.
+
+    Raises:
+        ValueError: if ``tier`` is not a recognised tier.
+    """
+    try:
+        tier_var = _TIER_ENV_VARS[tier]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown model tier: {tier!r} (expected one of {sorted(_TIER_ENV_VARS)})"
+        ) from exc
+    # Tier var first; fall back to the base model var, then the hard default.
+    tier_value = os.environ.get(tier_var)
+    if tier_value:
+        return tier_value
     return os.environ.get("HESTAI_AI_MODEL", DEFAULT_MODEL)
 
 

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -171,13 +171,20 @@ class OpenAICompatAIClient:
         return content
 
 
-def build_default_ai_client() -> AIClient | None:
+def build_default_ai_client(*, tier: str = "default") -> AIClient | None:
     """Build the default :class:`AIClient` from configuration.
 
     Reads provider, model, and API key via :mod:`ai_config`. Returns
     ``None`` when no credential is available — callers should treat
     ``None`` as "no AI synthesis possible; use the deterministic
     fallback".
+
+    Args:
+        tier: Model tier to resolve (issue #77). One of ``"default"``,
+            ``"analysis"``, ``"critical"``. The default keeps the
+            pre-#77 behaviour (the synthesis tier). Tier only selects the
+            *model identifier*; provider and credential resolution are
+            unchanged.
 
     This is the *single* env-reading site for AI client construction.
     Any other code reading ``HESTAI_AI_*`` or ``*_API_KEY`` is a
@@ -193,7 +200,7 @@ def build_default_ai_client() -> AIClient | None:
         # Misconfigured provider identifier — fail closed.
         logger.warning("Unknown HESTAI_AI_PROVIDER %r; cannot build AIClient", provider)
         return None
-    model = ai_config.resolve_model()
+    model = ai_config.resolve_model(tier)
     client = OpenAICompatAIClient(api_key=api_key, base_url=base_url, model=model)
     # Construction-time guard (CRS gemini follow-up
     # ``crs_review_pr9_followup_ceeaa71``): ``runtime_checkable`` Protocol

--- a/src/hestai_context_mcp/core/governance_reviewer.py
+++ b/src/hestai_context_mcp/core/governance_reviewer.py
@@ -1,0 +1,398 @@
+"""Scoped SEMANTIC governance reviewer over the AIClient port (issue #77).
+
+This is an *application-layer* capability — NOT a new port. It consumes the
+existing :class:`~hestai_context_mcp.ports.ai_client.AIClient` Protocol at the
+**analysis tier**, exactly mirroring the call pattern in
+:mod:`hestai_context_mcp.core.intake_compiler` /
+:mod:`hestai_context_mcp.core.synthesis`::
+
+    client = build_default_ai_client(tier="analysis")
+    async with client as c:
+        raw = await c.complete_text(CompletionRequest(...))
+
+**Scope (the AGR decision HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611).**
+The reviewer assesses *only* the semantic surface of a governance record:
+
+    * precedence / coherence,
+    * contradiction,
+    * scope,
+    * concept-validity.
+
+It is *explicitly instructed NOT to check schema or syntax* — the deterministic
+validators (Gate A regex rails) and octave-mcp (Gate B) own that. There is no
+facet-card and no schema commentary. The human retains the merge decision; this
+verdict is advisory/assistive.
+
+Provider, model, retry, and credential resolution all live *below* the port (in
+``adapters/ai_config`` + the adapter). No vendor/model literal appears in this
+module (PROD::I3; asserted by ``tests/unit/test_source_invariants.py``).
+
+Cost caps (mirroring intake_compiler; operator-ratified, env-overridable):
+    * ``HESTAI_REVIEW_MAX_OUTPUT_TOKENS`` — per-call output ceiling
+      (default 2000). Passed as ``CompletionRequest.max_tokens``.
+    * ``HESTAI_REVIEW_MAX_COST_USD`` — abort *before* the call if the projected
+      cost (input + max-output tokens, priced via
+      ``HESTAI_REVIEW_USD_PER_1K_TOKENS``) exceeds this cap (default 0.50).
+
+A cap breach or any backend failure is surfaced as a structured ``BLOCKED``
+result (PROD::I4) — never a fabricated APPROVED verdict (structural integrity
+over velocity).
+
+DIP boundary: this ``core/`` module imports only from ``ports`` at module load;
+the adapter factory and config are reached via lazy imports inside functions
+(composition-root pattern, mirroring ``core/intake_compiler``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Literal, TypedDict
+
+from hestai_context_mcp.ports.ai_client import (
+    AIClient,
+    AIClientAuthError,
+    AIClientError,
+    AIClientTransportError,
+    CompletionRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Verdict",
+    "ReviewMetrics",
+    "ReviewResult",
+    "review_governance",
+]
+
+Verdict = Literal["APPROVED", "CONCERNS", "BLOCKED"]
+
+# The analysis tier is the default for this reviewer (issue #77): a stronger,
+# balanced model than the synthesis-tier default. Tier resolution itself lives
+# below the port in ``ai_config`` — this is only the *tier name*, not a model.
+_DEFAULT_TIER = "analysis"
+
+# Defaults for the operator-ratified cost caps. All env-overridable. The output
+# ceiling is smaller than intake_compiler's: a review verdict is short prose +
+# a concern list, not a full AGR body.
+_DEFAULT_MAX_OUTPUT_TOKENS = 2000
+_DEFAULT_MAX_COST_USD = 0.50
+# Default blended price used only for the *pre-call* cost projection. The
+# guard's purpose is to abort runaway requests, not to bill; real billing is
+# provider-side. Override via HESTAI_REVIEW_USD_PER_1K_TOKENS for pricier
+# (analysis/critical) models.
+_DEFAULT_USD_PER_1K_TOKENS = 0.01
+
+# Rough char->token ratio for the pre-call projection (≈4 chars/token).
+_CHARS_PER_TOKEN = 4
+# Request timeout for the review call (seconds).
+_REQUEST_TIMEOUT_SECONDS = 60
+
+
+class ReviewMetrics(TypedDict):
+    """Per-call metrics (PROD::I4). ``cost`` is the projected USD cost."""
+
+    tokens: int
+    cost: float
+    model: str
+
+
+class ReviewResult(TypedDict):
+    """Structured result of a scoped semantic review (PROD::I4).
+
+    Keys:
+        verdict:    ``"APPROVED"`` | ``"CONCERNS"`` | ``"BLOCKED"``.
+        assessment: One-paragraph semantic assessment (never schema).
+        concerns:   Zero or more concrete concern strings.
+        metrics:    ``{tokens, cost, model}``.
+    """
+
+    verdict: Verdict
+    assessment: str
+    concerns: list[str]
+    metrics: ReviewMetrics
+
+
+# --- Prompt assembly (SEMANTIC-scoped; NEVER schema) ----------------------
+
+# The system prompt is a module constant here (unlike intake_context's JIT
+# prompt) because the review rubric is fixed: it does not depend on live repo
+# corpus. It explicitly excludes schema/syntax checking and names the four
+# semantic axes from the AGR decision. NO vendor/model literal appears.
+_REVIEW_SYSTEM_PROMPT = (
+    "You are a scoped SEMANTIC reviewer for a governance decision record.\n"
+    "\n"
+    "Assess ONLY the following semantic axes:\n"
+    "  1. PRECEDENCE / COHERENCE — does this record sit correctly relative to "
+    "existing decisions; is its supersession/precedence coherent?\n"
+    "  2. CONTRADICTION — does it contradict a ratified or still-active "
+    "decision?\n"
+    "  3. SCOPE — is the decision within an appropriate scope; does it overlap "
+    "or collide with another record's scope?\n"
+    "  4. CONCEPT-VALIDITY — is this the right concept; is the idea sound and "
+    "well-formed as a decision?\n"
+    "\n"
+    "CRITICAL EXCLUSION: Do NOT check schema, syntax, field names, OCTAVE "
+    "structure, or formatting. The deterministic validators own schema "
+    "correctness; you must NEVER comment on schema or syntax. Do not produce a "
+    "facet card. Your job is semantic judgement only.\n"
+    "\n"
+    "Respond in this exact line-oriented form:\n"
+    "VERDICT::<APPROVED|CONCERNS|BLOCKED>\n"
+    "ASSESSMENT::<one paragraph of semantic assessment>\n"
+    "CONCERNS::[<concern>; <concern>; ...]   (empty list [] if none)\n"
+    "\n"
+    "Use APPROVED when there is no semantic problem, CONCERNS for non-blocking "
+    "semantic doubts a human should weigh, and BLOCKED for a clear semantic "
+    "contradiction or precedence violation. You inform the human; you do not "
+    "merge."
+)
+
+
+def build_default_ai_client(*, tier: str = _DEFAULT_TIER) -> AIClient | None:
+    """Return the tier-aware default :class:`AIClient`, or ``None``.
+
+    Composition-root seam (lazy import of the adapter) so this ``core`` module
+    depends only on ``ports`` at module-load time. Tests monkeypatch this
+    symbol on the module to inject stubs; it is resolved via the module
+    attribute on each call, so patches are honoured.
+    """
+    from hestai_context_mcp.adapters.openai_compat_ai_client import (
+        build_default_ai_client as _factory,
+    )
+
+    return _factory(tier=tier)
+
+
+def _resolve_model_name(tier: str) -> str:
+    """Return the configured model identifier for ``tier`` (value, not literal).
+
+    Lazy import keeps the adapter/config dependency out of module-load scope
+    (DIP) and keeps any provider/model *literal* out of this file's source
+    (PROD::I3) — the model name is a runtime value resolved below the port.
+    """
+    from hestai_context_mcp.adapters import ai_config
+
+    return ai_config.resolve_model(tier)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %d", name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    """Ceiling integer division."""
+    return (numerator + denominator - 1) // denominator
+
+
+def _estimate_input_tokens(octave_content: str) -> int:
+    """Estimate input tokens from the system prompt + the record under review."""
+    input_chars = len(_REVIEW_SYSTEM_PROMPT) + len(octave_content)
+    return _ceil_div(input_chars, _CHARS_PER_TOKEN)
+
+
+def _blocked(
+    model: str,
+    assessment: str,
+    concerns: list[str],
+    *,
+    tokens: int = 0,
+    cost: float = 0.0,
+) -> ReviewResult:
+    """Build a fail-soft BLOCKED result. NEVER fabricates an APPROVED verdict."""
+    return {
+        "verdict": "BLOCKED",
+        "assessment": assessment,
+        "concerns": concerns,
+        "metrics": {"tokens": tokens, "cost": cost, "model": model},
+    }
+
+
+_VERDICT_RE = re.compile(r"^\s*VERDICT::\s*(APPROVED|CONCERNS|BLOCKED)\b", re.MULTILINE)
+_ASSESSMENT_RE = re.compile(r"^\s*ASSESSMENT::\s*(.+?)\s*$", re.MULTILINE)
+_CONCERNS_RE = re.compile(r"^\s*CONCERNS::\s*\[(.*)\]\s*$", re.MULTILINE | re.DOTALL)
+
+
+def _parse_concerns(raw_block: str) -> list[str]:
+    """Split a ``[a; b; c]`` concern block into a clean list of strings."""
+    parts = re.split(r"[;\n]+", raw_block)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _parse_review(raw: str, model: str, tokens: int, cost: float) -> ReviewResult:
+    """Parse the model's line-oriented response into a structured result.
+
+    An unparseable verdict degrades to ``CONCERNS`` (never silently
+    ``APPROVED``) so a malformed response routes to human attention rather
+    than rubber-stamping a record.
+    """
+    verdict_match = _VERDICT_RE.search(raw)
+    assessment_match = _ASSESSMENT_RE.search(raw)
+    concerns_match = _CONCERNS_RE.search(raw)
+
+    concerns = _parse_concerns(concerns_match.group(1)) if concerns_match else []
+    assessment = (
+        assessment_match.group(1).strip()
+        if assessment_match
+        else raw.strip()[:500] or "No assessment text returned."
+    )
+
+    if verdict_match is None:
+        # No recognisable verdict -> do not approve; route to a human.
+        concerns = concerns or ["Reviewer response did not contain a parseable verdict."]
+        return {
+            "verdict": "CONCERNS",
+            "assessment": assessment,
+            "concerns": concerns,
+            "metrics": {"tokens": tokens, "cost": cost, "model": model},
+        }
+
+    verdict: Verdict = verdict_match.group(1)  # type: ignore[assignment]
+    return {
+        "verdict": verdict,
+        "assessment": assessment,
+        "concerns": concerns,
+        "metrics": {"tokens": tokens, "cost": cost, "model": model},
+    }
+
+
+async def _run_completion(
+    client: AIClient, system_prompt: str, user_prompt: str, max_tokens: int
+) -> str:
+    async with client as c:
+        return await c.complete_text(
+            CompletionRequest(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                max_tokens=max_tokens,
+                timeout_seconds=_REQUEST_TIMEOUT_SECONDS,
+            )
+        )
+
+
+async def review_governance(
+    octave_content: str,
+    *,
+    tier: str = _DEFAULT_TIER,
+    max_output_tokens: int | None = None,
+    max_cost_usd: float | None = None,
+) -> ReviewResult:
+    """Run a scoped SEMANTIC review of a governance record over the AIClient port.
+
+    Args:
+        octave_content: The governance record (AGR) text to review. Reviewed
+            for semantics only — precedence, contradiction, scope, concept —
+            NEVER for schema.
+        tier: Model tier (default ``"analysis"``). Forwarded to the tier-aware
+            client factory and to model-name resolution.
+        max_output_tokens: Per-call output ceiling. Defaults to
+            ``HESTAI_REVIEW_MAX_OUTPUT_TOKENS`` then 2000.
+        max_cost_usd: Abort threshold for projected cost. Defaults to
+            ``HESTAI_REVIEW_MAX_COST_USD`` then 0.50.
+
+    Returns:
+        :class:`ReviewResult`. A semantic verdict on success; a structured
+        ``BLOCKED`` result on no-client / cost-cap / auth / transport / empty
+        response — never a fabricated ``APPROVED``.
+    """
+    out_cap = (
+        max_output_tokens
+        if max_output_tokens is not None
+        else _env_int("HESTAI_REVIEW_MAX_OUTPUT_TOKENS", _DEFAULT_MAX_OUTPUT_TOKENS)
+    )
+    cost_cap = (
+        max_cost_usd
+        if max_cost_usd is not None
+        else _env_float("HESTAI_REVIEW_MAX_COST_USD", _DEFAULT_MAX_COST_USD)
+    )
+    price_per_1k = _env_float("HESTAI_REVIEW_USD_PER_1K_TOKENS", _DEFAULT_USD_PER_1K_TOKENS)
+
+    model = _resolve_model_name(tier)
+
+    # --- Cost cap: project BEFORE the call; abort on breach (no fabrication). ---
+    projected_tokens = _estimate_input_tokens(octave_content) + out_cap
+    projected_cost = (projected_tokens / 1000.0) * price_per_1k
+    if projected_cost > cost_cap:
+        return _blocked(
+            model,
+            (
+                f"Aborted before backend call: projected cost ${projected_cost:.4f} "
+                f"exceeds cap ${cost_cap:.4f}. No review produced."
+            ),
+            [
+                (
+                    f"Projected cost ${projected_cost:.4f} over cap ${cost_cap:.4f} "
+                    f"({projected_tokens} tokens at ${price_per_1k:.4f}/1k)."
+                )
+            ],
+            tokens=projected_tokens,
+        )
+
+    client = build_default_ai_client(tier=tier)
+    if client is None:
+        return _blocked(
+            model,
+            "No AIClient available (no credential configured); cannot run semantic review.",
+            ["No AI client/credential available for the semantic review."],
+        )
+
+    user_prompt = f"BEGIN_RECORD\n{octave_content}\nEND_RECORD"
+    try:
+        raw = await _run_completion(client, _REVIEW_SYSTEM_PROMPT, user_prompt, out_cap)
+    except AIClientAuthError as exc:
+        return _blocked(
+            model,
+            f"AIClient auth error (permanent, no retry): {exc}",
+            [f"auth error: {exc}"],
+        )
+    except AIClientTransportError as exc:
+        return _blocked(
+            model,
+            f"AIClient transport error (call failed): {exc}",
+            [f"transport error: {exc}"],
+        )
+    except AIClientError as exc:
+        return _blocked(
+            model,
+            f"AIClient error: {exc.__class__.__name__}: {exc}",
+            [f"{exc.__class__.__name__}: {exc}"],
+        )
+
+    if not isinstance(raw, str) or not raw.strip():
+        return _blocked(
+            model,
+            "Backend returned an empty response; no semantic verdict produced.",
+            ["Empty reviewer response."],
+        )
+
+    # Reported metric = input estimate + ACTUAL output (NOT the output ceiling).
+    actual_output_tokens = _ceil_div(len(raw), _CHARS_PER_TOKEN)
+    actual_tokens = _estimate_input_tokens(octave_content) + actual_output_tokens
+    cost = (actual_tokens / 1000.0) * price_per_1k
+    logger.info(
+        "governance review ok: model=%s actual_tokens=%d est_cost=$%.4f",
+        model,
+        actual_tokens,
+        cost,
+    )
+    return _parse_review(raw, model, actual_tokens, cost)

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -66,6 +66,8 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "HESTAI_AI_PROVIDER",
         "HESTAI_AI_MODEL",
+        "HESTAI_AI_MODEL_ANALYSIS",
+        "HESTAI_AI_MODEL_CRITICAL",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
     ):
@@ -126,6 +128,76 @@ class TestResolveModel:
 
         monkeypatch.setenv("HESTAI_AI_MODEL", "some/other-model")
         assert resolve_model() == "some/other-model"
+
+
+class TestResolveModelTierAware:
+    """Issue #77: ``resolve_model(tier)`` maps a tier to its env var.
+
+    Tiers and their env vars:
+        * ``default``  -> ``HESTAI_AI_MODEL``
+        * ``analysis`` -> ``HESTAI_AI_MODEL_ANALYSIS``
+        * ``critical`` -> ``HESTAI_AI_MODEL_CRITICAL``
+
+    Fallback chain for the non-default tiers when their specific var is
+    unset: tier var -> ``HESTAI_AI_MODEL`` -> ``DEFAULT_MODEL``. The
+    zero-arg call (``resolve_model()``) keeps its pre-#77 default-tier
+    behaviour exactly (back-compatibility).
+    """
+
+    def test_default_tier_is_backcompat_zero_arg(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import DEFAULT_MODEL, resolve_model
+
+        # No arg and tier="default" must agree, and both equal the legacy default.
+        assert resolve_model() == DEFAULT_MODEL
+        assert resolve_model("default") == DEFAULT_MODEL
+
+    def test_default_tier_reads_hestai_ai_model(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "base/model")
+        assert resolve_model() == "base/model"
+        assert resolve_model("default") == "base/model"
+
+    def test_analysis_tier_reads_analysis_var(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "base/model")
+        monkeypatch.setenv("HESTAI_AI_MODEL_ANALYSIS", "analysis/model")
+        assert resolve_model("analysis") == "analysis/model"
+        # The default tier is unaffected by the analysis var.
+        assert resolve_model("default") == "base/model"
+
+    def test_critical_tier_reads_critical_var(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL_CRITICAL", "critical/model")
+        assert resolve_model("critical") == "critical/model"
+
+    def test_analysis_falls_back_to_hestai_ai_model_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch, clean_env
+    ):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        # Analysis-specific var unset -> falls back to HESTAI_AI_MODEL.
+        monkeypatch.setenv("HESTAI_AI_MODEL", "base/model")
+        assert resolve_model("analysis") == "base/model"
+
+    def test_analysis_falls_back_to_default_model_when_all_unset(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import DEFAULT_MODEL, resolve_model
+
+        # Neither the analysis var nor HESTAI_AI_MODEL set -> DEFAULT_MODEL.
+        assert resolve_model("analysis") == DEFAULT_MODEL
+
+    def test_critical_falls_back_to_default_model_when_all_unset(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import DEFAULT_MODEL, resolve_model
+
+        assert resolve_model("critical") == DEFAULT_MODEL
+
+    def test_unknown_tier_raises_value_error(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        with pytest.raises(ValueError):
+            resolve_model("nonsense-tier")
 
 
 class TestProviderBaseUrl:

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -427,3 +427,60 @@ class TestBuildDefaultFactory:
         monkeypatch.setattr(adapter_mod, "OpenAICompatAIClient", _BrokenClient)
         with pytest.raises(TypeError, match="async def"):
             adapter_mod.build_default_ai_client()
+
+
+class TestBuildDefaultFactoryTierAware:
+    """Issue #77: ``build_default_ai_client(tier=...)`` selects the tier model.
+
+    The factory remains the single env-reading site; passing ``tier`` makes
+    it resolve the model via ``ai_config.resolve_model(tier)``. The default
+    (no ``tier`` arg) stays back-compatible with the pre-#77 behaviour.
+    """
+
+    @staticmethod
+    def _no_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+        import hestai_context_mcp.adapters.ai_config as cfg
+
+        class _NoKR:
+            def get_password(self, *_a, **_kw):
+                return None
+
+            def set_password(self, *_a, **_kw):
+                return None
+
+            def delete_password(self, *_a, **_kw):
+                return None
+
+        monkeypatch.setattr(cfg, "keyring", _NoKR(), raising=True)
+
+    def test_analysis_tier_builds_client_with_analysis_model(self, monkeypatch: pytest.MonkeyPatch):
+        self._no_keyring(monkeypatch)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "ENV_KEY")
+        monkeypatch.setenv("HESTAI_AI_MODEL", "base/model")
+        monkeypatch.setenv("HESTAI_AI_MODEL_ANALYSIS", "analysis/model")
+
+        from hestai_context_mcp.adapters.openai_compat_ai_client import (
+            OpenAICompatAIClient,
+            build_default_ai_client,
+        )
+
+        client = build_default_ai_client(tier="analysis")
+        assert isinstance(client, OpenAICompatAIClient)
+        # The constructed adapter carries the analysis-tier model.
+        assert client._model == "analysis/model"
+
+    def test_default_tier_backcompat(self, monkeypatch: pytest.MonkeyPatch):
+        self._no_keyring(monkeypatch)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "ENV_KEY")
+        monkeypatch.setenv("HESTAI_AI_MODEL", "base/model")
+        monkeypatch.setenv("HESTAI_AI_MODEL_ANALYSIS", "analysis/model")
+
+        from hestai_context_mcp.adapters.openai_compat_ai_client import (
+            OpenAICompatAIClient,
+            build_default_ai_client,
+        )
+
+        # No tier arg -> default tier -> HESTAI_AI_MODEL (not the analysis var).
+        client = build_default_ai_client()
+        assert isinstance(client, OpenAICompatAIClient)
+        assert client._model == "base/model"

--- a/tests/unit/core/test_governance_reviewer.py
+++ b/tests/unit/core/test_governance_reviewer.py
@@ -1,0 +1,308 @@
+"""Tests for the scoped SEMANTIC governance reviewer (issue #77).
+
+``review_governance`` is an application-layer capability that consumes the
+existing ``AIClient`` port (NO new port) at the **analysis tier**. It mirrors
+``core/intake_compiler.py``: ``build_default_ai_client(tier=...)`` then
+``async with client as c: complete_text(...)``, with the same cost-cap +
+fail-soft + structured-result discipline.
+
+Scope (the AGR decision HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611):
+the reviewer assesses **precedence/coherence, contradiction, scope, and
+concept-validity ONLY** — it is explicitly told NOT to check schema/syntax
+(the deterministic validators + octave-mcp own that). It returns a structured
+``ReviewResult`` (PROD I4) of the shape
+``{"verdict", "assessment", "concerns", "metrics": {tokens, cost, model}}``.
+
+Provider-agnostic (PROD I3): no vendor literal in source (asserted in
+``tests/unit/test_source_invariants.py``). Never fabricates a verdict on an
+auth/transport failure (structural integrity over velocity).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import hestai_context_mcp.core.governance_reviewer as mod
+from hestai_context_mcp.core.governance_reviewer import review_governance
+from hestai_context_mcp.ports.ai_client import (
+    AIClientAuthError,
+    AIClientError,
+    AIClientProtocolError,
+    AIClientTransportError,
+    CompletionRequest,
+)
+
+_SAMPLE_AGR = (
+    "===DECISION_RECORD===\n"
+    "META:\n"
+    "  TYPE::DECISION_RECORD\n"
+    '  ID::"HO-EXAMPLE-20260611"\n'
+    "===END===\n"
+)
+
+# A well-formed APPROVED verdict the stub can return (the reviewer parses it).
+_APPROVED_RESPONSE = (
+    "VERDICT::APPROVED\n"
+    "ASSESSMENT::No precedence or contradiction issues; scope is coherent.\n"
+    "CONCERNS::[]\n"
+)
+_CONCERNS_RESPONSE = (
+    "VERDICT::CONCERNS\n"
+    "ASSESSMENT::Possible scope overlap with an existing record.\n"
+    "CONCERNS::[overlaps prior token on routing; concept name ambiguous]\n"
+)
+_BLOCKED_RESPONSE = (
+    "VERDICT::BLOCKED\n"
+    "ASSESSMENT::Directly contradicts a ratified precedence rule.\n"
+    "CONCERNS::[contradicts HO-PRIOR-20260101 precedence]\n"
+)
+
+
+class _StubClient:
+    """Async-context AIClient stub capturing the request it received."""
+
+    def __init__(self, *, text: str = "", raises: BaseException | None = None) -> None:
+        self._text = text
+        self._raises = raises
+        self.request: CompletionRequest | None = None
+        self.entered = False
+        self.closed = False
+
+    async def __aenter__(self) -> _StubClient:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.closed = True
+
+    async def complete_text(self, request: CompletionRequest) -> str:
+        self.request = request
+        if self._raises is not None:
+            raise self._raises
+        return self._text
+
+
+@pytest.fixture
+def patch_client(monkeypatch: pytest.MonkeyPatch):
+    """Patch the module-level tier-aware AIClient factory to return a stub.
+
+    The reviewer must resolve its client via a module attribute on each call
+    (composition-root seam) so this monkeypatch is honoured.
+    """
+
+    def _install(client_or_none: Any) -> Any:
+        captured: dict[str, Any] = {}
+
+        def _factory(*, tier: str = "default") -> Any:
+            captured["tier"] = tier
+            return client_or_none
+
+        monkeypatch.setattr(mod, "build_default_ai_client", _factory, raising=True)
+        return captured
+
+    return _install
+
+
+class TestReviewSuccess:
+    async def test_returns_structured_verdict_and_metrics(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "APPROVED"
+        assert isinstance(result["assessment"], str) and result["assessment"]
+        assert isinstance(result["concerns"], list)
+        metrics = result["metrics"]
+        assert set(metrics) == {"tokens", "cost", "model"}
+        assert isinstance(metrics["tokens"], int) and metrics["tokens"] > 0
+        assert isinstance(metrics["cost"], float) and metrics["cost"] >= 0.0
+        assert isinstance(metrics["model"], str) and metrics["model"]
+
+    async def test_concerns_verdict_carries_concern_list(self, patch_client) -> None:
+        stub = _StubClient(text=_CONCERNS_RESPONSE)
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "CONCERNS"
+        assert len(result["concerns"]) >= 1
+
+    async def test_blocked_verdict_parsed(self, patch_client) -> None:
+        stub = _StubClient(text=_BLOCKED_RESPONSE)
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["concerns"]
+
+    async def test_octave_content_is_in_user_prompt(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        await review_governance(_SAMPLE_AGR)
+        assert stub.request is not None
+        assert "HO-EXAMPLE-20260611" in stub.request.user_prompt
+
+
+class TestTierSelection:
+    async def test_defaults_to_analysis_tier(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        captured = patch_client(stub)
+        await review_governance(_SAMPLE_AGR)
+        assert captured["tier"] == "analysis"
+
+    async def test_tier_is_overridable(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        captured = patch_client(stub)
+        await review_governance(_SAMPLE_AGR, tier="critical")
+        assert captured["tier"] == "critical"
+
+
+class TestPromptIsSemanticScoped:
+    """The prompt must be SEMANTIC-scoped, NOT schema-checking.
+
+    The deterministic validators own schema; the reviewer must be told to
+    assess precedence/contradiction/scope/concept-validity and explicitly
+    NOT to check schema or syntax.
+    """
+
+    async def test_prompt_names_semantic_axes(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        await review_governance(_SAMPLE_AGR)
+        assert stub.request is not None
+        prompt = stub.request.system_prompt.lower()
+        assert "precedence" in prompt
+        assert "contradict" in prompt  # contradiction / contradict
+        assert "scope" in prompt
+        assert "concept" in prompt
+
+    async def test_prompt_explicitly_excludes_schema_checking(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        await review_governance(_SAMPLE_AGR)
+        assert stub.request is not None
+        prompt = stub.request.system_prompt.lower()
+        # Must mention schema/syntax in a NEGATIVE instruction (do not check).
+        assert "schema" in prompt
+        assert "not" in prompt
+        # A crude proximity check: the word "schema" appears alongside a
+        # negation cue so the instruction is exclusionary, not additive.
+        assert ("do not" in prompt) or ("never" in prompt) or ("not check" in prompt)
+
+    async def test_prompt_does_not_request_a_facet_card(self, patch_client) -> None:
+        # The reviewer must not ASK for a facet card. If "facet" appears at all
+        # it must be in an exclusionary instruction (do not / no facet card).
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        await review_governance(_SAMPLE_AGR)
+        assert stub.request is not None
+        prompt = stub.request.system_prompt.lower()
+        if "facet" in prompt:
+            assert ("do not produce a facet" in prompt) or ("no facet" in prompt)
+
+
+class TestNoClientAvailable:
+    async def test_returns_structured_failure_when_no_client(self, patch_client) -> None:
+        patch_client(None)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["concerns"]
+        assert result["metrics"]["tokens"] == 0
+
+
+class TestFailSoftErrorPaths:
+    """Auth/transport/protocol failures NEVER fabricate a verdict."""
+
+    async def test_auth_error_is_blocked_not_approved(self, patch_client) -> None:
+        stub = _StubClient(raises=AIClientAuthError("no key"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert "auth" in result["assessment"].lower() or any(
+            "auth" in c.lower() for c in result["concerns"]
+        )
+
+    async def test_transport_error_surfaced_not_fabricated(self, patch_client) -> None:
+        stub = _StubClient(raises=AIClientTransportError("timeout"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        # No fabricated APPROVED verdict from a transport failure.
+        assert result["verdict"] != "APPROVED"
+
+    async def test_protocol_error_surfaced(self, patch_client) -> None:
+        stub = _StubClient(raises=AIClientProtocolError("bad body"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+
+    async def test_generic_ai_client_error_surfaced(self, patch_client) -> None:
+        # The catch-all AIClientError branch (not auth/transport) also degrades
+        # to a structured BLOCKED result, never a fabricated verdict.
+        stub = _StubClient(raises=AIClientError("weird"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["concerns"]
+
+    async def test_empty_response_is_not_approved(self, patch_client) -> None:
+        stub = _StubClient(text="   ")
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+
+
+class TestCostCap:
+    async def test_cost_cap_aborts_before_call(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        # A microscopic cost cap forces a pre-call abort.
+        result = await review_governance(_SAMPLE_AGR, max_cost_usd=0.0)
+        assert result["verdict"] == "BLOCKED"
+        # The backend was never entered (abort before the call).
+        assert stub.entered is False
+        assert any("cost" in c.lower() for c in result["concerns"]) or (
+            "cost" in result["assessment"].lower()
+        )
+
+    async def test_output_cap_passed_to_request(self, patch_client) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        await review_governance(_SAMPLE_AGR, max_output_tokens=123)
+        assert stub.request is not None
+        assert stub.request.max_tokens == 123
+
+    async def test_env_caps_used_when_args_absent(
+        self, monkeypatch: pytest.MonkeyPatch, patch_client
+    ) -> None:
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        monkeypatch.setenv("HESTAI_REVIEW_MAX_OUTPUT_TOKENS", "55")
+        await review_governance(_SAMPLE_AGR)
+        assert stub.request is not None
+        assert stub.request.max_tokens == 55
+
+    async def test_invalid_env_caps_fall_back_to_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, patch_client
+    ) -> None:
+        # Malformed env caps must not crash; they fall back to the defaults
+        # (warning logged). The call still succeeds.
+        stub = _StubClient(text=_APPROVED_RESPONSE)
+        patch_client(stub)
+        monkeypatch.setenv("HESTAI_REVIEW_MAX_OUTPUT_TOKENS", "not-an-int")
+        monkeypatch.setenv("HESTAI_REVIEW_MAX_COST_USD", "not-a-float")
+        monkeypatch.setenv("HESTAI_REVIEW_USD_PER_1K_TOKENS", "nan-nan")
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "APPROVED"
+        assert stub.request is not None
+        # Fell back to the default 2000-token output ceiling.
+        assert stub.request.max_tokens == 2000
+
+
+class TestResultShape:
+    async def test_unparseable_verdict_falls_back_to_concerns(self, patch_client) -> None:
+        # A response with prose but no recognisable VERDICT:: line must not be
+        # silently treated as APPROVED — degrade to CONCERNS for human review.
+        stub = _StubClient(text="The record looks broadly fine to me.")
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] in {"CONCERNS", "BLOCKED"}
+        assert result["verdict"] != "APPROVED"

--- a/tests/unit/test_source_invariants.py
+++ b/tests/unit/test_source_invariants.py
@@ -29,6 +29,10 @@ _PORTS_ROOT = _SRC_ROOT / "ports"
 _GATE_C_PROVIDER_AGNOSTIC_FILES: tuple[Path, ...] = (
     _SRC_ROOT / "core" / "intake_compiler.py",
     _SRC_ROOT / "tools" / "governance" / "intake_context.py",
+    # Issue #77: the scoped SEMANTIC governance reviewer consumes the AIClient
+    # port at the analysis tier; like the other Gate C app modules it must
+    # never name a provider/model in source (PROD::I3).
+    _SRC_ROOT / "core" / "governance_reviewer.py",
 )
 
 


### PR DESCRIPTION
## What

Core increment of **#77**: a scoped **semantic** governance reviewer that runs at the **analysis tier** (provider-agnostic), implementing the merged decision `HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER` — validators own schema; a reviewer scoped to precedence/contradiction/scope/concept (never schema) runs at the analysis tier; the human owns the merge.

Composable capability only — **no** PR auto-posting, gate wiring, or MCP tool registration (deliberate follow-up).

## Changes

- **Tier-aware model resolution** (`ai_config.resolve_model(tier)`): `default→HESTAI_AI_MODEL`, `analysis→HESTAI_AI_MODEL_ANALYSIS`, `critical→HESTAI_AI_MODEL_CRITICAL`, each falling back to `HESTAI_AI_MODEL`→`DEFAULT_MODEL`. Zero-arg call is back-compatible (default tier). Tier-aware `build_default_ai_client(tier=...)`.
- **`core/governance_reviewer.py`** — `review_governance(octave_content, *, tier="analysis") -> ReviewResult` (`{verdict: APPROVED|CONCERNS|BLOCKED, assessment, concerns[], metrics}`). Mirrors `intake_compiler` (cost caps, fail-soft). **Never fabricates APPROVED** — no-client/cost-cap/auth/transport/empty → structured BLOCKED; unparseable verdict → CONCERNS (routes to a human). System prompt is semantic-scoped and explicitly forbids schema-checking.
- Provider-agnostic: no vendor/model literal (source-invariant guard).

## Gates

1176 passed; new module 98% coverage; ruff/black/mypy clean. `get_context` untouched (I5); no secrets logged (I2).

## Follow-up (tracked, not here)

Wire `review_governance` into the AGR PR flow (post the scoped-semantic verdict to clear the gate; human merges) + optional MCP tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-agnostic semantic governance reviewer that runs at the analysis tier and returns structured APPROVED/CONCERNS/BLOCKED verdicts without schema checks. Also adds tier-aware model selection used by the default client; aligns with Linear #77.

- **New Features**
  - `core/governance_reviewer.py`: `review_governance(octave_content, *, tier="analysis") -> {verdict, assessment, concerns, metrics}`.
  - Semantic-only rubric: precedence, contradiction, scope, concept; explicitly forbids schema/syntax; provider-agnostic.
  - Fail-soft: no-client/cost-cap/auth/transport/empty → BLOCKED; unparseable verdict → CONCERNS; never fabricates APPROVED.
  - Cost controls via `HESTAI_REVIEW_MAX_OUTPUT_TOKENS`, `HESTAI_REVIEW_MAX_COST_USD`, `HESTAI_REVIEW_USD_PER_1K_TOKENS`; reports tokens/cost/model.

- **Refactors**
  - `adapters/ai_config.resolve_model(tier)` for `default|analysis|critical` with fallback to `HESTAI_AI_MODEL` then default; zero-arg remains back-compat.
  - `build_default_ai_client(tier=...)` selects the tier model; provider and credential resolution unchanged.
  - Tests for tier resolution and reviewer behavior; source invariant updated to keep reviewer provider-agnostic.

<sup>Written for commit fa07df2cd29276afac37f00fb3c6262f70c111f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

