### PR TITLE
feat(governance): RFC #40 AGR read-side — lookup_decision, list_decisions, trace_supersedure + parser (#83)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -30,3 +30,7 @@ secret:
   ignored_paths:
     - "tests/unit/tools/governance/test_linker.py"
     - "tests/unit/tools/test_submit_governance.py"
+    # Deliberately-fake AGR TOKEN fixtures (#83 read-side suite): the
+    # TOKEN_OLD/MID/NEW/CYCLE_A/CYCLE_B constants are non-secret governance
+    # identifiers the "Generic High Entropy Secret" detector trips on.
+    - "tests/unit/tools/governance/_agr_fixtures.py"

--- a/src/hestai_context_mcp/core/agent_readable_governance_parser.py
+++ b/src/hestai_context_mcp/core/agent_readable_governance_parser.py
@@ -1,0 +1,164 @@
+"""Agent-Readable Governance Record (AGR) structured extraction.
+
+RFC #40 / ADR-RFC-ARCH-004 §1.2: turn one DECISION_RECORD ``.oct.md`` document's
+TEXT into a structured dict (PROD I4) so the read tools (lookup_decision /
+list_decisions / trace_supersedure) and the Payload Compiler can extract fields
+programmatically without re-implementing parsing at each consumer.
+
+Design invariants (mirrors ``core.north_star_parser`` exactly)
+--------------------------------------------------------------
+* **Pure function** (PROD I5) — text in, dict out. No filesystem access, no
+  side effects, DEBUG logging only on malformed input; never raises.
+* **Provider-agnostic** (PROD I3) — parses the OCTAVE DECISION_RECORD shape,
+  not any provider-specific representation; identical results across providers.
+* **Regex-only** (North Star §4 / PROD I3) — no OCTAVE AST parsing, no ``ast``
+  import, no octave-mcp invocation, no LLM. Deterministic for identical text.
+
+Format understood
+-----------------
+The canonical DECISION_RECORD envelope (§1.1)::
+
+    ===DECISION_RECORD===
+    META:
+      TYPE::DECISION_RECORD
+      VERSION::"1.0"
+      TOKEN::<TOKEN>            # bare canonical, OR legacy quoted TOKEN::"<TOKEN>"
+      STATUS::RATIFIED
+      TIER::STRATEGIC
+      AUTHORED_AT::"<ISO-8601>"
+      DECISION::"<sentence>"
+      BECAUSE::"<sentence>"
+      ...optional fields...
+    ===END===
+
+Quote-optionality (§1.1): values may be bare or double-quoted; the parser strips
+a single surrounding pair of double quotes from extracted values.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class DecisionRecord(TypedDict):
+    """Structured extraction of one DECISION_RECORD AGR document.
+
+    The eight core fields map to the §1.2 required fields (plus TYPE/VERSION).
+    ``fields`` carries every OTHER present ``KEY::value`` META pair (core fields
+    are NOT duplicated into it; ``SUPERSEDED_BY`` IS surfaced there so the read
+    tools can build the resolution chain). Core fields are ``None`` when absent
+    so the shape is stable (PROD I4) and the tools can detect parse failures.
+    """
+
+    token: str | None
+    type: str | None
+    version: str | None
+    status: str | None
+    tier: str | None
+    decision: str | None
+    because: str | None
+    authored_at: str | None
+    fields: dict[str, str]
+
+
+# The §1.2 core fields that are surfaced as top-level keys. Everything else
+# present in the META block lands in ``fields`` (including SUPERSEDED_BY).
+_CORE_FIELDS = (
+    "TYPE",
+    "VERSION",
+    "TOKEN",
+    "STATUS",
+    "TIER",
+    "DECISION",
+    "BECAUSE",
+    "AUTHORED_AT",
+)
+
+# A single ``KEY::value`` OCTAVE assignment at line start (whitespace-tolerant —
+# OCTAVE bodies are indented). KEY is an uppercase OCTAVE identifier; the value
+# is the rest of the line. List-valued fields (e.g. AMENDS::[A, B]) are captured
+# raw and left to the caller; the read tools only need scalar core fields plus
+# SUPERSEDED_BY (scalar). This is regex-only — no structural OCTAVE parsing.
+_FIELD_LINE_RE = re.compile(r"^\s*([A-Z][A-Z0-9_]*)::(.*?)\s*$")
+
+
+def _strip_quotes(value: str) -> str:
+    """Strip one surrounding pair of double quotes from a value (§1.1).
+
+    ``"1.0"`` -> ``1.0``; ``bare`` -> ``bare``. Only a matched leading+trailing
+    pair is removed so inner quotes (rare) survive.
+    """
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
+def parse_decision_record(text: str | None) -> DecisionRecord:
+    """Parse a DECISION_RECORD AGR document into a structured dict.
+
+    Pure function — text in, structured dict out. Graceful on empty, ``None``,
+    whitespace-only, and malformed input (returns a stable empty-ish result and
+    DEBUG-logs on parse exceptions; never raises).
+
+    Args:
+        text: Raw DECISION_RECORD ``.oct.md`` document text, or ``None``.
+
+    Returns:
+        A :class:`DecisionRecord`. All nine keys are always present. Core fields
+        are ``None`` when absent/unparseable; ``fields`` is ``{}`` in that case.
+    """
+    empty: DecisionRecord = {
+        "token": None,
+        "type": None,
+        "version": None,
+        "status": None,
+        "tier": None,
+        "decision": None,
+        "because": None,
+        "authored_at": None,
+        "fields": {},
+    }
+
+    if not text or not text.strip():
+        return empty
+
+    try:
+        return _parse_impl(text)
+    except Exception as exc:  # pragma: no cover - defensive only
+        logger.debug("agent_readable_governance_parser: parse failed: %s", exc)
+        return empty
+
+
+def _parse_impl(text: str) -> DecisionRecord:
+    """Internal regex-only extraction (raises only on truly unexpected input)."""
+    core: dict[str, str] = {}
+    extra: dict[str, str] = {}
+
+    for raw_line in text.splitlines():
+        match = _FIELD_LINE_RE.match(raw_line)
+        if not match:
+            continue
+        key = match.group(1)
+        value = _strip_quotes(match.group(2))
+
+        if key in _CORE_FIELDS:
+            # First occurrence wins (META block precedes any prose echoes).
+            core.setdefault(key, value)
+        else:
+            extra.setdefault(key, value)
+
+    return {
+        "token": core.get("TOKEN"),
+        "type": core.get("TYPE"),
+        "version": core.get("VERSION"),
+        "status": core.get("STATUS"),
+        "tier": core.get("TIER"),
+        "decision": core.get("DECISION"),
+        "because": core.get("BECAUSE"),
+        "authored_at": core.get("AUTHORED_AT"),
+        "fields": extra,
+    }

--- a/src/hestai_context_mcp/server.py
+++ b/src/hestai_context_mcp/server.py
@@ -6,6 +6,9 @@ This MCP server provides session lifecycle and context management tools:
 - get_context: Synthesize and return project context
 - submit_review: Submit structured review comments
 - submit_governance: Gate A Rails intake for OCTAVE governance artifacts (RFC #53)
+- lookup_decision: Resolve a single AGR by TOKEN (RFC #40, read-only)
+- list_decisions: List AGRs with optional filtering (RFC #40, read-only)
+- trace_supersedure: Trace an AGR supersession chain (RFC #40, read-only)
 
 Architecture:
 - Part of the three-service model (ADR-0353)
@@ -29,8 +32,11 @@ from fastmcp import FastMCP
 from hestai_context_mcp.tools.clock_in import clock_in
 from hestai_context_mcp.tools.clock_out import clock_out
 from hestai_context_mcp.tools.get_context import get_context
+from hestai_context_mcp.tools.list_decisions import list_decisions
+from hestai_context_mcp.tools.lookup_decision import lookup_decision
 from hestai_context_mcp.tools.submit_governance import submit_governance
 from hestai_context_mcp.tools.submit_review import submit_review
+from hestai_context_mcp.tools.trace_supersedure import trace_supersedure
 
 mcp = FastMCP(
     name="hestai-context-mcp",
@@ -82,6 +88,10 @@ mcp.tool(clock_out)
 mcp.tool(get_context)
 mcp.tool(submit_review)
 mcp.tool(submit_governance)
+# RFC #40 AGR read-side (ADR-RFC-ARCH-004 §3): pure-read governance-store tools.
+mcp.tool(lookup_decision)
+mcp.tool(list_decisions)
+mcp.tool(trace_supersedure)
 
 
 def main() -> None:

--- a/src/hestai_context_mcp/tools/governance/agr_read.py
+++ b/src/hestai_context_mcp/tools/governance/agr_read.py
@@ -1,0 +1,222 @@
+"""Shared read primitives for the AGR consumer tools (ADR-RFC-ARCH-004 §3).
+
+Single source of truth for the three pure-read tools (lookup_decision,
+list_decisions, trace_supersedure):
+
+* the §3.1.1 common error envelope (PROD I4),
+* working_dir validation (WORKING_DIR_INVALID),
+* TOKEN-format validation (§1.3) reusing the type_checker regex,
+* record discovery on disk (filename↔TOKEN, §1.1 flat + sub-grouped layouts),
+* structured parsing via ``core.agent_readable_governance_parser``.
+
+Pure reads (PROD I5): nothing here writes or mutates the filesystem. Regex-only
+(North Star §4): no OCTAVE AST parsing, no LLM. Reuses the established Gate-A
+primitives (``type_checker._TOKEN_FORMAT_RE`` / ``_extract_token``) rather than
+rebuilding them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hestai_context_mcp.core.agent_readable_governance_parser import (
+    DecisionRecord,
+    parse_decision_record,
+)
+
+# §1.3 TOKEN format — reuse the authoritative Gate-A regex (do not rebuild).
+from hestai_context_mcp.tools.governance.type_checker import (
+    _TOKEN_FORMAT_RE as TOKEN_FORMAT_RE,
+)
+from hestai_context_mcp.tools.governance.type_checker import (
+    _extract_token,
+)
+
+# The §1.2 required fields whose presence proves the OCTAVE envelope parsed.
+_REQUIRED_FIELDS = (
+    "token",
+    "type",
+    "status",
+    "tier",
+    "decision",
+    "because",
+    "authored_at",
+)
+
+
+def error_envelope(
+    *,
+    code: str,
+    category: str,
+    message: str,
+    tool: str,
+    context: dict[str, Any],
+    contract_ref: str,
+) -> dict[str, Any]:
+    """Build the §3.1.1 common error envelope (PROD I4).
+
+    The required keys are fixed; callers MAY pass any tool-specific ``context``
+    payload. Opaque-blob errors are forbidden — this is the only error shape the
+    AGR tools emit.
+    """
+    return {
+        "ok": False,
+        "error": {
+            "code": code,
+            "category": category,
+            "message": message,
+            "tool": tool,
+            "context": context,
+            "contract_ref": contract_ref,
+        },
+    }
+
+
+def validate_working_dir(working_dir: str) -> Path | None:
+    """Return the resolved decisions-bearing path, or ``None`` if invalid.
+
+    ``None`` signals the caller to emit a WORKING_DIR_INVALID envelope. A path
+    that exists and is a directory is valid even when ``.hestai/decisions`` is
+    absent (an empty store is a valid empty result, not an error).
+    """
+    try:
+        path = Path(working_dir)
+    except (TypeError, ValueError):
+        return None
+    if not path.exists() or not path.is_dir():
+        return None
+    return path
+
+
+def decisions_root(working_dir: Path) -> Path:
+    """Return the canonical AGR store root (may not exist yet)."""
+    return working_dir / ".hestai" / "decisions"
+
+
+def iter_record_paths(working_dir: Path) -> list[Path]:
+    """Return every ``.oct.md`` under ``.hestai/decisions/**`` (sorted, stable).
+
+    Honours both the §1.1 flat layout and ``<group>/`` sub-grouping. Read-only.
+    """
+    root = decisions_root(working_dir)
+    if not root.exists():
+        return []
+    return sorted(root.rglob("*.oct.md"))
+
+
+def is_valid_token(token: str) -> bool:
+    """True iff ``token`` matches the §1.3 TOKEN regex (reused from Gate A)."""
+    return bool(TOKEN_FORMAT_RE.match(token))
+
+
+def rel_path(working_dir: Path, path: Path) -> str:
+    """Repo-relative POSIX path string for a record (§3.2/§3.3/§3.4 ``path``)."""
+    return path.relative_to(working_dir).as_posix()
+
+
+def record_is_parseable(parsed: DecisionRecord) -> bool:
+    """True iff every §1.2 required field parsed (envelope + fields present)."""
+    if parsed.get("type") != "DECISION_RECORD":
+        return False
+    return all(parsed.get(field) is not None for field in _REQUIRED_FIELDS)
+
+
+def discover_record(working_dir: Path, token: str) -> Path | None:
+    """Resolve a TOKEN to its on-disk ``.oct.md`` path, or ``None`` if absent.
+
+    Resolution is path-first (§1.1 filename↔TOKEN): the canonical filename is
+    ``<token>.oct.md`` under the flat root or any sub-group. As a fallback (a
+    record whose filename was hand-edited away from its TOKEN), the store is
+    scanned and each file's embedded TOKEN compared via the Gate-A extractor.
+    Read-only; deterministic for identical filesystem state.
+    """
+    root = decisions_root(working_dir)
+    if not root.exists():
+        return None
+
+    # Fast path: canonical filename match (flat or sub-grouped).
+    direct = root / f"{token}.oct.md"
+    if direct.exists():
+        return direct
+    for candidate in root.rglob(f"{token}.oct.md"):
+        return candidate
+
+    # Fallback: embedded-TOKEN scan (filename drifted from TOKEN).
+    for path in iter_record_paths(working_dir):
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if _extract_token(content) == token:
+            return path
+    return None
+
+
+def load_parsed(path: Path) -> DecisionRecord:
+    """Read + parse a record file into a structured dict (pure read)."""
+    content = path.read_text(encoding="utf-8", errors="replace")
+    return parse_decision_record(content)
+
+
+def chain_entry(working_dir: Path, parsed: DecisionRecord, path: Path) -> dict[str, Any]:
+    """Build one §3.4 chain entry from a parsed record + its path."""
+    return {
+        "token": parsed.get("token"),
+        "status": parsed.get("status"),
+        "authored_at": parsed.get("authored_at"),
+        "superseded_by": parsed.get("fields", {}).get("SUPERSEDED_BY"),
+        "path": rel_path(working_dir, path),
+    }
+
+
+def walk_supersession_chain(working_dir: Path, start_token: str) -> dict[str, Any]:
+    """Follow SUPERSEDED_BY pointers from ``start_token`` to the terminal.
+
+    Pure read. The caller guarantees ``start_token`` already resolves on disk.
+
+    Returns a structured result (PROD I4) — one of:
+      * ``{"outcome": "ok", "chain": [...], "terminal_token", "terminal_status"}``
+      * ``{"outcome": "broken", "broken_at_token", "missing_successor_token",
+         "chain": [...]}``
+      * ``{"outcome": "cycle", "cycle_at_token", "chain": [...]}``
+
+    Cycle detection is fail-closed (visited-set) — never an unbounded walk
+    (§3.4). The chain follows the ``SUPERSEDED_BY`` subgraph only.
+    """
+    chain: list[dict[str, Any]] = []
+    visited: set[str] = set()
+    current = start_token
+
+    while True:
+        if current in visited:
+            # Revisited a TOKEN already in the walk — fail closed (§3.4).
+            return {"outcome": "cycle", "cycle_at_token": current, "chain": chain}
+        visited.add(current)
+
+        path = discover_record(working_dir, current)
+        if path is None:
+            # Mid-chain successor missing. The start token is guaranteed to
+            # exist by the caller, so a missing ``current`` here is a broken
+            # link from the previous entry (§3.4 CHAIN_BROKEN, distinct from
+            # TOKEN_NOT_FOUND).
+            return {
+                "outcome": "broken",
+                "broken_at_token": chain[-1]["token"] if chain else start_token,
+                "missing_successor_token": current,
+                "chain": chain,
+            }
+
+        parsed = load_parsed(path)
+        entry = chain_entry(working_dir, parsed, path)
+        chain.append(entry)
+
+        successor = entry["superseded_by"]
+        if not successor:
+            return {
+                "outcome": "ok",
+                "chain": chain,
+                "terminal_token": entry["token"],
+                "terminal_status": entry["status"],
+            }
+        current = successor

