### PR TITLE
feat(governance): add ISSUE_REF shape validation to Gate A type checke

### DIFF
--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -60,7 +60,7 @@ _ISSUE_REF_LINE_RE = re.compile(r"(?m)^[ \t]*ISSUE_REF::(.*)$")
 # ISSUE_REF shape per ADR-RFC-ARCH-004 §4.1 invariant #10: accepts ONLY the two
 # valid forms — the repo:<repo-id>#<n> shorthand or a GitHub issue URL.
 _ISSUE_REF_SHAPE_RE = re.compile(
-    r"^(?:repo:[A-Za-z0-9_-]+#[0-9]+|https://github\.com/[^/\s]+/[^/\s]+/issues/[0-9]+)$"
+    r"^(?:repo:[A-Za-z0-9_-]+#[0-9]+|https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/issues/[0-9]+)$"
 )
 
 # TOKEN format validation per ADR-RFC-ARCH-004 §1.3

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -54,13 +54,13 @@ _SUPERSEDED_BY_RE = re.compile(r'SUPERSEDED_BY::"([^"]+)"')
 # ISSUE_REF field: quote-optional, line-anchored (consistent with _TOKEN_RE).
 # Group 1 holds the quoted value, group 2 the bare value; the end-anchor (\s*$)
 # lives OUTSIDE the alternation so BOTH branches reject trailing garbage.
-_ISSUE_REF_RE = re.compile(r'(?m)ISSUE_REF::(?:"([^"]+)"|([^"\s]+))\s*$')
+_ISSUE_REF_RE = re.compile(r'(?m)^\s*ISSUE_REF::(?:"([^"]+)"|([^"\s]+))\s*$')
 
 # ISSUE_REF presence detector: matches ANY line that starts with ISSUE_REF::
 # (with optional leading whitespace). Used alongside _ISSUE_REF_RE to detect the
 # trailing-garbage bypass: if this matches but _ISSUE_REF_RE does not, the line
 # is present-but-malformed and must be reported as an error.
-_ISSUE_REF_LINE_PRESENT_RE = re.compile(r"(?m)^\s*ISSUE_REF::")
+_ISSUE_REF_LINE_PRESENT_RE = re.compile(r"(?m)^[ \t]*ISSUE_REF::")
 
 # ISSUE_REF shape per ADR-RFC-ARCH-004 §4.1 invariant #10: accepts ONLY the two
 # valid forms — the repo:<repo-id>#<n> shorthand or a GitHub issue URL.
@@ -335,13 +335,25 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
     # GitHub issue URL or the repo:<repo-id>#<n> shorthand. Collect alongside
     # other errors (no early return), mirroring the SUPERSEDED_BY check.
     #
-    # Bypass fix: _ISSUE_REF_RE uses \s*$ end-anchoring so trailing garbage
-    # causes it to return None — making check 5a a no-op for a malformed line.
-    # The presence detector (_ISSUE_REF_LINE_PRESENT_RE) catches this: if an
-    # ISSUE_REF:: line exists but strict extraction returned None the line is
+    # Duplicate-field guard: count all ISSUE_REF:: line occurrences. If more
+    # than one exists that is already a structural error (duplicate optional
+    # field) — _ISSUE_REF_RE.search() would silently skip a malformed first
+    # line and extract the second, letting the malformed line go undetected.
+    #
+    # Bypass fix: _ISSUE_REF_RE uses ^\s*...\s*$ anchoring so trailing garbage
+    # causes it to return None — making the shape check a no-op for a malformed
+    # line. The presence detector (_ISSUE_REF_LINE_PRESENT_RE) catches this: if
+    # an ISSUE_REF:: line exists but strict extraction returned None the line is
     # present-but-malformed and we emit a named error (ADR-RFC-ARCH-004 §4.1 #10).
     issue_ref = _extract_issue_ref(content)
-    if issue_ref is not None and not _ISSUE_REF_SHAPE_RE.match(issue_ref):
+    issue_ref_line_count = len(_ISSUE_REF_LINE_PRESENT_RE.findall(content))
+    if issue_ref_line_count > 1:
+        errors.append(
+            "ISSUE_REF field appears multiple times; expected at most one "
+            "(ADR-RFC-ARCH-004 §4.1 #10)."
+        )
+        # Continue to collect more errors
+    elif issue_ref is not None and not _ISSUE_REF_SHAPE_RE.fullmatch(issue_ref):
         errors.append(
             f"ISSUE_REF '{issue_ref}' does not match a valid shape. "
             "ISSUE_REF must be a GitHub issue URL "
@@ -349,7 +361,7 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
             "repo:<repo-id>#<n> shorthand (ADR-RFC-ARCH-004 §4.1 #10)."
         )
         # Continue to collect more errors
-    elif issue_ref is None and _ISSUE_REF_LINE_PRESENT_RE.search(content):
+    elif issue_ref is None and issue_ref_line_count == 1:
         errors.append(
             "ISSUE_REF line is present but could not be parsed. "
             "ISSUE_REF must be one of: "

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -51,6 +51,17 @@ _ID_QUOTED_RE = re.compile(r'(?m)^  ID::(?:"([^"]+)"|([^"\s]+))\s*$')
 # SUPERSEDED_BY field: quoted string
 _SUPERSEDED_BY_RE = re.compile(r'SUPERSEDED_BY::"([^"]+)"')
 
+# ISSUE_REF field: quote-optional, line-anchored (consistent with _TOKEN_RE).
+# Group 1 holds the quoted value, group 2 the bare value; the end-anchor (\s*$)
+# lives OUTSIDE the alternation so BOTH branches reject trailing garbage.
+_ISSUE_REF_RE = re.compile(r'(?m)ISSUE_REF::(?:"([^"]+)"|([^"\s]+))\s*$')
+
+# ISSUE_REF shape per ADR-RFC-ARCH-004 §4.1 invariant #10: accepts ONLY the two
+# valid forms — the repo:<repo-id>#<n> shorthand or a GitHub issue URL.
+_ISSUE_REF_SHAPE_RE = re.compile(
+    r"^(?:repo:[A-Za-z0-9_-]+#[0-9]+|https://github\.com/[^/\s]+/[^/\s]+/issues/[0-9]+)$"
+)
+
 # TOKEN format validation per ADR-RFC-ARCH-004 §1.3
 # ^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$
 _TOKEN_FORMAT_RE = re.compile(r"^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$")
@@ -137,6 +148,18 @@ def _extract_superseded_by(content: str) -> str | None:
     m = _SUPERSEDED_BY_RE.search(content)
     if m:
         return m.group(1)
+    return None
+
+
+def _extract_issue_ref(content: str) -> str | None:
+    """Extract the ISSUE_REF field if present, quote-optional.
+
+    Group 1 holds the quoted value, group 2 the bare value; exactly one is set.
+    Returns None when no ISSUE_REF line is present (the field is optional).
+    """
+    m = _ISSUE_REF_RE.search(content)
+    if m:
+        return m.group(1) if m.group(1) is not None else m.group(2)
     return None
 
 
@@ -298,6 +321,20 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
         errors.append(
             f"SUPERSEDED_BY target '{superseded_by}' not found in governance store. "
             "The referenced TOKEN must exist before it can be superseded."
+        )
+        # Continue to collect more errors
+
+    # --- Check 5a: ISSUE_REF shape (ADR-RFC-ARCH-004 §4.1 invariant #10) ---
+    # ISSUE_REF is OPTIONAL: absence is valid. When present, it MUST parse as a
+    # GitHub issue URL or the repo:<repo-id>#<n> shorthand. Collect alongside
+    # other errors (no early return), mirroring the SUPERSEDED_BY check.
+    issue_ref = _extract_issue_ref(content)
+    if issue_ref is not None and not _ISSUE_REF_SHAPE_RE.match(issue_ref):
+        errors.append(
+            f"ISSUE_REF '{issue_ref}' does not match a valid shape. "
+            "ISSUE_REF must be a GitHub issue URL "
+            "(https://github.com/<org>/<repo>/issues/<n>) or the "
+            "repo:<repo-id>#<n> shorthand (ADR-RFC-ARCH-004 §4.1 #10)."
         )
         # Continue to collect more errors
 

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -51,16 +51,11 @@ _ID_QUOTED_RE = re.compile(r'(?m)^  ID::(?:"([^"]+)"|([^"\s]+))\s*$')
 # SUPERSEDED_BY field: quoted string
 _SUPERSEDED_BY_RE = re.compile(r'SUPERSEDED_BY::"([^"]+)"')
 
-# ISSUE_REF field: quote-optional, line-anchored (consistent with _TOKEN_RE).
-# Group 1 holds the quoted value, group 2 the bare value; the end-anchor (\s*$)
-# lives OUTSIDE the alternation so BOTH branches reject trailing garbage.
-_ISSUE_REF_RE = re.compile(r'(?m)^\s*ISSUE_REF::(?:"([^"]+)"|([^"\s]+))\s*$')
-
-# ISSUE_REF presence detector: matches ANY line that starts with ISSUE_REF::
-# (with optional leading whitespace). Used alongside _ISSUE_REF_RE to detect the
-# trailing-garbage bypass: if this matches but _ISSUE_REF_RE does not, the line
-# is present-but-malformed and must be reported as an error.
-_ISSUE_REF_LINE_PRESENT_RE = re.compile(r"(?m)^[ \t]*ISSUE_REF::")
+# ISSUE_REF field: greedy line capture (horizontal whitespace anchor only —
+# no ReDoS risk, no extractor/presence-detector asymmetry).
+# Captures everything after ISSUE_REF:: to end-of-line; shape validation is
+# done separately after quote-stripping so trailing garbage is always detected.
+_ISSUE_REF_LINE_RE = re.compile(r"(?m)^[ \t]*ISSUE_REF::(.*)$")
 
 # ISSUE_REF shape per ADR-RFC-ARCH-004 §4.1 invariant #10: accepts ONLY the two
 # valid forms — the repo:<repo-id>#<n> shorthand or a GitHub issue URL.
@@ -158,15 +153,20 @@ def _extract_superseded_by(content: str) -> str | None:
 
 
 def _extract_issue_ref(content: str) -> str | None:
-    """Extract the ISSUE_REF field if present, quote-optional.
+    """Extract and normalise the ISSUE_REF value if exactly one line is present.
 
-    Group 1 holds the quoted value, group 2 the bare value; exactly one is set.
-    Returns None when no ISSUE_REF line is present (the field is optional).
+    Uses the greedy _ISSUE_REF_LINE_RE so trailing garbage is captured (not
+    silently dropped).  Returns the quote-stripped value, or None when no
+    ISSUE_REF line exists.  Callers that need the raw line count should use
+    _ISSUE_REF_LINE_RE.findall() directly.
     """
-    m = _ISSUE_REF_RE.search(content)
-    if m:
-        return m.group(1) if m.group(1) is not None else m.group(2)
-    return None
+    matches = _ISSUE_REF_LINE_RE.findall(content)
+    if len(matches) != 1:
+        return None
+    raw = matches[0].strip()
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        raw = raw[1:-1]
+    return raw or None
 
 
 def _extract_repo_id(content: str) -> str | None:
@@ -331,45 +331,28 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
         # Continue to collect more errors
 
     # --- Check 5a: ISSUE_REF shape (ADR-RFC-ARCH-004 §4.1 invariant #10) ---
-    # ISSUE_REF is OPTIONAL: absence is valid. When present, it MUST parse as a
-    # GitHub issue URL or the repo:<repo-id>#<n> shorthand. Collect alongside
-    # other errors (no early return), mirroring the SUPERSEDED_BY check.
-    #
-    # Duplicate-field guard: count all ISSUE_REF:: line occurrences. If more
-    # than one exists that is already a structural error (duplicate optional
-    # field) — _ISSUE_REF_RE.search() would silently skip a malformed first
-    # line and extract the second, letting the malformed line go undetected.
-    #
-    # Bypass fix: _ISSUE_REF_RE uses ^\s*...\s*$ anchoring so trailing garbage
-    # causes it to return None — making the shape check a no-op for a malformed
-    # line. The presence detector (_ISSUE_REF_LINE_PRESENT_RE) catches this: if
-    # an ISSUE_REF:: line exists but strict extraction returned None the line is
-    # present-but-malformed and we emit a named error (ADR-RFC-ARCH-004 §4.1 #10).
-    issue_ref = _extract_issue_ref(content)
-    issue_ref_line_count = len(_ISSUE_REF_LINE_PRESENT_RE.findall(content))
-    if issue_ref_line_count > 1:
+    # ISSUE_REF is OPTIONAL: absence (zero matching lines) is valid.
+    # _ISSUE_REF_LINE_RE is greedy — it always captures the full raw value
+    # including trailing garbage, so shape validation catches every malformed
+    # form without a separate presence detector.
+    issue_ref_raw_lines = _ISSUE_REF_LINE_RE.findall(content)
+    if len(issue_ref_raw_lines) > 1:
         errors.append(
             "ISSUE_REF field appears multiple times; expected at most one "
             "(ADR-RFC-ARCH-004 §4.1 #10)."
         )
         # Continue to collect more errors
-    elif issue_ref is not None and not _ISSUE_REF_SHAPE_RE.fullmatch(issue_ref):
-        errors.append(
-            f"ISSUE_REF '{issue_ref}' does not match a valid shape. "
-            "ISSUE_REF must be a GitHub issue URL "
-            "(https://github.com/<org>/<repo>/issues/<n>) or the "
-            "repo:<repo-id>#<n> shorthand (ADR-RFC-ARCH-004 §4.1 #10)."
-        )
-        # Continue to collect more errors
-    elif issue_ref is None and issue_ref_line_count == 1:
-        errors.append(
-            "ISSUE_REF line is present but could not be parsed. "
-            "ISSUE_REF must be one of: "
-            'ISSUE_REF::"repo:<repo-id>#<n>" or ISSUE_REF::<repo-id>#<n> '
-            "(bare) or a GitHub issue URL. "
-            "Remove trailing content or correct the value "
-            "(ADR-RFC-ARCH-004 §4.1 #10)."
-        )
+    elif len(issue_ref_raw_lines) == 1:
+        raw = issue_ref_raw_lines[0].strip()
+        if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+            raw = raw[1:-1]
+        if not raw or not _ISSUE_REF_SHAPE_RE.fullmatch(raw):
+            errors.append(
+                f"ISSUE_REF '{raw}' does not match a valid shape. "
+                "ISSUE_REF must be a GitHub issue URL "
+                "(https://github.com/<org>/<repo>/issues/<n>) or the "
+                "repo:<repo-id>#<n> shorthand (ADR-RFC-ARCH-004 §4.1 #10)."
+            )
         # Continue to collect more errors
 
     # --- Check 6: Token uniqueness (must NOT already exist for new records) ---

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -56,6 +56,12 @@ _SUPERSEDED_BY_RE = re.compile(r'SUPERSEDED_BY::"([^"]+)"')
 # lives OUTSIDE the alternation so BOTH branches reject trailing garbage.
 _ISSUE_REF_RE = re.compile(r'(?m)ISSUE_REF::(?:"([^"]+)"|([^"\s]+))\s*$')
 
+# ISSUE_REF presence detector: matches ANY line that starts with ISSUE_REF::
+# (with optional leading whitespace). Used alongside _ISSUE_REF_RE to detect the
+# trailing-garbage bypass: if this matches but _ISSUE_REF_RE does not, the line
+# is present-but-malformed and must be reported as an error.
+_ISSUE_REF_LINE_PRESENT_RE = re.compile(r"(?m)^\s*ISSUE_REF::")
+
 # ISSUE_REF shape per ADR-RFC-ARCH-004 §4.1 invariant #10: accepts ONLY the two
 # valid forms — the repo:<repo-id>#<n> shorthand or a GitHub issue URL.
 _ISSUE_REF_SHAPE_RE = re.compile(
@@ -328,6 +334,12 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
     # ISSUE_REF is OPTIONAL: absence is valid. When present, it MUST parse as a
     # GitHub issue URL or the repo:<repo-id>#<n> shorthand. Collect alongside
     # other errors (no early return), mirroring the SUPERSEDED_BY check.
+    #
+    # Bypass fix: _ISSUE_REF_RE uses \s*$ end-anchoring so trailing garbage
+    # causes it to return None — making check 5a a no-op for a malformed line.
+    # The presence detector (_ISSUE_REF_LINE_PRESENT_RE) catches this: if an
+    # ISSUE_REF:: line exists but strict extraction returned None the line is
+    # present-but-malformed and we emit a named error (ADR-RFC-ARCH-004 §4.1 #10).
     issue_ref = _extract_issue_ref(content)
     if issue_ref is not None and not _ISSUE_REF_SHAPE_RE.match(issue_ref):
         errors.append(
@@ -335,6 +347,16 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
             "ISSUE_REF must be a GitHub issue URL "
             "(https://github.com/<org>/<repo>/issues/<n>) or the "
             "repo:<repo-id>#<n> shorthand (ADR-RFC-ARCH-004 §4.1 #10)."
+        )
+        # Continue to collect more errors
+    elif issue_ref is None and _ISSUE_REF_LINE_PRESENT_RE.search(content):
+        errors.append(
+            "ISSUE_REF line is present but could not be parsed. "
+            "ISSUE_REF must be one of: "
+            'ISSUE_REF::"repo:<repo-id>#<n>" or ISSUE_REF::<repo-id>#<n> '
+            "(bare) or a GitHub issue URL. "
+            "Remove trailing content or correct the value "
+            "(ADR-RFC-ARCH-004 §4.1 #10)."
         )
         # Continue to collect more errors
 

--- a/tests/unit/tools/governance/test_bare_canonical.py
+++ b/tests/unit/tools/governance/test_bare_canonical.py
@@ -358,3 +358,122 @@ class TestLexerTrailingGarbageRejected:
             _decision_record_raw_token_line(f'TOKEN::"{_VALID_TOKEN}"')
         )
         assert lookup_token_deterministic(tmp_path, _VALID_TOKEN) is True
+
+
+# ---------------------------------------------------------------------------
+# ISSUE_REF shape validation (ADR-RFC-ARCH-004 §4.1 invariant #10)
+#
+# "ISSUE_REF shape — when present, parses as a GitHub URL or repo:<repo-id>#<n>."
+# (ADR line 86: "GitHub issue URL or repo:<repo-id>#<n> shorthand. Optional on
+#  PROPOSED/RATIFIED ...")
+#
+# ISSUE_REF is OPTIONAL: absence MUST remain valid. Only a PRESENT-but-malformed
+# value is rejected, and it is collected alongside other errors (it does NOT
+# early-return), mirroring the SUPERSEDED_BY collect-more-errors pattern.
+# ---------------------------------------------------------------------------
+
+# Valid §1.3 TOKEN used as the "wrong shape" injected into ISSUE_REF. It is a
+# legal decision-TOKEN but NOT a legal ISSUE_REF — exactly the elevana-studio
+# dogfood finding (a decision-TOKEN leaked into ISSUE_REF and Gate A passed it
+# silently because ISSUE_REF was never validated). Referenced via a constant so
+# secret scanners do not read the keyword+literal adjacency as a credential.
+_DECISION_TOKEN_IN_ISSUE_REF = "HO-CONTEXT-MCP-TEST-20260513"
+_VALID_ISSUE_REF_SHORTHAND = "repo:hestai-context-mcp#77"
+_VALID_ISSUE_REF_URL = "https://github.com/elevanaltd/hestai-context-mcp/issues/53"
+# A §1.3-valid TOKEN for the host DECISION_RECORD (kept distinct from the
+# ISSUE_REF payload so a failure points unambiguously at ISSUE_REF).
+_ISSUE_REF_HOST_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-HOST-20260613"
+
+
+def _decision_record_with_issue_ref(token: str, issue_ref: str | None) -> str:
+    """Build a well-formed DECISION_RECORD, optionally carrying an ISSUE_REF.
+
+    When ``issue_ref`` is None the ISSUE_REF line is omitted entirely (the
+    optional-field case). The TOKEN is quoted (already covered by the bare
+    tests); the focus here is solely the ISSUE_REF shape.
+    """
+    issue_ref_line = f'  ISSUE_REF::"{issue_ref}"\n' if issue_ref is not None else ""
+    return (
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        '  VERSION::"1.0"\n'
+        f'  TOKEN::"{token}"\n'
+        "  STATUS::PROPOSED\n"
+        "  TIER::OPERATIONAL\n"
+        f"{issue_ref_line}"
+        '  DECISION::"ISSUE_REF shape validation."\n'
+        '  BECAUSE::"ADR-RFC-ARCH-004 §4.1 invariant #10."\n'
+        '  AUTHORED_AT::"2026-06-13T00:00:00Z"\n'
+        "===END===\n"
+    )
+
+
+class TestTypeCheckerIssueRefShape:
+    @pytest.mark.unit
+    def test_issue_ref_holding_decision_token_rejected(self, tmp_path: Path) -> None:
+        """A decision-TOKEN in ISSUE_REF is rejected (the dogfood finding).
+
+        ISSUE_REF::"HO-...-20260513" is a valid TOKEN but NOT a valid ISSUE_REF.
+        """
+        content = _decision_record_with_issue_ref(
+            _ISSUE_REF_HOST_TOKEN, _DECISION_TOKEN_IN_ISSUE_REF
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        assert any("ISSUE_REF" in e for e in result.errors), result.errors
+        # The bad value must be named in the error for operator diagnosis.
+        assert any(_DECISION_TOKEN_IN_ISSUE_REF in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_issue_ref_repo_shorthand_accepted(self, tmp_path: Path) -> None:
+        """ISSUE_REF::"repo:<repo-id>#<n>" passes the ISSUE_REF shape check."""
+        content = _decision_record_with_issue_ref(_ISSUE_REF_HOST_TOKEN, _VALID_ISSUE_REF_SHORTHAND)
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
+        assert not any("ISSUE_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_issue_ref_github_url_accepted(self, tmp_path: Path) -> None:
+        """ISSUE_REF::"https://github.com/<org>/<repo>/issues/<n>" passes."""
+        content = _decision_record_with_issue_ref(_ISSUE_REF_HOST_TOKEN, _VALID_ISSUE_REF_URL)
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
+        assert not any("ISSUE_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_issue_ref_absent_is_valid(self, tmp_path: Path) -> None:
+        """ISSUE_REF is OPTIONAL: a record with no ISSUE_REF field is valid."""
+        content = _decision_record_with_issue_ref(_ISSUE_REF_HOST_TOKEN, None)
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
+        assert not any("ISSUE_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_real_ratified_record_with_issue_ref_still_validates(self, tmp_path: Path) -> None:
+        """Regression: a real RATIFIED AGR with a valid shorthand ISSUE_REF validates.
+
+        Mirrors the on-disk record
+        .hestai/decisions/HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611.oct.md
+        (ISSUE_REF::"repo:hestai-context-mcp#77"). Reproduced inline (TOKEN
+        localised so the uniqueness check on tmp_path stays clean).
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            "  TOKEN::HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611\n"
+            "  STATUS::RATIFIED\n"
+            "  TIER::TACTICAL\n"
+            '  AUTHORED_AT::"2026-06-11T00:00:00Z"\n'
+            '  RATIFIED_BY::"human:operator"\n'
+            '  RATIFIED_AT::"2026-06-11T00:00:00Z"\n'
+            f'  ISSUE_REF::"{_VALID_ISSUE_REF_SHORTHAND}"\n'
+            '  SCOPE::"hestai-context-mcp"\n'
+            '  DECISION::"Scoped semantic reviewer at analysis tier."\n'
+            '  BECAUSE::"Semantic second opinion catches what the human misses."\n'
+            "===END===\n"
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors

--- a/tests/unit/tools/governance/test_bare_canonical.py
+++ b/tests/unit/tools/governance/test_bare_canonical.py
@@ -482,11 +482,10 @@ class TestTypeCheckerIssueRefShape:
 # ---------------------------------------------------------------------------
 # ISSUE_REF trailing-garbage rejection (ADR-RFC-ARCH-004 §4.1 #10)
 #
-# _ISSUE_REF_RE end-anchors (\s*$) reject trailing garbage at the regex level,
-# but that means _extract_issue_ref returns None for a malformed line, and check
-# 5a (``if issue_ref is not None``) silently skips it.  A presence detector must
-# close this bypass: if any ISSUE_REF:: line exists in content but strict
-# extraction fails, Gate A must emit a named error.
+# _ISSUE_REF_LINE_RE is greedy: it captures everything after ISSUE_REF:: to
+# end-of-line, including trailing garbage.  Shape validation always runs on the
+# captured raw value, so no separate presence detector is needed and no bypass
+# class exists.
 # ---------------------------------------------------------------------------
 
 
@@ -522,15 +521,11 @@ class TestTypeCheckerIssueRefTrailingGarbageRejected:
     def test_issue_ref_trailing_garbage_quoted_rejected(self, tmp_path: Path) -> None:
         """ISSUE_REF::"repo:..#77" EXTRA must fail validation (quoted + trailing garbage).
 
-        When a quoted ISSUE_REF line has trailing content the end-anchor causes
-        _ISSUE_REF_RE to not match, _extract_issue_ref returns None, and check 5a
-        is skipped -- the malformed line silently passes Gate A.  The presence
-        detector must catch this and return valid=False with a named ISSUE_REF error.
+        The greedy _ISSUE_REF_LINE_RE captures the full raw value including the
+        trailing content; shape validation then rejects it.
         """
         raw = f'ISSUE_REF::"{_VALID_ISSUE_REF_SHORTHAND}" trailing-garbage'
-        content = _decision_record_with_raw_issue_ref_line(
-            _ISSUE_REF_TRAILING_HOST_TOKEN, raw
-        )
+        content = _decision_record_with_raw_issue_ref_line(_ISSUE_REF_TRAILING_HOST_TOKEN, raw)
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False, "Expected invalid: quoted ISSUE_REF with trailing garbage"
         assert any("ISSUE_REF" in e for e in result.errors), result.errors
@@ -539,26 +534,23 @@ class TestTypeCheckerIssueRefTrailingGarbageRejected:
     def test_issue_ref_trailing_garbage_bare_rejected(self, tmp_path: Path) -> None:
         """ISSUE_REF::repo:..#77 EXTRA must fail validation (bare + trailing garbage).
 
-        Same bypass as the quoted form: bare ISSUE_REF line with trailing content
-        causes _ISSUE_REF_RE to not match, extraction returns None, check 5a
-        skips.  The presence detector must emit a named ISSUE_REF error.
+        The greedy _ISSUE_REF_LINE_RE captures the full raw value; the trailing
+        content causes shape validation to fail.
         """
         raw = f"ISSUE_REF::{_VALID_ISSUE_REF_SHORTHAND} trailing-garbage"
-        content = _decision_record_with_raw_issue_ref_line(
-            _ISSUE_REF_TRAILING_HOST_TOKEN, raw
-        )
+        content = _decision_record_with_raw_issue_ref_line(_ISSUE_REF_TRAILING_HOST_TOKEN, raw)
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False, "Expected invalid: bare ISSUE_REF with trailing garbage"
         assert any("ISSUE_REF" in e for e in result.errors), result.errors
 
 
 # ---------------------------------------------------------------------------
-# Fix 1 — Line-start anchor on _ISSUE_REF_RE (CE + TMG + CRS)
+# Prefix-anchor guard (CE + TMG + CRS)
 #
 # A string like ``NOT_ISSUE_REF::"repo:x#1"`` must NOT be treated as an
-# ISSUE_REF field.  Without a ``^\s*`` start-anchor the unanchored regex
-# matches the substring ``ISSUE_REF::`` inside ``NOT_ISSUE_REF::`` and
-# extracts the value, falsely triggering ISSUE_REF shape-validation.
+# ISSUE_REF field.  _ISSUE_REF_LINE_RE is anchored to ``^[ \t]*ISSUE_REF::``
+# so only lines where ISSUE_REF:: appears at the start of the line (after
+# optional horizontal whitespace) are matched.
 # ---------------------------------------------------------------------------
 
 _NOT_FIELD_PREFIX_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-PREFIX-20260613"
@@ -569,15 +561,9 @@ class TestTypeCheckerIssueRefNotFieldPrefixNotMatched:
     def test_issue_ref_not_field_prefix_not_matched(self, tmp_path: Path) -> None:
         """NOT_ISSUE_REF:: must not be treated as an ISSUE_REF field.
 
-        Without the ``^\\s*`` anchor, ``_ISSUE_REF_RE`` matches the
-        ``ISSUE_REF::`` substring inside ``NOT_ISSUE_REF::`` and falsely
-        extracts a value.  When that value is NOT a valid ISSUE_REF shape
-        (e.g. a decision-TOKEN), the current code emits a spurious ISSUE_REF
-        shape error even though no real ISSUE_REF field is present.
-
-        After Fix 1 the regex is anchored with ``^\\s*``, so
-        ``NOT_ISSUE_REF::`` is never matched, the document validates as
-        valid=True, and no ISSUE_REF errors are emitted.
+        ``_ISSUE_REF_LINE_RE`` is anchored to ``^[ \\t]*ISSUE_REF::`` so
+        ``NOT_ISSUE_REF::`` is never matched.  The document validates as
+        valid=True with no ISSUE_REF errors.
         """
         content = (
             "===DECISION_RECORD===\n"
@@ -602,12 +588,10 @@ class TestTypeCheckerIssueRefNotFieldPrefixNotMatched:
 
 
 # ---------------------------------------------------------------------------
-# Fix 3 — Multi-line document with duplicate ISSUE_REF fields (CRS)
+# Duplicate ISSUE_REF guard (CRS)
 #
-# When a document contains two ISSUE_REF lines (first malformed, second
-# valid), ``_ISSUE_REF_RE.search()`` skips the malformed line and finds the
-# valid one, leaving the malformed line undetected.  Gate A must count all
-# ISSUE_REF:: occurrences and reject any document with more than one.
+# Gate A counts all ISSUE_REF lines via _ISSUE_REF_LINE_RE.findall() and
+# rejects any document with more than one occurrence.
 # ---------------------------------------------------------------------------
 
 _DUPLICATE_ISSUE_REF_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-DUPE-20260613"
@@ -642,4 +626,4 @@ class TestTypeCheckerIssueRefDuplicateFieldRejected:
         )
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False, "Expected invalid: duplicate ISSUE_REF fields"
-        assert any("ISSUE_REF" in e for e in result.errors), result.errors
+        assert any("multiple times" in e for e in result.errors), result.errors

--- a/tests/unit/tools/governance/test_bare_canonical.py
+++ b/tests/unit/tools/governance/test_bare_canonical.py
@@ -477,3 +477,76 @@ class TestTypeCheckerIssueRefShape:
         )
         result = validate_octave_content(tmp_path, content)
         assert result.valid, result.errors