--- a/src/hestai_context_mcp/tools/governance/agr_read.py
+++ b/src/hestai_context_mcp/tools/governance/agr_read.py
@@ -27,10 +27,13 @@ from hestai_context_mcp.core.agent_readable_governance_parser import (
 
 # §1.3 TOKEN format — reuse the authoritative Gate-A regex (do not rebuild).
 from hestai_context_mcp.tools.governance.type_checker import (
-    _TOKEN_FORMAT_RE as TOKEN_FORMAT_RE,
+    _DECISION_RECORD_TYPE,
+    _extract_sentinel,
+    _extract_token,
+    _extract_type,
 )
 from hestai_context_mcp.tools.governance.type_checker import (
-    _extract_token,
+    _TOKEN_FORMAT_RE as TOKEN_FORMAT_RE,
 )
 
 # The §1.2 required fields whose presence proves the OCTAVE envelope parsed.
@@ -43,6 +46,26 @@ _REQUIRED_FIELDS = (
     "because",
     "authored_at",
 )
+
+
+def is_decision_record(content: str) -> bool:
+    """True iff this OCTAVE document declares itself a DECISION_RECORD (AGR).
+
+    Type membership is a SCOPING signal, distinct from parse-completeness
+    (``record_is_parseable``). ``.hestai/decisions/`` legitimately co-hosts
+    non-AGR governance artefacts (BUILD_PLAN, SECURITY_DESIGN_REVIEW, arbitration
+    records) per ADR-RFC-ARCH-001; those are OUT OF SCOPE for the AGR read tools
+    and must be skipped silently — never raised as RECORD_PARSE_FAILED.
+
+    A document is a DECISION_RECORD iff its opening sentinel is
+    ``===DECISION_RECORD===`` OR its META declares ``TYPE::DECISION_RECORD``
+    (§1.1). The two signals are OR-ed so a file that declares the type either way
+    is in scope; co-located non-AGRs (different sentinel, ``DOCUMENT_TYPE::``,
+    or no TYPE at all) are out of scope. Regex-only via the Gate-A extractors.
+    """
+    if _extract_sentinel(content) == _DECISION_RECORD_TYPE:
+        return True
+    return _extract_type(content) == _DECISION_RECORD_TYPE
 
 
 def error_envelope(
@@ -122,33 +145,45 @@ def record_is_parseable(parsed: DecisionRecord) -> bool:
     return all(parsed.get(field) is not None for field in _REQUIRED_FIELDS)
 
 
+def _is_decision_record_for_token(path: Path, token: str) -> bool:
+    """True iff ``path`` is a DECISION_RECORD whose embedded TOKEN == ``token``.
+
+    Both conditions are required: a co-located non-AGR (BUILD_PLAN, etc.) must
+    NOT resolve as a record even if its filename collides, and an AGR whose
+    filename drifted from its TOKEN must still resolve by content. Read-only.
+    """
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return is_decision_record(content) and _extract_token(content) == token
+
+
 def discover_record(working_dir: Path, token: str) -> Path | None:
-    """Resolve a TOKEN to its on-disk ``.oct.md`` path, or ``None`` if absent.
+    """Resolve a TOKEN to its on-disk DECISION_RECORD path, or ``None``.
 
     Resolution is path-first (§1.1 filename↔TOKEN): the canonical filename is
-    ``<token>.oct.md`` under the flat root or any sub-group. As a fallback (a
-    record whose filename was hand-edited away from its TOKEN), the store is
-    scanned and each file's embedded TOKEN compared via the Gate-A extractor.
-    Read-only; deterministic for identical filesystem state.
+    ``<token>.oct.md`` under the flat root or any sub-group. Every candidate is
+    verified to be a DECISION_RECORD whose embedded TOKEN equals ``token`` —
+    a co-located non-AGR ``.oct.md`` can never resolve as a record (F1 guard).
+    As a fallback (a record whose filename drifted from its TOKEN), the store is
+    scanned by content. Deterministic for identical filesystem state.
     """
     root = decisions_root(working_dir)
     if not root.exists():
         return None
 
-    # Fast path: canonical filename match (flat or sub-grouped).
+    # Fast path: canonical filename match (flat or sub-grouped), type-verified.
     direct = root / f"{token}.oct.md"
-    if direct.exists():
+    if direct.exists() and _is_decision_record_for_token(direct, token):
         return direct
-    for candidate in root.rglob(f"{token}.oct.md"):
-        return candidate
+    for candidate in sorted(root.rglob(f"{token}.oct.md")):
+        if _is_decision_record_for_token(candidate, token):
+            return candidate
 
-    # Fallback: embedded-TOKEN scan (filename drifted from TOKEN).
+    # Fallback: embedded-TOKEN scan (filename drifted from TOKEN), type-verified.
     for path in iter_record_paths(working_dir):
-        try:
-            content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if _extract_token(content) == token:
+        if _is_decision_record_for_token(path, token):
             return path
     return None
 
@@ -157,6 +192,21 @@ def load_parsed(path: Path) -> DecisionRecord:
     """Read + parse a record file into a structured dict (pure read)."""
     content = path.read_text(encoding="utf-8", errors="replace")
     return parse_decision_record(content)
+
+
+def classify_file(path: Path) -> tuple[bool, DecisionRecord]:
+    """Read a file ONCE and return ``(is_decision_record, parsed)`` (pure read).
+
+    The two-way scoping split for list_decisions (F1):
+      * ``is_decision_record`` False  → out of scope (co-located non-AGR): SKIP.
+      * ``is_decision_record`` True   → in scope; the caller then checks
+        ``record_is_parseable(parsed)`` to distinguish a healthy AGR from a
+        genuinely-malformed one (RECORD_PARSE_FAILED).
+
+    Reads the file a single time so type-membership and field-parse share one IO.
+    """
+    content = path.read_text(encoding="utf-8", errors="replace")
+    return is_decision_record(content), parse_decision_record(content)
 
 
 def chain_entry(working_dir: Path, parsed: DecisionRecord, path: Path) -> dict[str, Any]:

--- a/src/hestai_context_mcp/tools/governance/agr_read.py
+++ b/src/hestai_context_mcp/tools/governance/agr_read.py
@@ -17,6 +17,7 @@ rebuilding them.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +31,6 @@ from hestai_context_mcp.tools.governance.type_checker import (
     _DECISION_RECORD_TYPE,
     _extract_sentinel,
     _extract_token,
-    _extract_type,
 )
 from hestai_context_mcp.tools.governance.type_checker import (
     _TOKEN_FORMAT_RE as TOKEN_FORMAT_RE,
@@ -47,6 +47,19 @@ _REQUIRED_FIELDS = (
     "authored_at",
 )
 
+# Read-side TYPE-membership regex: LINE-ANCHORED and EXACT (CRS P2 guard).
+# The KEY must be exactly ``TYPE`` at line start — a leading whitespace-only
+# indent is allowed (OCTAVE META bodies are indented), but NO other characters
+# may precede ``TYPE``. This rejects ``DOCUMENT_TYPE::``/``CONTENT_TYPE::`` and
+# any other ``*TYPE::DECISION_RECORD`` substring that Gate-A's unanchored
+# ``_TYPE_RE.search()`` would falsely admit. The trailing ``\s*$`` end-anchor
+# rejects trailing garbage (e.g. ``TYPE::DECISION_RECORD EXTRA``). This is a
+# read-side-only decision; Gate-A's shared ``_TYPE_RE`` is intentionally NOT
+# touched (write-side root, tracked separately).
+_TYPE_IS_DECISION_RECORD_RE = re.compile(
+    r"(?m)^\s*TYPE::" + re.escape(_DECISION_RECORD_TYPE) + r"\s*$"
+)
+
 
 def is_decision_record(content: str) -> bool:
     """True iff this OCTAVE document declares itself a DECISION_RECORD (AGR).
@@ -58,14 +71,17 @@ def is_decision_record(content: str) -> bool:
     and must be skipped silently — never raised as RECORD_PARSE_FAILED.
 
     A document is a DECISION_RECORD iff its opening sentinel is
-    ``===DECISION_RECORD===`` OR its META declares ``TYPE::DECISION_RECORD``
-    (§1.1). The two signals are OR-ed so a file that declares the type either way
-    is in scope; co-located non-AGRs (different sentinel, ``DOCUMENT_TYPE::``,
-    or no TYPE at all) are out of scope. Regex-only via the Gate-A extractors.
+    ``===DECISION_RECORD===`` OR a META line is EXACTLY ``TYPE::DECISION_RECORD``
+    (§1.1). The two signals are OR-ed. The sentinel branch reuses the Gate-A
+    ``_extract_sentinel`` (already ``\\A===…===`` anchored/exact). The TYPE
+    branch uses a read-side LINE-ANCHORED regex (``_TYPE_IS_DECISION_RECORD_RE``)
+    rather than Gate-A's substring-tolerant ``_TYPE_RE`` so a non-AGR line such
+    as ``DOCUMENT_TYPE::DECISION_RECORD`` / ``CONTENT_TYPE::DECISION_RECORD``
+    can never qualify (CRS P2 — same failure class as F1).
     """
     if _extract_sentinel(content) == _DECISION_RECORD_TYPE:
         return True
-    return _extract_type(content) == _DECISION_RECORD_TYPE
+    return _TYPE_IS_DECISION_RECORD_RE.search(content) is not None
 
 
 def error_envelope(

--- a/src/hestai_context_mcp/tools/governance/agr_read.py
+++ b/src/hestai_context_mcp/tools/governance/agr_read.py
@@ -184,7 +184,20 @@ def discover_record(working_dir: Path, token: str) -> Path | None:
     a co-located non-AGR ``.oct.md`` can never resolve as a record (F1 guard).
     As a fallback (a record whose filename drifted from its TOKEN), the store is
     scanned by content. Deterministic for identical filesystem state.
+
+    SECURITY (P1 — fix-the-class path-traversal guard): the ``token`` is
+    validated against the §1.3 TOKEN regex BEFORE it is ever joined into a path
+    (``root / f"{token}.oct.md"``) or used in an ``rglob`` glob. The §1.3 format
+    ``^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$`` admits no ``/``, ``.`` or
+    ``..`` sequence, so a traversal-shaped token (e.g. ``../../../etc/passwd``)
+    is rejected here — closing the escape for EVERY caller at once, including
+    ``trace_supersedure``, which does not pre-validate. Callers that need the
+    explicit TOKEN_MALFORMED envelope (lookup_decision) still validate upstream;
+    this guard is defence-in-depth and simply returns ``None`` (not found).
     """
+    if not is_valid_token(token):
+        return None
+
     root = decisions_root(working_dir)
     if not root.exists():
         return None

--- a/src/hestai_context_mcp/tools/list_decisions.py
+++ b/src/hestai_context_mcp/tools/list_decisions.py
@@ -58,10 +58,20 @@ def list_decisions(
 
     records: list[dict[str, Any]] = []
     for path in agr_read.iter_record_paths(working_path):
-        parsed = agr_read.load_parsed(path)
+        is_agr, parsed = agr_read.classify_file(path)
+
+        # F1 SCOPING: ``.hestai/decisions/`` legitimately co-hosts non-AGR
+        # governance artefacts (BUILD_PLAN, SECURITY_DESIGN_REVIEW, arbitration
+        # records) per ADR-RFC-ARCH-001. A file that does NOT declare itself a
+        # DECISION_RECORD is OUT OF SCOPE — skip silently, never error.
+        if not is_agr:
+            continue
+
+        # §3.3 PROTECTION (preserved): a file that IS a DECISION_RECORD but fails
+        # to parse its required §1.2 fields fails the WHOLE call — consumers MUST
+        # be able to detect that the list is incomplete; do not silently drop a
+        # genuinely-malformed AGR.
         if not agr_read.record_is_parseable(parsed):
-            # §3.3: fail the whole call rather than silently dropping; consumers
-            # MUST be able to detect that the list is incomplete.
             return agr_read.error_envelope(
                 code="RECORD_PARSE_FAILED",
                 category="schema_violation",

--- a/src/hestai_context_mcp/tools/list_decisions.py
+++ b/src/hestai_context_mcp/tools/list_decisions.py
@@ -1,0 +1,110 @@
+"""list_decisions — list AGRs with optional filtering (ADR-RFC-ARCH-004 §3.3).
+
+Pure read (PROD I5), structured return (PROD I4). Returns summary entries sorted
+by ``authored_at`` DESCENDING with optional scope/status/tier filters. Errors use
+the §3.1.1 envelope: FILTER_INVALID, WORKING_DIR_INVALID, RECORD_PARSE_FAILED
+(a single unparseable record fails the WHOLE call — no silent drop).
+
+Reuses the shared ``tools.governance.agr_read`` primitives (enumeration via
+``iter_record_paths``, structured parsing) — no rebuilt logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hestai_context_mcp.tools.governance import agr_read
+
+_TOOL = "list_decisions"
+_CONTRACT_REF = "ADR-RFC-ARCH-004 §3.3"
+
+_VALID_STATUS = ("PROPOSED", "RATIFIED", "SUPERSEDED", "VOID")
+_VALID_TIER = ("STRATEGIC", "TACTICAL", "OPERATIONAL")
+
+
+def list_decisions(
+    working_dir: str,
+    scope: str | None = None,
+    status: str | None = None,
+    tier: str | None = None,
+) -> dict[str, Any]:
+    """List AGRs with optional filtering. Pure read.
+
+    Args:
+        working_dir: Project path.
+        scope: Exact-match SCOPE filter, or ``None`` for no filter.
+        status: One of the STATUS enum values, or ``None``.
+        tier: One of the TIER enum values, or ``None``.
+
+    Returns:
+        On success: ``{"ok": True, "records": [...], "total": int}`` sorted by
+        ``authored_at`` DESC. On failure: the §3.1.1 error envelope.
+    """
+    working_path = agr_read.validate_working_dir(working_dir)
+    if working_path is None:
+        return agr_read.error_envelope(
+            code="WORKING_DIR_INVALID",
+            category="io_failure",
+            message=f"working_dir does not exist or is not a directory: {working_dir}",
+            tool=_TOOL,
+            context={"working_dir": working_dir},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    if status is not None and status not in _VALID_STATUS:
+        return _filter_invalid("status", status)
+    if tier is not None and tier not in _VALID_TIER:
+        return _filter_invalid("tier", tier)
+
+    records: list[dict[str, Any]] = []
+    for path in agr_read.iter_record_paths(working_path):
+        parsed = agr_read.load_parsed(path)
+        if not agr_read.record_is_parseable(parsed):
+            # §3.3: fail the whole call rather than silently dropping; consumers
+            # MUST be able to detect that the list is incomplete.
+            return agr_read.error_envelope(
+                code="RECORD_PARSE_FAILED",
+                category="schema_violation",
+                message="A DECISION_RECORD under .hestai/decisions failed to parse.",
+                tool=_TOOL,
+                context={
+                    "path": agr_read.rel_path(working_path, path),
+                    "parse_error": "missing OCTAVE envelope or required §1.2 field(s)",
+                },
+                contract_ref=_CONTRACT_REF,
+            )
+
+        if status is not None and parsed["status"] != status:
+            continue
+        if tier is not None and parsed["tier"] != tier:
+            continue
+        if scope is not None and parsed["fields"].get("SCOPE") != scope:
+            continue
+
+        records.append(
+            {
+                "token": parsed["token"],
+                "status": parsed["status"],
+                "tier": parsed["tier"],
+                "decision": parsed["decision"],
+                "authored_at": parsed["authored_at"],
+                "path": agr_read.rel_path(working_path, path),
+            }
+        )
+
+    # §3.3: sorted by authored_at DESCENDING.
+    records.sort(key=lambda r: r["authored_at"] or "", reverse=True)
+
+    return {"ok": True, "records": records, "total": len(records)}
+
+
+def _filter_invalid(field: str, value: str) -> dict[str, Any]:
+    """Build the §3.3 FILTER_INVALID envelope for a bad enum filter."""
+    return agr_read.error_envelope(
+        code="FILTER_INVALID",
+        category="input_validation",
+        message=f"Filter {field}={value!r} is not a member of the admissible enum.",
+        tool=_TOOL,
+        context={"field": field, "value": value},
+        contract_ref=_CONTRACT_REF,
+    )

--- a/src/hestai_context_mcp/tools/lookup_decision.py
+++ b/src/hestai_context_mcp/tools/lookup_decision.py
@@ -1,0 +1,113 @@
+"""lookup_decision — resolve a single AGR by TOKEN (ADR-RFC-ARCH-004 §3.2).
+
+Pure read (PROD I5), structured return (PROD I4). Returns the full record shape
+plus a ``resolution_chain`` populated when STATUS == SUPERSEDED. Errors use the
+§3.1.1 envelope: TOKEN_NOT_FOUND, TOKEN_MALFORMED, RECORD_PARSE_FAILED,
+WORKING_DIR_INVALID.
+
+Reuses the shared ``tools.governance.agr_read`` primitives (working_dir
+validation, §1.3 TOKEN regex, on-disk discovery, structured parsing, chain
+walking) — no rebuilt parsing or enumeration logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hestai_context_mcp.tools.governance import agr_read
+
+_TOOL = "lookup_decision"
+_CONTRACT_REF = "ADR-RFC-ARCH-004 §3.2"
+
+
+def lookup_decision(
+    working_dir: str,
+    token: str,
+    audience: str = "agent",
+) -> dict[str, Any]:
+    """Resolve a single AGR by TOKEN. Pure read.
+
+    Args:
+        working_dir: Absolute or repo-rooted project path.
+        token: The DECISION_RECORD TOKEN to resolve.
+        audience: ``"agent"`` (default) or ``"human"``. The implementation
+            always returns the agent-shape record; ``audience`` is accepted for
+            contract conformance (§3.2 — consumers must tolerate agent shape).
+
+    Returns:
+        On success: ``{"ok": True, "record": {...}, "resolution_chain": [...]}``.
+        On failure: the §3.1.1 error envelope.
+    """
+    working_path = agr_read.validate_working_dir(working_dir)
+    if working_path is None:
+        return agr_read.error_envelope(
+            code="WORKING_DIR_INVALID",
+            category="io_failure",
+            message=f"working_dir does not exist or is not a directory: {working_dir}",
+            tool=_TOOL,
+            context={"working_dir": working_dir},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    if not agr_read.is_valid_token(token):
+        return agr_read.error_envelope(
+            code="TOKEN_MALFORMED",
+            category="input_validation",
+            message=f"TOKEN does not match the ADR-RFC-ARCH-004 §1.3 format: {token!r}",
+            tool=_TOOL,
+            context={"token": token},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    path = agr_read.discover_record(working_path, token)
+    if path is None:
+        return agr_read.error_envelope(
+            code="TOKEN_NOT_FOUND",
+            category="input_validation",
+            message=f"No DECISION_RECORD found for TOKEN: {token}",
+            tool=_TOOL,
+            context={"token": token},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    parsed = agr_read.load_parsed(path)
+    if not agr_read.record_is_parseable(parsed):
+        return agr_read.error_envelope(
+            code="RECORD_PARSE_FAILED",
+            category="schema_violation",
+            message="DECISION_RECORD envelope or required fields failed to parse.",
+            tool=_TOOL,
+            context={
+                "token": token,
+                "path": agr_read.rel_path(working_path, path),
+                "parse_error": "missing OCTAVE envelope or required §1.2 field(s)",
+            },
+            contract_ref=_CONTRACT_REF,
+        )
+
+    record = {
+        "token": parsed["token"],
+        "type": parsed["type"],
+        "version": parsed["version"],
+        "status": parsed["status"],
+        "tier": parsed["tier"],
+        "decision": parsed["decision"],
+        "because": parsed["because"],
+        "authored_at": parsed["authored_at"],
+        "path": agr_read.rel_path(working_path, path),
+        "fields": parsed["fields"],
+    }
+
+    resolution_chain: list[dict[str, Any]] = []
+    if parsed["status"] == "SUPERSEDED":
+        walk = agr_read.walk_supersession_chain(working_path, token)
+        # §3.2: the resolution chain mirrors the trace_supersedure entry shape.
+        # A broken/cyclic chain still surfaces the entries gathered so far so the
+        # caller sees the partial resolution rather than nothing.
+        resolution_chain = walk["chain"]
+
+    return {
+        "ok": True,
+        "record": record,
+        "resolution_chain": resolution_chain,
+    }

--- a/src/hestai_context_mcp/tools/trace_supersedure.py
+++ b/src/hestai_context_mcp/tools/trace_supersedure.py
@@ -1,0 +1,88 @@
+"""trace_supersedure — supersession chain for a TOKEN (ADR-RFC-ARCH-004 §3.4).
+
+Pure read (PROD I5), structured return (PROD I4). Follows SUPERSEDED_BY pointers
+from the requested token to the terminal record. Errors use the §3.1.1 envelope:
+TOKEN_NOT_FOUND, CHAIN_BROKEN, CHAIN_CYCLE_DETECTED (fails closed — never an
+infinite loop), WORKING_DIR_INVALID.
+
+Reuses the shared ``tools.governance.agr_read`` chain walker (which reuses the
+``lineage`` SUPERSEDED_BY semantics via the parser's ``fields`` map) — no rebuilt
+traversal logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hestai_context_mcp.tools.governance import agr_read
+
+_TOOL = "trace_supersedure"
+_CONTRACT_REF = "ADR-RFC-ARCH-004 §3.4"
+
+
+def trace_supersedure(working_dir: str, token: str) -> dict[str, Any]:
+    """Return the supersession chain for ``token``. Pure read.
+
+    Args:
+        working_dir: Project path.
+        token: The starting DECISION_RECORD TOKEN.
+
+    Returns:
+        On success: ``{"ok": True, "chain": [...], "terminal_token",
+        "terminal_status"}``. On failure: the §3.1.1 error envelope.
+    """
+    working_path = agr_read.validate_working_dir(working_dir)
+    if working_path is None:
+        return agr_read.error_envelope(
+            code="WORKING_DIR_INVALID",
+            category="io_failure",
+            message=f"working_dir does not exist or is not a directory: {working_dir}",
+            tool=_TOOL,
+            context={"working_dir": working_dir},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    # A missing START token is TOKEN_NOT_FOUND (distinct from a missing
+    # mid-chain successor, which the walker reports as CHAIN_BROKEN).
+    if agr_read.discover_record(working_path, token) is None:
+        return agr_read.error_envelope(
+            code="TOKEN_NOT_FOUND",
+            category="input_validation",
+            message=f"No DECISION_RECORD found for starting TOKEN: {token}",
+            tool=_TOOL,
+            context={"token": token},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    walk = agr_read.walk_supersession_chain(working_path, token)
+    outcome = walk["outcome"]
+
+    if outcome == "cycle":
+        return agr_read.error_envelope(
+            code="CHAIN_CYCLE_DETECTED",
+            category="schema_violation",
+            message="SUPERSEDED_BY traversal revisited a TOKEN already in the chain.",
+            tool=_TOOL,
+            context={"cycle_at_token": walk["cycle_at_token"]},
+            contract_ref=_CONTRACT_REF,
+        )
+
+    if outcome == "broken":
+        return agr_read.error_envelope(
+            code="CHAIN_BROKEN",
+            category="schema_violation",
+            message="A record's SUPERSEDED_BY points at a TOKEN that does not exist.",
+            tool=_TOOL,
+            context={
+                "broken_at_token": walk["broken_at_token"],
+                "missing_successor_token": walk["missing_successor_token"],
+            },
+            contract_ref=_CONTRACT_REF,
+        )
+
+    return {
+        "ok": True,
+        "chain": walk["chain"],
+        "terminal_token": walk["terminal_token"],
+        "terminal_status": walk["terminal_status"],
+    }

--- a/tests/storage/test_source_invariants_pss.py
+++ b/tests/storage/test_source_invariants_pss.py
@@ -267,7 +267,8 @@ class TestLocalFilesystemAdapterHasNoKeyringImport:
 
 
 class TestNoNewToolRegistration:
-    """TEST_167 — server.py registers the B1 tools plus RFC-53 Gate A submit_governance."""
+    """TEST_167 — server.py registers the B1 tools plus RFC-53 Gate A submit_governance
+    plus the RFC #40 AGR read-side tools (ADR-RFC-ARCH-004 §3, pure reads)."""
 
     def test_no_new_tool_registration_for_publish_or_restore(self) -> None:
         path = _SRC_ROOT / "server.py"
@@ -275,13 +276,26 @@ class TestNoNewToolRegistration:
         # Count mcp.tool(...) registrations.
         registrations = re.findall(r"^\s*mcp\.tool\(([\w_]+)\)", source, re.MULTILINE)
         # RFC #53 Gate A: submit_governance is the approved additive tool (PROD I5 — additive only).
-        # B2_START_BLOCKER_002 / R5 blocks publish/restore — NOT intake tools per RFC #53.
+        # RFC #40 (ADR-RFC-ARCH-004 §3): lookup_decision/list_decisions/trace_supersedure are
+        # the approved additive pure-read AGR tools (PROD I5 pure reads).
+        # B2_START_BLOCKER_002 / R5 still blocks publish/restore — those names remain absent
+        # from the allowlist, so a publish/restore registration still fails this equality.
         allowed = sorted(
-            ["clock_in", "clock_out", "get_context", "submit_review", "submit_governance"]
+            [
+                "clock_in",
+                "clock_out",
+                "get_context",
+                "submit_review",
+                "submit_governance",
+                "lookup_decision",
+                "list_decisions",
+                "trace_supersedure",
+            ]
         )
         assert sorted(registrations) == allowed, (
             "B2_START_BLOCKER_002 / R5 violation — server.py must register exactly "
-            f"the five approved tools (RFC #53 Gate A additive); got {registrations}"
+            "the approved tools (B1 + RFC #53 Gate A + RFC #40 read-side); "
+            f"got {registrations}"
         )
 
     def test_server_does_not_import_publish_or_restore_helpers(self) -> None:

--- a/tests/unit/core/test_agent_readable_governance_parser.py
+++ b/tests/unit/core/test_agent_readable_governance_parser.py
@@ -1,0 +1,17 @@
+"""Test-locator shim for the AGR parser.
+
+The authoritative parser suite lives next to its sibling governance tests at
+``tests/unit/tools/governance/test_agent_readable_governance_parser.py`` (TMG-
+confirmed existing-neighbor convention, ruling (d)). This module re-exports that
+suite so a ``core/``-path test-locator (and pytest) discovers it here too; it
+adds NO new assertions and duplicates nothing.
+"""
+
+from __future__ import annotations
+
+from tests.unit.tools.governance.test_agent_readable_governance_parser import (  # noqa: F401
+    TestGracefulDegradation,
+    TestPurityAndRegexOnly,
+    TestRequiredFieldExtraction,
+    TestSupersededRecord,
+)

--- a/tests/unit/core/test_agent_readable_governance_parser.py
+++ b/tests/unit/core/test_agent_readable_governance_parser.py
@@ -2,16 +2,18 @@
 
 The authoritative parser suite lives next to its sibling governance tests at
 ``tests/unit/tools/governance/test_agent_readable_governance_parser.py`` (TMG-
-confirmed existing-neighbor convention, ruling (d)). This module re-exports that
-suite so a ``core/``-path test-locator (and pytest) discovers it here too; it
-adds NO new assertions and duplicates nothing.
+confirmed existing-neighbor convention, ruling (d)). A ``core/``-path
+test-locator/gate derives the expected test path from the source module
+(``src/hestai_context_mcp/core/agent_readable_governance_parser.py`` →
+``tests/unit/core/test_agent_readable_governance_parser.py``); this file
+satisfies that path.
+
+It uses a MODULE-ALIAS import (not ``from … import Test*``) so the authoritative
+``Test*`` classes are NOT re-bound into this module's namespace — pytest
+therefore collects them EXACTLY once (in their home module), with no duplicate
+collection.
 """
 
 from __future__ import annotations
 
-from tests.unit.tools.governance.test_agent_readable_governance_parser import (  # noqa: F401
-    TestGracefulDegradation,
-    TestPurityAndRegexOnly,
-    TestRequiredFieldExtraction,
-    TestSupersededRecord,
-)
+import tests.unit.tools.governance.test_agent_readable_governance_parser as _agr_parser_tests  # noqa: E501, F401

--- a/tests/unit/tools/governance/_agr_fixtures.py
+++ b/tests/unit/tools/governance/_agr_fixtures.py
@@ -134,18 +134,68 @@ def write_broken_chain(working_dir: Path) -> None:
 
 
 def write_malformed_record(working_dir: Path) -> Path:
-    """Write a file with a valid-format TOKEN but a broken OCTAVE envelope.
+    """Write a genuinely-malformed DECISION_RECORD (F1 distinction).
 
-    Used to exercise RECORD_PARSE_FAILED: the file is discoverable but its
-    required fields / envelope do not parse.
+    The file DECLARES itself a DECISION_RECORD (canonical sentinel +
+    ``TYPE::DECISION_RECORD`` + a valid-format TOKEN, so it is in scope and
+    discoverable) but is MISSING required §1.2 fields (no STATUS / TIER /
+    DECISION / BECAUSE / AUTHORED_AT). It must therefore trigger
+    RECORD_PARSE_FAILED — NOT be silently skipped. This is the "is-an-AGR-but-
+    broken" half of the two-way scoping split.
     """
     root = decisions_dir(working_dir)
     path = root / f"{MALFORMED_TOKEN}.oct.md"
-    # No sentinel, no required fields — envelope is broken.
     path.write_text(
-        f"this is not a valid OCTAVE record\nTOKEN::{MALFORMED_TOKEN}\n",
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        '  VERSION::"1.0"\n'
+        f"  TOKEN::{MALFORMED_TOKEN}\n"
+        # Required STATUS/TIER/DECISION/BECAUSE/AUTHORED_AT deliberately absent.
+        "===END===\n",
         encoding="utf-8",
     )
+    return path
+
+
+def write_non_agr_record(
+    working_dir: Path,
+    *,
+    filename: str,
+    sentinel: str = "BUILD_PLAN",
+    type_field: str | None = "BUILD_PLAN",
+    type_key: str = "TYPE",
+    group: str | None = None,
+) -> Path:
+    """Write a correctly-placed NON-AGR ``.oct.md`` (F1 co-residency case).
+
+    Models the governance artefacts that legitimately co-reside under
+    ``.hestai/decisions/`` per ADR-RFC-ARCH-001 (BUILD_PLAN, SECURITY_DESIGN_
+    REVIEW, arbitration records). These declare a NON-DECISION_RECORD sentinel
+    and/or type (or no type at all) and carry no TOKEN. They are OUT OF SCOPE for
+    the AGR read tools and must be skipped silently.
+
+    Args:
+        filename: The on-disk basename (e.g. ``BUILD-PLAN.oct.md``).
+        sentinel: The opening ``===<sentinel>===`` envelope name.
+        type_field: Value for the META type line, or ``None`` to omit it.
+        type_key: META key for the type line — defaults to ``TYPE``; pass
+            ``DOCUMENT_TYPE`` to model the real BUILD_PLAN convention.
+        group: Optional ``<group>/`` subdirectory.
+    """
+    root = decisions_dir(working_dir)
+    if group:
+        root = root / group
+        root.mkdir(parents=True, exist_ok=True)
+
+    lines = [f"==={sentinel}===", "META:"]
+    if type_field is not None:
+        lines.append(f"  {type_key}::{type_field}")
+    lines.append('  NOTE::"a correctly-placed non-AGR governance artefact"')
+    lines.append("===END===")
+
+    path = root / filename
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return path
 
 

--- a/tests/unit/tools/governance/_agr_fixtures.py
+++ b/tests/unit/tools/governance/_agr_fixtures.py
@@ -1,0 +1,163 @@
+"""Shared AGR fixture builders for the RFC #40 read-side RED suite.
+
+Helpers to materialise crafted DECISION_RECORD ``.oct.md`` files under a temp
+``.hestai/decisions/`` tree so the read tools (lookup_decision / list_decisions
+/ trace_supersedure) can be exercised against real on-disk records.
+
+Pure builders: they only write fixtures the tests asked for. The tools under
+test are the ones that must stay pure (PROD I5); these helpers set up state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Non-secret governance identifiers used across the read-side suite.
+TOKEN_RATIFIED = "HO-CONTEXT-MCP-DOGFOOD-RATIFIED-20260601"
+TOKEN_OLD = "HO-CONTEXT-MCP-CHAIN-OLD-20260101"
+TOKEN_MID = "HO-CONTEXT-MCP-CHAIN-MID-20260201"
+TOKEN_NEW = "HO-CONTEXT-MCP-CHAIN-NEW-20260301"
+TOKEN_CYCLE_A = "HO-CONTEXT-MCP-CYCLE-A-20260401"
+TOKEN_CYCLE_B = "HO-CONTEXT-MCP-CYCLE-B-20260402"
+TOKEN_BROKEN = "HO-CONTEXT-MCP-BROKEN-HEAD-20260501"
+TOKEN_MISSING = "HO-CONTEXT-MCP-NEVER-WRITTEN-20260101"
+MALFORMED_TOKEN = "HO-CONTEXT-MCP-MALFORMED-20260601"
+
+
+def decisions_dir(working_dir: Path) -> Path:
+    """Return (and create) the canonical ``.hestai/decisions`` root."""
+    root = working_dir / ".hestai" / "decisions"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def write_record(
+    working_dir: Path,
+    *,
+    token: str,
+    status: str = "RATIFIED",
+    tier: str = "STRATEGIC",
+    authored_at: str = "2026-06-01T00:00:00Z",
+    decision: str = "A binding decision sentence.",
+    because: str = "A one-sentence rationale.",
+    scope: str | None = None,
+    superseded_by: str | None = None,
+    group: str | None = None,
+    extra_lines: list[str] | None = None,
+) -> Path:
+    """Write a single DECISION_RECORD AGR and return its path.
+
+    ``group`` writes under ``.hestai/decisions/<group>/`` to exercise §1.1
+    sub-grouping (both layouts must resolve identically).
+    """
+    root = decisions_dir(working_dir)
+    if group:
+        root = root / group
+        root.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "===DECISION_RECORD===",
+        "META:",
+        "  TYPE::DECISION_RECORD",
+        '  VERSION::"1.0"',
+        f"  TOKEN::{token}",
+        f"  STATUS::{status}",
+        f"  TIER::{tier}",
+        f'  AUTHORED_AT::"{authored_at}"',
+        f'  DECISION::"{decision}"',
+        f'  BECAUSE::"{because}"',
+    ]
+    if scope is not None:
+        lines.append(f'  SCOPE::"{scope}"')
+    if superseded_by is not None:
+        lines.append(f"  SUPERSEDED_BY::{superseded_by}")
+    if extra_lines:
+        lines.extend(extra_lines)
+    lines.append("===END===")
+
+    path = root / f"{token}.oct.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def write_supersession_chain(working_dir: Path) -> None:
+    """Seed a three-record chain: OLD -> MID -> NEW (NEW terminal/RATIFIED)."""
+    write_record(
+        working_dir,
+        token=TOKEN_OLD,
+        status="SUPERSEDED",
+        authored_at="2026-01-01T00:00:00Z",
+        superseded_by=TOKEN_MID,
+    )
+    write_record(
+        working_dir,
+        token=TOKEN_MID,
+        status="SUPERSEDED",
+        authored_at="2026-02-01T00:00:00Z",
+        superseded_by=TOKEN_NEW,
+    )
+    write_record(
+        working_dir,
+        token=TOKEN_NEW,
+        status="RATIFIED",
+        authored_at="2026-03-01T00:00:00Z",
+    )
+
+
+def write_cyclic_pair(working_dir: Path) -> None:
+    """Seed a 2-record SUPERSEDED_BY cycle: A -> B -> A (fail-closed test)."""
+    write_record(
+        working_dir,
+        token=TOKEN_CYCLE_A,
+        status="SUPERSEDED",
+        authored_at="2026-04-01T00:00:00Z",
+        superseded_by=TOKEN_CYCLE_B,
+    )
+    write_record(
+        working_dir,
+        token=TOKEN_CYCLE_B,
+        status="SUPERSEDED",
+        authored_at="2026-04-02T00:00:00Z",
+        superseded_by=TOKEN_CYCLE_A,
+    )
+
+
+def write_broken_chain(working_dir: Path) -> None:
+    """Seed a record whose SUPERSEDED_BY points at a non-existent successor."""
+    write_record(
+        working_dir,
+        token=TOKEN_BROKEN,
+        status="SUPERSEDED",
+        authored_at="2026-05-01T00:00:00Z",
+        superseded_by=TOKEN_MISSING,
+    )
+
+
+def write_malformed_record(working_dir: Path) -> Path:
+    """Write a file with a valid-format TOKEN but a broken OCTAVE envelope.
+
+    Used to exercise RECORD_PARSE_FAILED: the file is discoverable but its
+    required fields / envelope do not parse.
+    """
+    root = decisions_dir(working_dir)
+    path = root / f"{MALFORMED_TOKEN}.oct.md"
+    # No sentinel, no required fields — envelope is broken.
+    path.write_text(
+        f"this is not a valid OCTAVE record\nTOKEN::{MALFORMED_TOKEN}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def snapshot_tree(working_dir: Path) -> dict[str, tuple[float, int]]:
+    """Capture {relpath: (mtime_ns_as_float, size)} for every file under root.
+
+    Used by purity tests to prove a tool performed zero writes/mutations
+    (PROD I5). Compares before/after a tool call.
+    """
+    snap: dict[str, tuple[float, int]] = {}
+    for p in sorted(working_dir.rglob("*")):
+        if p.is_file():
+            st = p.stat()
+            snap[str(p.relative_to(working_dir))] = (st.st_mtime_ns, st.st_size)
+    return snap

--- a/tests/unit/tools/governance/test_agent_readable_governance_parser.py
+++ b/tests/unit/tools/governance/test_agent_readable_governance_parser.py
@@ -1,0 +1,206 @@
+"""RED suite — Agent-Readable Governance Record (AGR) parser.
+
+Contract: ADR-RFC-ARCH-004 §1.2 (fields) / §1.1 (envelope). The parser is the
+structured-extraction primitive the read tools build on: it turns one AGR
+``.oct.md`` document's TEXT into a structured dict (PROD I4), mirroring
+``core.north_star_parser`` exactly:
+
+  * Pure function (PROD I5) — text in, dict out. No filesystem access, no
+    side effects, DEBUG logging only on malformed input; never raises.
+  * Regex-only (North Star §4 / PROD I3) — no OCTAVE AST parsing, no ``ast``
+    import, no LLM. Deterministic for identical text.
+  * Graceful on empty / None / whitespace / malformed — returns a stable
+    empty-ish shape rather than raising.
+
+This is RED: ``core.agent_readable_governance_parser`` does not exist yet, so
+import raises ``ModuleNotFoundError`` (failure for the right reason — missing
+implementation, not a collection error).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# Non-secret governance identifier reused across the suite.
+_TOKEN = "HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611"
+
+
+def _parse_decision_record() -> Callable[..., dict]:
+    """Lazily import the not-yet-existing parser.
+
+    RED-discipline (build-anti-patterns §5 / tdd-discipline): the import lives
+    inside each test rather than at module top so COLLECTION succeeds and every
+    test FAILS individually with a clear 'missing implementation' reason — not a
+    single module-level collection error that masks the whole file. GREEN
+    creates ``core.agent_readable_governance_parser.parse_decision_record`` and
+    these resolve.
+    """
+    from hestai_context_mcp.core.agent_readable_governance_parser import (
+        parse_decision_record,
+    )
+
+    return parse_decision_record
+
+
+def _full_record(token: str = _TOKEN) -> str:
+    """A complete RATIFIED DECISION_RECORD covering every schema field.
+
+    Mirrors the real on-disk record
+    ``.hestai/decisions/HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-20260611.oct.md``
+    (bare canonical TOKEN per §1.1).
+    """
+    return (
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        '  VERSION::"1.0"\n'
+        f"  TOKEN::{token}\n"
+        "  STATUS::RATIFIED\n"
+        "  TIER::STRATEGIC\n"
+        '  AUTHORED_AT::"2026-06-11T00:00:00Z"\n'
+        '  RATIFIED_BY::"human:operator"\n'
+        '  RATIFIED_AT::"2026-06-11T00:00:00Z"\n'
+        '  ISSUE_REF::"repo:hestai-context-mcp#53"\n'
+        '  HUMAN_ADR_REF::".hestai/decisions/rfc-arch/ADR-RFC-ARCH-004.md"\n'
+        '  SCOPE::"hestai-context-mcp"\n'
+        '  DECISION::"hestai-context-mcp dogfoods its own AGR standard."\n'
+        '  BECAUSE::"This repository owns the AGR standard and validates it."\n'
+        "===END===\n"
+    )
+
+
+class TestRequiredFieldExtraction:
+    @pytest.mark.unit
+    def test_extracts_all_required_fields(self) -> None:
+        """Every §1.2 required field is surfaced verbatim from the text."""
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record(_full_record())
+
+        assert rec["token"] == _TOKEN
+        assert rec["type"] == "DECISION_RECORD"
+        assert rec["version"] == "1.0"
+        assert rec["status"] == "RATIFIED"
+        assert rec["tier"] == "STRATEGIC"
+        assert rec["decision"] == "hestai-context-mcp dogfoods its own AGR standard."
+        assert rec["because"] == "This repository owns the AGR standard and validates it."
+        assert rec["authored_at"] == "2026-06-11T00:00:00Z"
+
+    @pytest.mark.unit
+    def test_optional_fields_collected_in_fields_map(self) -> None:
+        """Non-core present fields land in a ``fields`` sub-dict (§3.2 shape).
+
+        The lookup_decision return packs all other present fields under
+        ``record.fields``; the parser is the single source of that map.
+        """
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record(_full_record())
+        fields = rec["fields"]
+        assert fields["RATIFIED_BY"] == "human:operator"
+        assert fields["ISSUE_REF"] == "repo:hestai-context-mcp#53"
+        assert fields["SCOPE"] == "hestai-context-mcp"
+        # Core fields must NOT be duplicated into the fields map.
+        assert "TOKEN" not in fields
+        assert "DECISION" not in fields
+
+    @pytest.mark.unit
+    def test_bare_and_quoted_token_both_parse(self) -> None:
+        """Quote-optional TOKEN per §1.1: bare canonical AND legacy quoted."""
+        parse_decision_record = _parse_decision_record()
+        bare = parse_decision_record(_full_record())
+        quoted_text = _full_record().replace(f"TOKEN::{_TOKEN}", f'TOKEN::"{_TOKEN}"')
+        quoted = parse_decision_record(quoted_text)
+        assert bare["token"] == quoted["token"] == _TOKEN
+
+
+class TestSupersededRecord:
+    @pytest.mark.unit
+    def test_superseded_by_is_surfaced(self) -> None:
+        """A SUPERSEDED record exposes its successor TOKEN for chain walking."""
+        successor = "HO-CONTEXT-MCP-ADOPTS-AGR-DOGFOOD-V2-20260612"
+        text = (
+            _full_record()
+            .replace("  STATUS::RATIFIED\n", "  STATUS::SUPERSEDED\n")
+            .replace("===END===\n", f"  SUPERSEDED_BY::{successor}\n===END===\n")
+        )
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record(text)
+        assert rec["status"] == "SUPERSEDED"
+        assert rec["fields"]["SUPERSEDED_BY"] == successor
+
+
+class TestGracefulDegradation:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [None, "", "   ", "\n\t  \n"])
+    def test_empty_or_none_returns_stable_empty_shape(self, bad: str | None) -> None:
+        """Empty / None / whitespace yields a stable shape, never raises.
+
+        Mirrors ``north_star_parser.extract_constraints`` graceful contract.
+        The required keys are always present so consumers never special-case
+        absence (PROD I4 consistent shape).
+        """
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record(bad)
+        for key in (
+            "token",
+            "type",
+            "version",
+            "status",
+            "tier",
+            "decision",
+            "because",
+            "authored_at",
+            "fields",
+        ):
+            assert key in rec
+        assert rec["fields"] == {}
+
+    @pytest.mark.unit
+    def test_malformed_octave_does_not_raise(self) -> None:
+        """Garbage input returns a structured (empty) result, not an exception."""
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record("not octave at all :: %%% [[[")
+        assert rec["token"] is None
+        assert rec["fields"] == {}
+
+    @pytest.mark.unit
+    def test_missing_required_field_leaves_none_not_raise(self) -> None:
+        """A record missing BECAUSE still parses; absent field is None."""
+        text = _full_record().replace(
+            '  BECAUSE::"This repository owns the AGR standard and validates it."\n',
+            "",
+        )
+        parse_decision_record = _parse_decision_record()
+        rec = parse_decision_record(text)
+        assert rec["token"] == _TOKEN
+        assert rec["because"] is None
+
+
+class TestPurityAndRegexOnly:
+    @pytest.mark.unit
+    def test_parser_is_pure_no_filesystem_writes(self, tmp_path: Path) -> None:
+        """Parsing must not create/modify any file (PROD I5 pure read)."""
+        parse_decision_record = _parse_decision_record()
+        before = sorted(p.name for p in tmp_path.iterdir())
+        parse_decision_record(_full_record())
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert before == after == []
+
+    @pytest.mark.unit
+    def test_module_does_not_import_ast(self) -> None:
+        """North Star §4 / PROD I3: regex-only — no OCTAVE AST parsing.
+
+        The parser module MUST NOT pull in Python's ``ast`` module nor the
+        octave-mcp grammar package (a proxy for 'no structured OCTAVE AST
+        parsing in the read path').
+        """
+        import hestai_context_mcp.core.agent_readable_governance_parser as mod
+
+        source = mod.__file__
+        assert source is not None
+        with open(source, encoding="utf-8") as fh:
+            module_text = fh.read()
+        assert "import ast" not in module_text
+        assert "octave_mcp" not in module_text

--- a/tests/unit/tools/governance/test_agent_readable_governance_parser.py
+++ b/tests/unit/tools/governance/test_agent_readable_governance_parser.py
@@ -202,5 +202,6 @@ class TestPurityAndRegexOnly:
         assert source is not None
         with open(source, encoding="utf-8") as fh:
             module_text = fh.read()
-        assert "import ast" not in module_text
+        # Reject BOTH ``import ast`` and ``from ast import …`` (P2 hardening).
+        assert "import ast" not in module_text and "from ast " not in module_text
         assert "octave_mcp" not in module_text

--- a/tests/unit/tools/governance/test_agr_read.py
+++ b/tests/unit/tools/governance/test_agr_read.py
@@ -65,3 +65,66 @@ def test_discover_record_returns_none_when_store_absent(tmp_path: Path) -> None:
     from hestai_context_mcp.tools.governance.agr_read import discover_record
 
     assert discover_record(tmp_path, "HO-CONTEXT-MCP-ANY-20260601") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "evil_token",
+    [
+        "../../../etc/passwd",
+        "../secret",
+        "..",
+        ".hestai/decisions/x",
+        "HO-X-20260101/../../../etc/passwd",
+        "/etc/passwd",
+    ],
+)
+def test_discover_record_rejects_traversal_token_without_path_join(
+    tmp_path: Path, evil_token: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """P1 SECURITY: a traversal-shaped token is rejected BEFORE any path join.
+
+    ``discover_record`` validates the token against the §1.3 regex at the very
+    top, so a token containing ``/``, ``.`` or ``..`` returns ``None`` and never
+    constructs ``root / f"{token}.oct.md"`` nor globs it. We plant a file OUTSIDE
+    the decisions tree and monkeypatch ``Path.exists``/``Path.read_text`` to fail
+    loudly if any out-of-tree path is touched — proving no escape occurs.
+    """
+    from hestai_context_mcp.tools.governance import agr_read
+
+    decisions = tmp_path / ".hestai" / "decisions"
+    decisions.mkdir(parents=True, exist_ok=True)
+    # A real AGR planted OUTSIDE the decisions tree — must never be reached.
+    outside = tmp_path / ".hestai" / "OUTSIDE.oct.md"
+    outside.write_text(
+        "===DECISION_RECORD===\nMETA:\n  TYPE::DECISION_RECORD\n"
+        "  TOKEN::HO-CONTEXT-MCP-OUTSIDE-20260101\n===END===\n",
+        encoding="utf-8",
+    )
+
+    decisions_resolved = decisions.resolve()
+    real_read_text = Path.read_text
+
+    def guarded_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        resolved = self.resolve()
+        # Any read must stay within the decisions tree.
+        assert str(resolved).startswith(
+            str(decisions_resolved)
+        ), f"path escape — discover_record read outside decisions tree: {resolved}"
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    result = agr_read.discover_record(tmp_path, evil_token)
+    assert result is None  # rejected by the §1.3 guard, no escape
+
+
+@pytest.mark.unit
+def test_is_valid_token_rejects_traversal_shapes() -> None:
+    """The §1.3 TOKEN regex admits no path-traversal metacharacters."""
+    from hestai_context_mcp.tools.governance.agr_read import is_valid_token
+
+    for evil in ("../../../etc/passwd", "../secret", "..", "a/b", "/etc/passwd"):
+        assert is_valid_token(evil) is False
+    # A well-formed token still validates.
+    assert is_valid_token("HO-CONTEXT-MCP-OK-20260101") is True

--- a/tests/unit/tools/governance/test_agr_read.py
+++ b/tests/unit/tools/governance/test_agr_read.py
@@ -1,0 +1,67 @@
+"""Locator/marker test for the shared AGR read primitive.
+
+``tools/governance/agr_read.py`` is exercised end-to-end through the three
+public tool suites (test_lookup_decision / test_list_decisions /
+test_trace_supersedure), which is where its behaviour is asserted. This module
+exists so the test-locator finds a co-located test for the shared module and to
+pin its public surface (a smoke import) — it adds no behavioural assertions
+beyond what the tool suites already cover.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_shared_read_surface_importable() -> None:
+    """The shared primitive exposes the envelope + discovery helpers."""
+    from hestai_context_mcp.tools.governance.agr_read import (
+        TOKEN_FORMAT_RE,
+        discover_record,
+        error_envelope,
+        validate_working_dir,
+    )
+
+    assert TOKEN_FORMAT_RE is not None
+    assert callable(discover_record)
+    assert callable(error_envelope)
+    assert callable(validate_working_dir)
+
+
+@pytest.mark.unit
+def test_discover_record_falls_back_to_embedded_token(tmp_path: Path) -> None:
+    """A record whose FILENAME drifted from its TOKEN still resolves (§1.1).
+
+    Path-first resolution misses (filename != token), so discovery falls back to
+    scanning the store and matching the embedded TOKEN via the Gate-A extractor.
+    This exercises the fallback branch the canonical-filename fixtures bypass.
+    """
+    from hestai_context_mcp.tools.governance.agr_read import discover_record
+
+    token = "HO-CONTEXT-MCP-FILENAME-DRIFT-20260601"
+    decisions = tmp_path / ".hestai" / "decisions"
+    decisions.mkdir(parents=True, exist_ok=True)
+    # Filename deliberately does NOT match the embedded TOKEN.
+    (decisions / "renamed-by-hand.oct.md").write_text(
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        f"  TOKEN::{token}\n"
+        "===END===\n",
+        encoding="utf-8",
+    )
+
+    found = discover_record(tmp_path, token)
+    assert found is not None
+    assert found.name == "renamed-by-hand.oct.md"
+
+
+@pytest.mark.unit
+def test_discover_record_returns_none_when_store_absent(tmp_path: Path) -> None:
+    """No .hestai/decisions store => discovery returns None (defensive guard)."""
+    from hestai_context_mcp.tools.governance.agr_read import discover_record
+
+    assert discover_record(tmp_path, "HO-CONTEXT-MCP-ANY-20260601") is None

--- a/tests/unit/tools/governance/test_list_decisions.py
+++ b/tests/unit/tools/governance/test_list_decisions.py
@@ -258,6 +258,40 @@ class TestCoLocatedNonAgrFiles:
         assert tokens == [_T3, _T1]  # sorted authored_at DESC
 
     @pytest.mark.unit
+    def test_suffixed_type_field_does_not_falsely_qualify(self, tmp_path: Path) -> None:
+        """CRS P2 (same class as F1): a non-AGR whose META carries a
+        ``*TYPE::DECISION_RECORD`` line (``DOCUMENT_TYPE::`` / ``CONTENT_TYPE::``)
+        and NO ``===DECISION_RECORD===`` sentinel must be EXCLUDED, not admitted.
+
+        The pre-fix TYPE detection used an unanchored substring search, so
+        ``DOCUMENT_TYPE::DECISION_RECORD`` matched ``TYPE::DECISION_RECORD`` and
+        tripped RECORD_PARSE_FAILED. The anchored read-side check rejects it.
+        """
+        list_decisions = _list_decisions()
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        # DOCUMENT_TYPE::DECISION_RECORD — substring-leak variant.
+        write_non_agr_record(
+            tmp_path,
+            filename="doc-type-decoy.oct.md",
+            sentinel="B1_BUILD_PLAN",
+            type_field="DECISION_RECORD",
+            type_key="DOCUMENT_TYPE",
+        )
+        # CONTENT_TYPE::DECISION_RECORD — second substring-leak variant.
+        write_non_agr_record(
+            tmp_path,
+            filename="content-type-decoy.oct.md",
+            sentinel="SOME_DOC",
+            type_field="DECISION_RECORD",
+            type_key="CONTENT_TYPE",
+        )
+
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True  # NOT RECORD_PARSE_FAILED
+        assert result["total"] == 1
+        assert [r["token"] for r in result["records"]] == [_T1]
+
+    @pytest.mark.unit
     def test_only_non_agr_files_yields_empty_list(self, tmp_path: Path) -> None:
         """A store with ONLY non-AGR artefacts lists nothing (no error)."""
         list_decisions = _list_decisions()

--- a/tests/unit/tools/governance/test_list_decisions.py
+++ b/tests/unit/tools/governance/test_list_decisions.py
@@ -1,0 +1,220 @@
+"""RED suite — ``list_decisions`` MCP tool.
+
+Contract: ADR-RFC-ARCH-004 §3.3 (return shape) + §3.1.1 (error envelope).
+Pure read (PROD I5), structured return (PROD I4).
+
+Return::
+
+    {
+      "ok": true,
+      "records": [{token, status, tier, decision, authored_at, path}, ...],
+      "total": <int>
+    }
+
+sorted by authored_at DESCENDING. Optional scope/status/tier filters.
+FILTER_INVALID for a bad enum, WORKING_DIR_INVALID for a bad path,
+RECORD_PARSE_FAILED fails the WHOLE call (no silent drop) per §3.3.
+
+RED: ``tools.list_decisions`` does not exist yet — import raises
+ModuleNotFoundError.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from ._agr_fixtures import (
+    snapshot_tree,
+    write_malformed_record,
+    write_record,
+)
+
+
+def _list_decisions() -> Callable[..., dict]:
+    """Lazily import the not-yet-existing tool (RED discipline).
+
+    Import-inside-test keeps COLLECTION green and yields a per-test
+    'missing implementation' failure. GREEN creates
+    ``tools.list_decisions.list_decisions``.
+    """
+    from hestai_context_mcp.tools.list_decisions import list_decisions
+
+    return list_decisions
+
+
+_T1 = "HO-CONTEXT-MCP-LIST-ONE-20260101"
+_T2 = "HO-CONTEXT-MCP-LIST-TWO-20260201"
+_T3 = "HO-CONTEXT-MCP-LIST-THREE-20260301"
+
+
+def _seed_three(tmp_path: Path) -> None:
+    """Three records spanning statuses/tiers/scopes for filter + sort tests."""
+    write_record(
+        tmp_path,
+        token=_T1,
+        status="RATIFIED",
+        tier="STRATEGIC",
+        authored_at="2026-01-01T00:00:00Z",
+        scope="hestai-context-mcp",
+    )
+    write_record(
+        tmp_path,
+        token=_T2,
+        status="SUPERSEDED",
+        tier="TACTICAL",
+        authored_at="2026-02-01T00:00:00Z",
+        scope="elevana-studio",
+        superseded_by=_T3,
+    )
+    write_record(
+        tmp_path,
+        token=_T3,
+        status="RATIFIED",
+        tier="OPERATIONAL",
+        authored_at="2026-03-01T00:00:00Z",
+        scope="hestai-context-mcp",
+    )
+
+
+class TestHappyPath:
+    @pytest.mark.unit
+    def test_lists_all_records_sorted_desc(self, tmp_path: Path) -> None:
+        """§3.3: records sorted by authored_at DESC, total reflects count."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        assert result["total"] == 3
+        tokens = [r["token"] for r in result["records"]]
+        # Newest first.
+        assert tokens == [_T3, _T2, _T1]
+
+    @pytest.mark.unit
+    def test_record_summary_shape(self, tmp_path: Path) -> None:
+        """Each entry exposes exactly the §3.3 summary fields."""
+        list_decisions = _list_decisions()
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        result = list_decisions(str(tmp_path))
+        entry = result["records"][0]
+        assert set(entry.keys()) == {
+            "token",
+            "status",
+            "tier",
+            "decision",
+            "authored_at",
+            "path",
+        }
+        assert entry["path"] == f".hestai/decisions/{_T1}.oct.md"
+
+    @pytest.mark.unit
+    def test_empty_store_returns_empty_list(self, tmp_path: Path) -> None:
+        """No records => ok with empty list and total 0 (not an error)."""
+        list_decisions = _list_decisions()
+        (tmp_path / ".hestai" / "decisions").mkdir(parents=True, exist_ok=True)
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        assert result["records"] == []
+        assert result["total"] == 0
+
+
+class TestFilters:
+    @pytest.mark.unit
+    def test_status_filter(self, tmp_path: Path) -> None:
+        """status filter narrows to matching records only."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), status="RATIFIED")
+        assert result["ok"] is True
+        assert {r["token"] for r in result["records"]} == {_T1, _T3}
+        assert result["total"] == 2
+
+    @pytest.mark.unit
+    def test_tier_filter(self, tmp_path: Path) -> None:
+        """tier filter narrows by semantic-gravity tier."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), tier="TACTICAL")
+        assert [r["token"] for r in result["records"]] == [_T2]
+
+    @pytest.mark.unit
+    def test_scope_filter_exact_match(self, tmp_path: Path) -> None:
+        """scope filter matches the SCOPE field exactly (§3.3)."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), scope="elevana-studio")
+        assert [r["token"] for r in result["records"]] == [_T2]
+
+    @pytest.mark.unit
+    def test_combined_filters(self, tmp_path: Path) -> None:
+        """status + scope filters compose conjunctively."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), status="RATIFIED", scope="hestai-context-mcp")
+        assert {r["token"] for r in result["records"]} == {_T1, _T3}
+
+
+class TestErrorEnvelope:
+    def _assert_envelope(self, result: dict, code: str, category: str) -> None:
+        assert result["ok"] is False
+        err = result["error"]
+        assert err["code"] == code
+        assert err["category"] == category
+        assert err["tool"] == "list_decisions"
+        assert isinstance(err["message"], str) and err["message"]
+        assert isinstance(err["context"], dict)
+        assert err["contract_ref"].startswith("ADR-RFC-ARCH-004 §3")
+
+    @pytest.mark.unit
+    def test_filter_invalid_status(self, tmp_path: Path) -> None:
+        """A non-enum status => FILTER_INVALID with field+value context (§3.3)."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), status="BOGUS")
+        self._assert_envelope(result, "FILTER_INVALID", "input_validation")
+        assert result["error"]["context"]["field"] == "status"
+        assert result["error"]["context"]["value"] == "BOGUS"
+
+    @pytest.mark.unit
+    def test_filter_invalid_tier(self, tmp_path: Path) -> None:
+        """A non-enum tier => FILTER_INVALID."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path), tier="HUGE")
+        self._assert_envelope(result, "FILTER_INVALID", "input_validation")
+        assert result["error"]["context"]["field"] == "tier"
+
+    @pytest.mark.unit
+    def test_working_dir_invalid(self, tmp_path: Path) -> None:
+        """Non-existent working_dir => WORKING_DIR_INVALID."""
+        list_decisions = _list_decisions()
+        result = list_decisions(str(tmp_path / "nope"))
+        self._assert_envelope(result, "WORKING_DIR_INVALID", "io_failure")
+
+    @pytest.mark.unit
+    def test_record_parse_failed_fails_whole_call(self, tmp_path: Path) -> None:
+        """§3.3: a single unparseable record fails the WHOLE call, no silent drop.
+
+        Consumers MUST be able to detect that the list is incomplete; the tool
+        therefore returns the error envelope rather than dropping the bad file.
+        """
+        list_decisions = _list_decisions()
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        write_malformed_record(tmp_path)
+        result = list_decisions(str(tmp_path))
+        self._assert_envelope(result, "RECORD_PARSE_FAILED", "schema_violation")
+
+
+class TestPurity:
+    @pytest.mark.unit
+    def test_list_is_pure_no_mutation(self, tmp_path: Path) -> None:
+        """PROD I5: list_decisions performs zero writes/mutations."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        before = snapshot_tree(tmp_path)
+        list_decisions(str(tmp_path))
+        list_decisions(str(tmp_path), status="RATIFIED")
+        after = snapshot_tree(tmp_path)
+        assert before == after

--- a/tests/unit/tools/governance/test_list_decisions.py
+++ b/tests/unit/tools/governance/test_list_decisions.py
@@ -29,6 +29,7 @@ import pytest
 from ._agr_fixtures import (
     snapshot_tree,
     write_malformed_record,
+    write_non_agr_record,
     write_record,
 )
 
@@ -205,6 +206,92 @@ class TestErrorEnvelope:
         write_malformed_record(tmp_path)
         result = list_decisions(str(tmp_path))
         self._assert_envelope(result, "RECORD_PARSE_FAILED", "schema_violation")
+
+
+class TestCoLocatedNonAgrFiles:
+    """F1 (CIV NO-GO regression): ``.hestai/decisions/`` co-hosts non-AGR
+    governance artefacts (BUILD_PLAN, SECURITY_DESIGN_REVIEW, arbitration
+    records) per ADR-RFC-ARCH-001. They are OUT OF SCOPE and must be skipped
+    silently — never RECORD_PARSE_FAILED — while genuinely-malformed AGRs still
+    error.
+    """
+
+    @pytest.mark.unit
+    def test_non_agr_files_excluded_not_errored(self, tmp_path: Path) -> None:
+        """Real AGRs are listed; co-located non-AGRs are silently skipped."""
+        list_decisions = _list_decisions()
+        # Two valid DECISION_RECORDs.
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        write_record(tmp_path, token=_T3, authored_at="2026-03-01T00:00:00Z")
+        # A correctly-placed BUILD_PLAN (DOCUMENT_TYPE convention, no TOKEN).
+        write_non_agr_record(
+            tmp_path,
+            filename="BUILD-PLAN.oct.md",
+            sentinel="B1_BUILD_PLAN",
+            type_field="BUILD_PLAN",
+            type_key="DOCUMENT_TYPE",
+            group="phase-pss-b1",
+        )
+        # A no-TYPE arbitration record (no TYPE line at all).
+        write_non_agr_record(
+            tmp_path,
+            filename="arbitration-1.oct.md",
+            sentinel="B1_GATE_ARBITRATION_RECORD",
+            type_field=None,
+            group="phase-pss-b1",
+        )
+        # A SECURITY_DESIGN_REVIEW (declares TYPE, but not DECISION_RECORD) in a
+        # nested subdir.
+        write_non_agr_record(
+            tmp_path,
+            filename="issue-43-redaction-design.oct.md",
+            sentinel="REDACTION_DESIGN_REVIEW",
+            type_field="SECURITY_DESIGN_REVIEW",
+            group="security",
+        )
+
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        # Only the two real AGRs are listed — non-AGRs excluded entirely.
+        assert result["total"] == 2
+        tokens = [r["token"] for r in result["records"]]
+        assert tokens == [_T3, _T1]  # sorted authored_at DESC
+
+    @pytest.mark.unit
+    def test_only_non_agr_files_yields_empty_list(self, tmp_path: Path) -> None:
+        """A store with ONLY non-AGR artefacts lists nothing (no error)."""
+        list_decisions = _list_decisions()
+        write_non_agr_record(
+            tmp_path,
+            filename="BUILD-PLAN.oct.md",
+            sentinel="B1_BUILD_PLAN",
+            type_field="BUILD_PLAN",
+            type_key="DOCUMENT_TYPE",
+        )
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        assert result["records"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.unit
+    def test_malformed_agr_still_errors_amid_non_agrs(self, tmp_path: Path) -> None:
+        """§3.3 protection intact: an is-an-AGR-but-broken record errors even when
+        co-located non-AGRs are present (the non-AGRs are not what trips it)."""
+        list_decisions = _list_decisions()
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        write_non_agr_record(
+            tmp_path,
+            filename="BUILD-PLAN.oct.md",
+            sentinel="B1_BUILD_PLAN",
+            type_field="BUILD_PLAN",
+            type_key="DOCUMENT_TYPE",
+        )
+        write_malformed_record(tmp_path)  # declares DECISION_RECORD, missing fields
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is False
+        assert result["error"]["code"] == "RECORD_PARSE_FAILED"
+        # The failing path is the broken AGR, not the legitimately-typed non-AGR.
+        assert "MALFORMED" in result["error"]["context"]["path"]
 
 
 class TestPurity:

--- a/tests/unit/tools/governance/test_lookup_decision.py
+++ b/tests/unit/tools/governance/test_lookup_decision.py
@@ -33,6 +33,7 @@ from ._agr_fixtures import (
     TOKEN_RATIFIED,
     snapshot_tree,
     write_malformed_record,
+    write_non_agr_record,
     write_record,
     write_supersession_chain,
 )
@@ -173,6 +174,33 @@ class TestErrorEnvelope:
         missing = tmp_path / "does-not-exist"
         result = lookup_decision(str(missing), TOKEN_RATIFIED)
         self._assert_envelope(result, "WORKING_DIR_INVALID", "io_failure")
+
+
+class TestCoLocatedNonAgrFiles:
+    """F1 (CIV NO-GO regression): a co-located non-AGR must never resolve as a
+    record. A token that only matches a non-AGR is TOKEN_NOT_FOUND, not a hit.
+    """
+
+    @pytest.mark.unit
+    def test_token_matching_only_a_non_agr_is_not_found(self, tmp_path: Path) -> None:
+        """A non-AGR whose filename embeds a valid-format token does not resolve.
+
+        We name a BUILD_PLAN with a DECISION_RECORD-looking filename token; since
+        the file is not a DECISION_RECORD (wrong sentinel/type, no TOKEN field),
+        discover_record must reject it and lookup must return TOKEN_NOT_FOUND.
+        """
+        lookup_decision = _lookup_decision()
+        decoy_token = "HO-CONTEXT-MCP-DECOY-NONAGR-20260601"
+        write_non_agr_record(
+            tmp_path,
+            filename=f"{decoy_token}.oct.md",
+            sentinel="B1_BUILD_PLAN",
+            type_field="BUILD_PLAN",
+            type_key="DOCUMENT_TYPE",
+        )
+        result = lookup_decision(str(tmp_path), decoy_token)
+        assert result["ok"] is False
+        assert result["error"]["code"] == "TOKEN_NOT_FOUND"
 
 
 class TestPurity:

--- a/tests/unit/tools/governance/test_lookup_decision.py
+++ b/tests/unit/tools/governance/test_lookup_decision.py
@@ -1,0 +1,194 @@
+"""RED suite — ``lookup_decision`` MCP tool.
+
+Contract: ADR-RFC-ARCH-004 §3.2 (return shape) + §3.1.1 (common error
+envelope). Pure read (PROD I5), structured return (PROD I4).
+
+Happy path returns::
+
+    {
+      "ok": true,
+      "record": {token, type, version, status, tier, decision, because,
+                 authored_at, path, fields{}},
+      "resolution_chain": [ ... ]   # populated when STATUS == SUPERSEDED
+    }
+
+Error envelope (§3.1.1) for TOKEN_NOT_FOUND, TOKEN_MALFORMED,
+RECORD_PARSE_FAILED, WORKING_DIR_INVALID.
+
+RED: ``tools.lookup_decision`` does not exist yet — import raises
+ModuleNotFoundError (right-reason failure, not a collection error).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from ._agr_fixtures import (
+    TOKEN_MID,
+    TOKEN_NEW,
+    TOKEN_OLD,
+    TOKEN_RATIFIED,
+    snapshot_tree,
+    write_malformed_record,
+    write_record,
+    write_supersession_chain,
+)
+
+
+def _lookup_decision() -> Callable[..., dict]:
+    """Lazily import the not-yet-existing tool (RED discipline).
+
+    The import lives inside each test so COLLECTION succeeds and every test
+    FAILS individually with a 'missing implementation' reason rather than a
+    module-level collection error masking the file. GREEN creates
+    ``tools.lookup_decision.lookup_decision``.
+    """
+    from hestai_context_mcp.tools.lookup_decision import lookup_decision
+
+    return lookup_decision
+
+
+class TestHappyPath:
+    @pytest.mark.unit
+    def test_returns_full_record_shape(self, tmp_path: Path) -> None:
+        """§3.2 return shape: ok + record with every defined field + chain."""
+        lookup_decision = _lookup_decision()
+        write_record(
+            tmp_path,
+            token=TOKEN_RATIFIED,
+            status="RATIFIED",
+            tier="STRATEGIC",
+            authored_at="2026-06-01T00:00:00Z",
+            decision="A binding decision sentence.",
+            because="A one-sentence rationale.",
+            scope="hestai-context-mcp",
+        )
+        result = lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+
+        assert result["ok"] is True
+        rec = result["record"]
+        assert rec["token"] == TOKEN_RATIFIED
+        assert rec["type"] == "DECISION_RECORD"
+        assert rec["version"] == "1.0"
+        assert rec["status"] == "RATIFIED"
+        assert rec["tier"] == "STRATEGIC"
+        assert rec["decision"] == "A binding decision sentence."
+        assert rec["because"] == "A one-sentence rationale."
+        assert rec["authored_at"] == "2026-06-01T00:00:00Z"
+        # path is repo-relative (§3.2).
+        assert rec["path"] == f".hestai/decisions/{TOKEN_RATIFIED}.oct.md"
+        assert isinstance(rec["fields"], dict)
+        assert rec["fields"].get("SCOPE") == "hestai-context-mcp"
+        # Non-superseded record => empty resolution_chain.
+        assert result["resolution_chain"] == []
+
+    @pytest.mark.unit
+    def test_audience_defaults_to_agent(self, tmp_path: Path) -> None:
+        """``audience`` is optional and defaults to 'agent' (§3.2).
+
+        Omitting audience must succeed and yield the agent-shape record;
+        passing audience='agent' explicitly yields the identical record.
+        """
+        lookup_decision = _lookup_decision()
+        write_record(tmp_path, token=TOKEN_RATIFIED)
+        default = lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+        explicit = lookup_decision(str(tmp_path), TOKEN_RATIFIED, audience="agent")
+        assert default["record"] == explicit["record"]
+
+    @pytest.mark.unit
+    def test_resolves_record_under_subgroup(self, tmp_path: Path) -> None:
+        """§1.1: a token under .hestai/decisions/<group>/ resolves identically."""
+        lookup_decision = _lookup_decision()
+        write_record(tmp_path, token=TOKEN_RATIFIED, group="rfc-arch")
+        result = lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+        assert result["ok"] is True
+        assert result["record"]["path"] == (f".hestai/decisions/rfc-arch/{TOKEN_RATIFIED}.oct.md")
+
+
+class TestResolutionChain:
+    @pytest.mark.unit
+    def test_chain_populated_when_superseded(self, tmp_path: Path) -> None:
+        """STATUS==SUPERSEDED populates resolution_chain (§3.2)."""
+        lookup_decision = _lookup_decision()
+        write_supersession_chain(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_OLD)
+        assert result["ok"] is True
+        assert result["record"]["status"] == "SUPERSEDED"
+        chain_tokens = [entry["token"] for entry in result["resolution_chain"]]
+        # Chain starts at the requested token and walks to the terminal.
+        assert chain_tokens == [TOKEN_OLD, TOKEN_MID, TOKEN_NEW]
+
+
+class TestErrorEnvelope:
+    def _assert_envelope(self, result: dict, code: str, category: str) -> None:
+        """§3.1.1 envelope assertions shared across error cases."""
+        assert result["ok"] is False
+        err = result["error"]
+        assert err["code"] == code
+        assert err["category"] == category
+        assert err["tool"] == "lookup_decision"
+        assert isinstance(err["message"], str) and err["message"]
+        assert isinstance(err["context"], dict)
+        assert err["contract_ref"].startswith("ADR-RFC-ARCH-004 §3")
+
+    @pytest.mark.unit
+    def test_token_not_found(self, tmp_path: Path) -> None:
+        """Well-formed token with no record => TOKEN_NOT_FOUND."""
+        lookup_decision = _lookup_decision()
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True, exist_ok=True)
+        result = lookup_decision(str(tmp_path), "HO-CONTEXT-MCP-ABSENT-20260101")
+        self._assert_envelope(result, "TOKEN_NOT_FOUND", "input_validation")
+        assert result["error"]["context"]["token"] == "HO-CONTEXT-MCP-ABSENT-20260101"
+
+    @pytest.mark.unit
+    def test_token_malformed(self, tmp_path: Path) -> None:
+        """A token failing the §1.3 regex => TOKEN_MALFORMED (not NOT_FOUND)."""
+        lookup_decision = _lookup_decision()
+        result = lookup_decision(str(tmp_path), "not a valid token")
+        self._assert_envelope(result, "TOKEN_MALFORMED", "input_validation")
+
+    @pytest.mark.unit
+    def test_record_parse_failed_is_fatal_not_skipped(self, tmp_path: Path) -> None:
+        """A discoverable-but-unparseable record => RECORD_PARSE_FAILED (§3.2).
+
+        Implementation choice in the ADR: treat as fatal for the read; do NOT
+        silently skip. context.path is populated.
+        """
+        lookup_decision = _lookup_decision()
+        path = write_malformed_record(tmp_path)
+        # Look it up by its (valid-format) filename token.
+        token = path.stem.replace(".oct", "")
+        result = lookup_decision(str(tmp_path), token)
+        self._assert_envelope(result, "RECORD_PARSE_FAILED", "schema_violation")
+        assert "path" in result["error"]["context"]
+
+    @pytest.mark.unit
+    def test_working_dir_invalid(self, tmp_path: Path) -> None:
+        """A non-existent working_dir => WORKING_DIR_INVALID (io_failure)."""
+        lookup_decision = _lookup_decision()
+        missing = tmp_path / "does-not-exist"
+        result = lookup_decision(str(missing), TOKEN_RATIFIED)
+        self._assert_envelope(result, "WORKING_DIR_INVALID", "io_failure")
+
+
+class TestPurity:
+    @pytest.mark.unit
+    def test_lookup_is_pure_no_mutation(self, tmp_path: Path) -> None:
+        """PROD I5: lookup_decision performs zero writes/mutations.
+
+        Snapshot every file's (mtime_ns, size) before and after the call; the
+        tree must be byte-identical. A MANIFEST side-write or any mutation
+        fails the suite.
+        """
+        lookup_decision = _lookup_decision()
+        write_record(tmp_path, token=TOKEN_RATIFIED)
+        write_supersession_chain(tmp_path)
+        before = snapshot_tree(tmp_path)
+        lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+        lookup_decision(str(tmp_path), TOKEN_OLD)
+        after = snapshot_tree(tmp_path)
+        assert before == after

--- a/tests/unit/tools/governance/test_trace_supersedure.py
+++ b/tests/unit/tools/governance/test_trace_supersedure.py
@@ -1,0 +1,193 @@
+"""RED suite — ``trace_supersedure`` MCP tool.
+
+Contract: ADR-RFC-ARCH-004 §3.4 (return shape) + §3.1.1 (error envelope).
+Pure read (PROD I5), structured return (PROD I4).
+
+Return::
+
+    {
+      "ok": true,
+      "chain": [{token, status, authored_at, superseded_by, path}, ...],
+      "terminal_token": "<end token>",
+      "terminal_status": "PROPOSED" | "RATIFIED" | "VOID"
+    }
+
+The chain starts at the requested token and follows SUPERSEDED_BY pointers to a
+record whose SUPERSEDED_BY is null. A terminal token yields a single-entry
+chain. Errors: TOKEN_NOT_FOUND, CHAIN_BROKEN, CHAIN_CYCLE_DETECTED (MUST fail
+closed, not infinite-loop), WORKING_DIR_INVALID.
+
+RED: ``tools.trace_supersedure`` does not exist yet — import raises
+ModuleNotFoundError.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from ._agr_fixtures import (
+    TOKEN_BROKEN,
+    TOKEN_CYCLE_A,
+    TOKEN_MID,
+    TOKEN_MISSING,
+    TOKEN_NEW,
+    TOKEN_OLD,
+    TOKEN_RATIFIED,
+    snapshot_tree,
+    write_broken_chain,
+    write_cyclic_pair,
+    write_record,
+    write_supersession_chain,
+)
+
+
+def _trace_supersedure() -> Callable[..., dict]:
+    """Lazily import the not-yet-existing tool (RED discipline).
+
+    Import-inside-test keeps COLLECTION green and yields a per-test
+    'missing implementation' failure. GREEN creates
+    ``tools.trace_supersedure.trace_supersedure``.
+    """
+    from hestai_context_mcp.tools.trace_supersedure import trace_supersedure
+
+    return trace_supersedure
+
+
+class TestHappyPath:
+    @pytest.mark.unit
+    def test_full_chain_shape(self, tmp_path: Path) -> None:
+        """§3.4: chain walks OLD->MID->NEW; terminal fields reflect the end."""
+        trace_supersedure = _trace_supersedure()
+        write_supersession_chain(tmp_path)
+        result = trace_supersedure(str(tmp_path), TOKEN_OLD)
+        assert result["ok"] is True
+
+        chain = result["chain"]
+        assert [e["token"] for e in chain] == [TOKEN_OLD, TOKEN_MID, TOKEN_NEW]
+
+        # Per-entry shape (§3.4).
+        first = chain[0]
+        assert set(first.keys()) == {
+            "token",
+            "status",
+            "authored_at",
+            "superseded_by",
+            "path",
+        }
+        assert first["superseded_by"] == TOKEN_MID
+        assert first["path"] == f".hestai/decisions/{TOKEN_OLD}.oct.md"
+
+        # Terminal: never SUPERSEDED; superseded_by null on the last entry.
+        assert chain[-1]["superseded_by"] is None
+        assert result["terminal_token"] == TOKEN_NEW
+        assert result["terminal_status"] == "RATIFIED"
+
+    @pytest.mark.unit
+    def test_single_entry_chain_when_terminal(self, tmp_path: Path) -> None:
+        """A record with no SUPERSEDED_BY yields a one-entry chain (§3.4)."""
+        trace_supersedure = _trace_supersedure()
+        write_record(tmp_path, token=TOKEN_RATIFIED, status="RATIFIED")
+        result = trace_supersedure(str(tmp_path), TOKEN_RATIFIED)
+        assert result["ok"] is True
+        assert len(result["chain"]) == 1
+        assert result["terminal_token"] == TOKEN_RATIFIED
+        assert result["chain"][0]["superseded_by"] is None
+
+    @pytest.mark.unit
+    def test_mid_chain_start_truncates_to_remaining(self, tmp_path: Path) -> None:
+        """Starting at a mid-chain token traces from there to the terminal."""
+        trace_supersedure = _trace_supersedure()
+        write_supersession_chain(tmp_path)
+        result = trace_supersedure(str(tmp_path), TOKEN_MID)
+        assert [e["token"] for e in result["chain"]] == [TOKEN_MID, TOKEN_NEW]
+        assert result["terminal_token"] == TOKEN_NEW
+
+
+class TestErrorEnvelope:
+    def _assert_envelope(self, result: dict, code: str, category: str) -> None:
+        assert result["ok"] is False
+        err = result["error"]
+        assert err["code"] == code
+        assert err["category"] == category
+        assert err["tool"] == "trace_supersedure"
+        assert isinstance(err["message"], str) and err["message"]
+        assert isinstance(err["context"], dict)
+        assert err["contract_ref"].startswith("ADR-RFC-ARCH-004 §3")
+
+    @pytest.mark.unit
+    def test_token_not_found(self, tmp_path: Path) -> None:
+        """A missing START token => TOKEN_NOT_FOUND (§3.4)."""
+        trace_supersedure = _trace_supersedure()
+        (tmp_path / ".hestai" / "decisions").mkdir(parents=True, exist_ok=True)
+        result = trace_supersedure(str(tmp_path), TOKEN_MISSING)
+        self._assert_envelope(result, "TOKEN_NOT_FOUND", "input_validation")
+
+    @pytest.mark.unit
+    def test_chain_broken_distinct_from_not_found(self, tmp_path: Path) -> None:
+        """A mid-chain SUPERSEDED_BY pointing at a missing TOKEN => CHAIN_BROKEN.
+
+        §3.4 keeps this DISTINCT from TOKEN_NOT_FOUND so consumers can tell
+        missing-start from missing-middle. Context names both the broken-at
+        token and the missing successor.
+        """
+        trace_supersedure = _trace_supersedure()
+        write_broken_chain(tmp_path)
+        result = trace_supersedure(str(tmp_path), TOKEN_BROKEN)
+        self._assert_envelope(result, "CHAIN_BROKEN", "schema_violation")
+        ctx = result["error"]["context"]
+        assert ctx["broken_at_token"] == TOKEN_BROKEN
+        assert ctx["missing_successor_token"] == TOKEN_MISSING
+
+    @pytest.mark.unit
+    def test_chain_cycle_detected_fails_closed(self, tmp_path: Path) -> None:
+        """§3.4: a SUPERSEDED_BY cycle MUST fail closed, never infinite-loop.
+
+        The two-record cycle A->B->A must terminate with CHAIN_CYCLE_DETECTED
+        and name the revisited token. Loop-safety is enforced HARD: the call
+        runs in a worker thread with a bounded join. If GREEN ever regresses
+        into an unbounded walk, the join times out and the test FAILS loudly
+        instead of hanging CI.
+        """
+        import threading
+
+        trace_supersedure = _trace_supersedure()
+        write_cyclic_pair(tmp_path)
+
+        box: dict[str, dict] = {}
+
+        def _run() -> None:
+            box["result"] = trace_supersedure(str(tmp_path), TOKEN_CYCLE_A)
+
+        worker = threading.Thread(target=_run, daemon=True)
+        worker.start()
+        worker.join(timeout=5.0)
+        assert not worker.is_alive(), (
+            "trace_supersedure did not terminate on a cyclic chain within 5s "
+            "— it must fail closed (CHAIN_CYCLE_DETECTED), never infinite-loop."
+        )
+
+        result = box["result"]
+        self._assert_envelope(result, "CHAIN_CYCLE_DETECTED", "schema_violation")
+        assert "cycle_at_token" in result["error"]["context"]
+
+    @pytest.mark.unit
+    def test_working_dir_invalid(self, tmp_path: Path) -> None:
+        """Non-existent working_dir => WORKING_DIR_INVALID."""
+        trace_supersedure = _trace_supersedure()
+        result = trace_supersedure(str(tmp_path / "absent"), TOKEN_OLD)
+        self._assert_envelope(result, "WORKING_DIR_INVALID", "io_failure")
+
+
+class TestPurity:
+    @pytest.mark.unit
+    def test_trace_is_pure_no_mutation(self, tmp_path: Path) -> None:
+        """PROD I5: trace_supersedure performs zero writes/mutations."""
+        trace_supersedure = _trace_supersedure()
+        write_supersession_chain(tmp_path)
+        before = snapshot_tree(tmp_path)
+        trace_supersedure(str(tmp_path), TOKEN_OLD)
+        after = snapshot_tree(tmp_path)
+        assert before == after

--- a/tests/unit/tools/governance/test_trace_supersedure.py
+++ b/tests/unit/tools/governance/test_trace_supersedure.py
@@ -126,6 +126,49 @@ class TestErrorEnvelope:
         self._assert_envelope(result, "TOKEN_NOT_FOUND", "input_validation")
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "evil_token", ["../../../etc/passwd", "../secret", "..", "/etc/passwd"]
+    )
+    def test_traversal_token_is_not_found_no_escape(self, tmp_path: Path, evil_token: str) -> None:
+        """P1 SECURITY: trace_supersedure does NOT pre-validate the token, so the
+        path-traversal guard MUST live in discover_record. A traversal-shaped
+        token yields the clean TOKEN_NOT_FOUND envelope, no exception, and no
+        out-of-tree access.
+
+        A real AGR is planted OUTSIDE the decisions tree; if the guard were
+        missing, ``root / "../OUTSIDE.oct.md"`` could escape — here it must not
+        resolve. ``Path.read_text`` is guarded to fail loudly on any escape.
+        """
+        trace_supersedure = _trace_supersedure()
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True, exist_ok=True)
+        outside = tmp_path / ".hestai" / "OUTSIDE.oct.md"
+        outside.write_text(
+            "===DECISION_RECORD===\nMETA:\n  TYPE::DECISION_RECORD\n"
+            "  TOKEN::HO-CONTEXT-MCP-OUTSIDE-20260101\n  STATUS::RATIFIED\n"
+            '  TIER::STRATEGIC\n  AUTHORED_AT::"2026-01-01T00:00:00Z"\n'
+            '  DECISION::"x"\n  BECAUSE::"y"\n===END===\n',
+            encoding="utf-8",
+        )
+
+        decisions_resolved = decisions.resolve()
+        real_read_text = Path.read_text
+
+        def guarded_read_text(self: Path, *args: object, **kwargs: object) -> str:
+            resolved = self.resolve()
+            assert str(resolved).startswith(
+                str(decisions_resolved)
+            ), f"path escape — trace_supersedure read outside tree: {resolved}"
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(Path, "read_text", guarded_read_text)
+            result = trace_supersedure(str(tmp_path), evil_token)
+
+        # Clean envelope, no exception, no escape.
+        self._assert_envelope(result, "TOKEN_NOT_FOUND", "input_validation")
+
+    @pytest.mark.unit
     def test_chain_broken_distinct_from_not_found(self, tmp_path: Path) -> None:
         """A mid-chain SUPERSEDED_BY pointing at a missing TOKEN => CHAIN_BROKEN.
 

--- a/tests/unit/tools/test_list_decisions.py
+++ b/tests/unit/tools/test_list_decisions.py
@@ -2,16 +2,19 @@
 
 The authoritative suite lives at
 ``tests/unit/tools/governance/test_list_decisions.py`` (TMG-confirmed
-existing-neighbor convention, ruling (d)). This module re-exports it so a
-``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
-assertions and duplicates nothing.
+existing-neighbor convention, ruling (d)). A ``tools/``-path test-locator/gate
+derives the expected test path from the source module
+(``src/hestai_context_mcp/tools/list_decisions.py`` →
+``tests/unit/tools/test_list_decisions.py``); this file satisfies that path.
+
+It uses a MODULE-ALIAS import (not ``from … import Test*``) so the authoritative
+``Test*`` classes are NOT re-bound into this module's namespace — pytest
+therefore collects them EXACTLY once (in their home module), with no duplicate
+collection and no risk of silently dropping a class (the previous explicit
+import list omitted ``TestCoLocatedNonAgrFiles``; an alias import cannot drop
+anything).
 """
 
 from __future__ import annotations
 
-from tests.unit.tools.governance.test_list_decisions import (  # noqa: F401
-    TestErrorEnvelope,
-    TestFilters,
-    TestHappyPath,
-    TestPurity,
-)
+import tests.unit.tools.governance.test_list_decisions as _list_decisions_tests  # noqa: F401

--- a/tests/unit/tools/test_list_decisions.py
+++ b/tests/unit/tools/test_list_decisions.py
@@ -1,0 +1,17 @@
+"""Test-locator shim for ``list_decisions``.
+
+The authoritative suite lives at
+``tests/unit/tools/governance/test_list_decisions.py`` (TMG-confirmed
+existing-neighbor convention, ruling (d)). This module re-exports it so a
+``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
+assertions and duplicates nothing.
+"""
+
+from __future__ import annotations
+
+from tests.unit.tools.governance.test_list_decisions import (  # noqa: F401
+    TestErrorEnvelope,
+    TestFilters,
+    TestHappyPath,
+    TestPurity,
+)

--- a/tests/unit/tools/test_lookup_decision.py
+++ b/tests/unit/tools/test_lookup_decision.py
@@ -2,16 +2,17 @@
 
 The authoritative suite lives at
 ``tests/unit/tools/governance/test_lookup_decision.py`` (TMG-confirmed
-existing-neighbor convention, ruling (d)). This module re-exports it so a
-``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
-assertions and duplicates nothing.
+existing-neighbor convention, ruling (d)). A ``tools/``-path test-locator/gate
+derives the expected test path from the source module
+(``src/hestai_context_mcp/tools/lookup_decision.py`` →
+``tests/unit/tools/test_lookup_decision.py``); this file satisfies that path.
+
+It uses a MODULE-ALIAS import (not ``from … import Test*``) so the authoritative
+``Test*`` classes are NOT re-bound into this module's namespace — pytest
+therefore collects them EXACTLY once (in their home module), with no duplicate
+collection and no risk of silently dropping a class from an explicit import list.
 """
 
 from __future__ import annotations
 
-from tests.unit.tools.governance.test_lookup_decision import (  # noqa: F401
-    TestErrorEnvelope,
-    TestHappyPath,
-    TestPurity,
-    TestResolutionChain,
-)
+import tests.unit.tools.governance.test_lookup_decision as _lookup_decision_tests  # noqa: F401

--- a/tests/unit/tools/test_lookup_decision.py
+++ b/tests/unit/tools/test_lookup_decision.py
@@ -1,0 +1,17 @@
+"""Test-locator shim for ``lookup_decision``.
+
+The authoritative suite lives at
+``tests/unit/tools/governance/test_lookup_decision.py`` (TMG-confirmed
+existing-neighbor convention, ruling (d)). This module re-exports it so a
+``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
+assertions and duplicates nothing.
+"""
+
+from __future__ import annotations
+
+from tests.unit.tools.governance.test_lookup_decision import (  # noqa: F401
+    TestErrorEnvelope,
+    TestHappyPath,
+    TestPurity,
+    TestResolutionChain,
+)

--- a/tests/unit/tools/test_trace_supersedure.py
+++ b/tests/unit/tools/test_trace_supersedure.py
@@ -2,15 +2,17 @@
 
 The authoritative suite lives at
 ``tests/unit/tools/governance/test_trace_supersedure.py`` (TMG-confirmed
-existing-neighbor convention, ruling (d)). This module re-exports it so a
-``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
-assertions and duplicates nothing.
+existing-neighbor convention, ruling (d)). A ``tools/``-path test-locator/gate
+derives the expected test path from the source module
+(``src/hestai_context_mcp/tools/trace_supersedure.py`` →
+``tests/unit/tools/test_trace_supersedure.py``); this file satisfies that path.
+
+It uses a MODULE-ALIAS import (not ``from … import Test*``) so the authoritative
+``Test*`` classes are NOT re-bound into this module's namespace — pytest
+therefore collects them EXACTLY once (in their home module), with no duplicate
+collection.
 """
 
 from __future__ import annotations
 
-from tests.unit.tools.governance.test_trace_supersedure import (  # noqa: F401
-    TestErrorEnvelope,
-    TestHappyPath,
-    TestPurity,
-)
+import tests.unit.tools.governance.test_trace_supersedure as _trace_supersedure_tests  # noqa: F401

--- a/tests/unit/tools/test_trace_supersedure.py
+++ b/tests/unit/tools/test_trace_supersedure.py
@@ -1,0 +1,16 @@
+"""Test-locator shim for ``trace_supersedure``.
+
+The authoritative suite lives at
+``tests/unit/tools/governance/test_trace_supersedure.py`` (TMG-confirmed
+existing-neighbor convention, ruling (d)). This module re-exports it so a
+``tools/``-path test-locator (and pytest) discovers it here too; it adds NO new
+assertions and duplicates nothing.
+"""
+
+from __future__ import annotations
+
+from tests.unit.tools.governance.test_trace_supersedure import (  # noqa: F401
+    TestErrorEnvelope,
+    TestHappyPath,
+    TestPurity,
+)


### PR DESCRIPTION
Closes #83. Implements the **read half** of Agent-Readable Governance Records (RFC #40), per the ratified **ADR-RFC-ARCH-004 §3.2–3.4**. The AGR registry was write-only (`submit_governance` authors records; nothing could query them) — this adds the three pure-read MCP tools + parser.

## What changed

- **`AgentReadableGovernanceParser`** (`core/agent_readable_governance_parser.py`) — mirrors `north_star_parser` (regex-only, pure, graceful on malformed; no AST, no octave-mcp, no LLM in the read path).
- **`lookup_decision(working_dir, token, audience?)`** → structured record + resolution_chain when SUPERSEDED (§3.2).
- **`list_decisions(working_dir, scope?, status?, tier?)`** → filtered list, sorted `authored_at` DESC (§3.3).
- **`trace_supersedure(working_dir, token)`** → supersession chain with fail-closed cycle/broken-chain detection (§3.4).
- Shared `tools/governance/agr_read.py` primitive (envelope, validation, discovery, chain walk) — reuses `manifest`/`lexer`/`lineage`/`type_checker`, no rebuild.
- `server.py` — registers the three tools (additive; `get_context` untouched).

## Governance conformance

- **PROD I4** — structured dicts + §3.1.1 common error envelope; never blobs.
- **PROD I5** — pure reads, zero side effects (independently proven via SHA-256/mtime snapshot diff; `get_context` unmodified).
- **North Star §4** — regex field extraction only (octave-mcp owns format).
- Records read from `.hestai/decisions/` (committed git), never PSS.

## TDD + T3 gate chain (all green)

<!-- Review Gate canonical verdicts (HEAD 298e9ce) -->
CE GO: Architecture sound — thin contract-shapers over the shared agr_read primitive (reuses manifest/lexer/lineage/type_checker); additive server.py registration, get_context (PROD I5) untouched; TEST_167 guard intact; v1 no-paging is ADR §3.3-mandated (#84).
CIV GO: P1 path-traversal closed at the discover_record chokepoint (§1.3 regex guard before any path join) — verified across 6 attack shapes + the second-order SUPERSEDED_BY vector with an out-of-tree read detector (zero escapes) and a mutation test; 143 governance tests green, F1 scoping + I5 purity preserved, coverage >=85%.
CRS APPROVED: Closes the reachable path-traversal fix-the-class at the discover_record chokepoint (token guard before any path join, all callers incl. the recursive chain-walker), mutation-proven regression tests, correct P2-ast/P3-shim fixes — no coverage loss, no behavioral regression, gates green.
TMG APPROVED: RED suite is a contract-faithful methodology gate — §3.2-3.4 return shapes + §3.1.1 error envelope pinned verbatim, genuine PROD I5 purity diff, regex-only parser guard, cycle test thread-bounded/fail-closed; all enumerated error paths covered, >=85% reachable.


## Verification

- `1281 passed, 2 deselected` (2 = pre-existing #66 `clock_in` AI-env flake, unrelated — touches zero AGR code).
- Coverage: parser / lookup / list / trace **100%**, shared `agr_read` **93%** — all ≥85% (CI gate).
- `ruff` / `black --check` / `mypy src` clean.
- Live-store proof: `list_decisions('.') → ok:True, total:3` (the three real DECISION_RECORD AGRs; non-AGRs excluded).

## Out of scope (deferred, tracked)

- `propose_decision_amendment` write broker (§3.5 — OPTIONAL), `decisions.index.json` projection, `validate_agr` CLI (§4) — separate increments.
- **#84** — `list_decisions` v1.1 paging (trigger at ~hundreds of records).
- **#85** — Gate-A `_TYPE_RE` write-side anchoring (root of the read-side P2).

Post-merge: `PROJECT-CONTEXT.oct.md` TOOLS list to be updated via octave-secretary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AGR read side (RFC #40) with a regex-only parser and three pure-read tools to look up, list, and trace governance decisions. Also hardens discovery against path traversal and tidies tests/CI.

- **New Features**
  - `core/agent_readable_governance_parser.py`: pure regex extraction of DECISION_RECORD core fields + `fields{}`.
  - Tools: `lookup_decision`, `list_decisions`, `trace_supersedure` with structured returns and common error envelope.
  - Shared `tools/governance/agr_read.py`: working dir + token validation, record discovery, chain walker.
  - `server.py`: registers the three tools (additive; pure reads).

- **Bug Fixes**
  - Scope reads to true DECISION_RECORDs; exclude co-located non-AGR `.oct.md` (e.g., BUILD_PLAN, security reviews).
  - Line-anchored `TYPE::DECISION_RECORD` check to reject `DOCUMENT_TYPE::`/`CONTENT_TYPE::` decoys.
  - Deterministic fallback discovery via sorted `rglob`; verify embedded TOKEN matches.
  - Security: validate TOKEN in `discover_record` before any path join/glob to prevent traversal (protects `trace_supersedure` too).
  - Tests/CI: avoid duplicate test collection via module-alias shims; add GitGuardian ignore for fake TOKEN fixtures.

<sup>Written for commit 298e9ce26137b55f0675891dbc8a8437837530bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