+
+
+# ---------------------------------------------------------------------------
+# ISSUE_REF trailing-garbage rejection (ADR-RFC-ARCH-004 §4.1 #10)
+#
+# _ISSUE_REF_RE end-anchors (\s*$) reject trailing garbage at the regex level,
+# but that means _extract_issue_ref returns None for a malformed line, and check
+# 5a (``if issue_ref is not None``) silently skips it.  A presence detector must
+# close this bypass: if any ISSUE_REF:: line exists in content but strict
+# extraction fails, Gate A must emit a named error.
+# ---------------------------------------------------------------------------
+
+
+def _decision_record_with_raw_issue_ref_line(token: str, raw_issue_ref_line: str) -> str:
+    """Build a DECISION_RECORD with a caller-supplied raw ISSUE_REF field line.
+
+    ``raw_issue_ref_line`` is the exact text of the ISSUE_REF field including
+    any trailing garbage (e.g. ``ISSUE_REF::"repo:hestai-context-mcp#77" EXTRA``).
+    The two-space indent is added here.
+    """
+    return (
+        "===DECISION_RECORD===\n"
+        "META:\n"
+        "  TYPE::DECISION_RECORD\n"
+        '  VERSION::"1.0"\n'
+        f'  TOKEN::"{token}"\n'
+        "  STATUS::PROPOSED\n"
+        "  TIER::OPERATIONAL\n"
+        f"  {raw_issue_ref_line}\n"
+        '  DECISION::"ISSUE_REF trailing-garbage guard."\n'
+        '  BECAUSE::"ADR-RFC-ARCH-004 §4.1 invariant #10."\n'
+        '  AUTHORED_AT::"2026-06-13T00:00:00Z"\n'
+        "===END===\n"
+    )
+
+
+# §1.3-valid TOKEN for the host DECISION_RECORD in trailing-garbage tests.
+_ISSUE_REF_TRAILING_HOST_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-TRAILING-20260613"
+
+
+class TestTypeCheckerIssueRefTrailingGarbageRejected:
+    @pytest.mark.unit
+    def test_issue_ref_trailing_garbage_quoted_rejected(self, tmp_path: Path) -> None:
+        """ISSUE_REF::"repo:..#77" EXTRA must fail validation (quoted + trailing garbage).
+
+        When a quoted ISSUE_REF line has trailing content the end-anchor causes
+        _ISSUE_REF_RE to not match, _extract_issue_ref returns None, and check 5a
+        is skipped -- the malformed line silently passes Gate A.  The presence
+        detector must catch this and return valid=False with a named ISSUE_REF error.
+        """
+        raw = f'ISSUE_REF::"{_VALID_ISSUE_REF_SHORTHAND}" trailing-garbage'
+        content = _decision_record_with_raw_issue_ref_line(
+            _ISSUE_REF_TRAILING_HOST_TOKEN, raw
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, "Expected invalid: quoted ISSUE_REF with trailing garbage"
+        assert any("ISSUE_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_issue_ref_trailing_garbage_bare_rejected(self, tmp_path: Path) -> None:
+        """ISSUE_REF::repo:..#77 EXTRA must fail validation (bare + trailing garbage).
+
+        Same bypass as the quoted form: bare ISSUE_REF line with trailing content
+        causes _ISSUE_REF_RE to not match, extraction returns None, check 5a
+        skips.  The presence detector must emit a named ISSUE_REF error.
+        """
+        raw = f"ISSUE_REF::{_VALID_ISSUE_REF_SHORTHAND} trailing-garbage"
+        content = _decision_record_with_raw_issue_ref_line(
+            _ISSUE_REF_TRAILING_HOST_TOKEN, raw
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, "Expected invalid: bare ISSUE_REF with trailing garbage"
+        assert any("ISSUE_REF" in e for e in result.errors), result.errors

--- a/tests/unit/tools/governance/test_bare_canonical.py
+++ b/tests/unit/tools/governance/test_bare_canonical.py
@@ -550,3 +550,96 @@ class TestTypeCheckerIssueRefTrailingGarbageRejected:
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False, "Expected invalid: bare ISSUE_REF with trailing garbage"
         assert any("ISSUE_REF" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — Line-start anchor on _ISSUE_REF_RE (CE + TMG + CRS)
+#
+# A string like ``NOT_ISSUE_REF::"repo:x#1"`` must NOT be treated as an
+# ISSUE_REF field.  Without a ``^\s*`` start-anchor the unanchored regex
+# matches the substring ``ISSUE_REF::`` inside ``NOT_ISSUE_REF::`` and
+# extracts the value, falsely triggering ISSUE_REF shape-validation.
+# ---------------------------------------------------------------------------
+
+_NOT_FIELD_PREFIX_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-PREFIX-20260613"
+
+
+class TestTypeCheckerIssueRefNotFieldPrefixNotMatched:
+    @pytest.mark.unit
+    def test_issue_ref_not_field_prefix_not_matched(self, tmp_path: Path) -> None:
+        """NOT_ISSUE_REF:: must not be treated as an ISSUE_REF field.
+
+        Without the ``^\\s*`` anchor, ``_ISSUE_REF_RE`` matches the
+        ``ISSUE_REF::`` substring inside ``NOT_ISSUE_REF::`` and falsely
+        extracts a value.  When that value is NOT a valid ISSUE_REF shape
+        (e.g. a decision-TOKEN), the current code emits a spurious ISSUE_REF
+        shape error even though no real ISSUE_REF field is present.
+
+        After Fix 1 the regex is anchored with ``^\\s*``, so
+        ``NOT_ISSUE_REF::`` is never matched, the document validates as
+        valid=True, and no ISSUE_REF errors are emitted.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_NOT_FIELD_PREFIX_TOKEN}"\n'
+            "  STATUS::PROPOSED\n"
+            "  TIER::OPERATIONAL\n"
+            # Value is a decision-TOKEN shape — valid token but NOT a valid
+            # ISSUE_REF shape.  The unanchored regex extracts it from
+            # NOT_ISSUE_REF:: and emits a spurious shape error.
+            f'  NOT_ISSUE_REF::"{_DECISION_TOKEN_IN_ISSUE_REF}"\n'
+            '  DECISION::"Prefix anchor validation."\n'
+            '  BECAUSE::"ADR-RFC-ARCH-004 §4.1 #10."\n'
+            '  AUTHORED_AT::"2026-06-13T00:00:00Z"\n'
+            "===END===\n"
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is True, result.errors
+        assert not any("ISSUE_REF" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — Multi-line document with duplicate ISSUE_REF fields (CRS)
+#
+# When a document contains two ISSUE_REF lines (first malformed, second
+# valid), ``_ISSUE_REF_RE.search()`` skips the malformed line and finds the
+# valid one, leaving the malformed line undetected.  Gate A must count all
+# ISSUE_REF:: occurrences and reject any document with more than one.
+# ---------------------------------------------------------------------------
+
+_DUPLICATE_ISSUE_REF_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-DUPE-20260613"
+_DUPLICATE_ISSUE_REF_VALID = "repo:hestai-context-mcp#10"
+
+
+class TestTypeCheckerIssueRefDuplicateFieldRejected:
+    @pytest.mark.unit
+    def test_issue_ref_duplicate_field_rejected(self, tmp_path: Path) -> None:
+        """A document with two ISSUE_REF lines must be rejected.
+
+        Even when the second ISSUE_REF line is valid, the first malformed
+        line must not be silently skipped.  Gate A must count all ISSUE_REF::
+        line occurrences and emit a 'multiple times' error when count > 1.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_DUPLICATE_ISSUE_REF_TOKEN}"\n'
+            "  STATUS::PROPOSED\n"
+            "  TIER::OPERATIONAL\n"
+            # first line: malformed (trailing garbage, would be skipped by search)
+            '  ISSUE_REF::"repo:hestai-context-mcp#1" EXTRA\n'
+            # second line: valid (search() would land here and miss the first)
+            f'  ISSUE_REF::"{_DUPLICATE_ISSUE_REF_VALID}"\n'
+            '  DECISION::"Duplicate ISSUE_REF guard."\n'
+            '  BECAUSE::"ADR-RFC-ARCH-004 §4.1 #10."\n'
+            '  AUTHORED_AT::"2026-06-13T00:00:00Z"\n'
+            "===END===\n"
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, "Expected invalid: duplicate ISSUE_REF fields"
+        assert any("ISSUE_REF" in e for e in result.errors), result.errors

--- a/tests/unit/tools/governance/test_bare_canonical.py
+++ b/tests/unit/tools/governance/test_bare_canonical.py
@@ -627,3 +627,32 @@ class TestTypeCheckerIssueRefDuplicateFieldRejected:
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False, "Expected invalid: duplicate ISSUE_REF fields"
         assert any("multiple times" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# ISSUE_REF_SHAPE_RE segment character-class guard
+#
+# _ISSUE_REF_SHAPE_RE uses [A-Za-z0-9._-]+ for GitHub owner and repo segments.
+# [^/\s]+ (the prior class) accepted characters like `"` that are not valid
+# in GitHub names; after outer-quote stripping a malformed quoted URL
+# ISSUE_REF::"https://github.com/org"/repo/issues/1" would pass because the
+# embedded `"` fell inside [^/\s]+.
+# ---------------------------------------------------------------------------
+
+_SHAPE_RE_HOST_TOKEN = "HO-CONTEXT-MCP-ISSUE-REF-SHAPE-RE-20260613"
+
+
+class TestTypeCheckerIssueRefShapeReSegments:
+    @pytest.mark.unit
+    def test_issue_ref_url_with_illegal_char_in_org_rejected(self, tmp_path: Path) -> None:
+        """GitHub URL with illegal character in org segment is rejected.
+
+        ISSUE_REF::"https://github.com/org"/repo/issues/1" — after outer-quote
+        stripping the embedded quote lands inside the org segment.
+        ``[A-Za-z0-9._-]+`` rejects this; ``[^/\\s]+`` (prior class) accepted it.
+        """
+        raw = 'ISSUE_REF::"https://github.com/elevanaltd\\"/hestai-context-mcp/issues/53"'
+        content = _decision_record_with_raw_issue_ref_line(_SHAPE_RE_HOST_TOKEN, raw)
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, "Expected invalid: illegal char in GitHub org segment"
+        assert any("ISSUE_REF" in e for e in result.errors), result.errors


### PR DESCRIPTION
## Summary
- Implement ISSUE_REF shape enforcement in Gate A type checker per ADR-004 §4.1
- Add comprehensive unit tests validating canonical bare reference patterns
- Closes #10: Gate A now validates issue reference format before downstream processing

## Changes
- **governance/type_checker.py**: New validation logic enforcing ISSUE_REF shape constraints in Gate A pipeline
- **tests/unit/tools/governance/test_bare_canonical.py**: 119 lines of test coverage for ISSUE_REF pattern validation across canonical and bare reference formats

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces ISSUE_REF shape in Gate A per ADR-004 §4.1 #10 using greedy, line-anchored capture; the field stays optional. Tightens GitHub URL matching to valid org/repo characters and rejects duplicates and trailing garbage.

- **New Features**
  - Validates `ISSUE_REF` as `repo:<repo-id>#<n>` or a GitHub issue URL with strict `[A-Za-z0-9._-]+` org/repo segments; collects errors without early exit.
  - Anchors to line start and uses greedy capture; rejects duplicates and ignores `NOT_ISSUE_REF::` prefixes.
  - Adds tests for shorthand/URL, absence, dogfood regression, trailing-garbage (quoted/bare), anchor, duplicate-field, and illegal-char-in-org/repo segment cases.

- **Refactors**
  - Replaced extractor + presence detector with a single greedy regex `(?m)^[ \t]*ISSUE_REF::(.*)$`, removing asymmetry and closing trailing-garbage bypass.

<sup>Written for commit 295ccca7364ee7f724d75005e571d4c29663b48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

