### PR TITLE
fix(governance): anchor Gate-A TYPE/REPO_ID/lexer-field extractors — *FIELD:: substring leak (#85)

### DIFF
--- a/src/hestai_context_mcp/tools/governance/lexer.py
+++ b/src/hestai_context_mcp/tools/governance/lexer.py
@@ -23,14 +23,20 @@ _CONTEXT_BUDGET_CHARS = 25_000
 # quote-optional per the AGR canonical-form convergence ruling.
 # Matches the bare canonical form  TOKEN::<value> / ID::<value>  AND the legacy
 # quoted form  TOKEN::"<value>" / ID::"<value>"  where <value> == the token.
-# Compiled with re.MULTILINE; EVERY branch (quoted and bare) ends with a
-# (?:\s*$) line-end anchor (only trailing whitespace, then end-of-line) so that:
-#   - a shorter token (HO-FOO-20260101) never prefix-matches a longer one, and
-#   - a trailing-garbage line (TOKEN::"<value>" junk) is NOT counted as a clean
-#     existence hit (cubic P2 — the quoted branches were previously unanchored,
-#     and a (?=\s|$) lookahead was satisfied by the leading space of the junk).
+# Compiled with re.MULTILINE; EVERY branch (quoted and bare) is LINE-ANCHORED at
+# BOTH ends:
+#   - line START via ``^\s*`` — admits OCTAVE indentation but forbids a
+#     ``*TOKEN::`` / ``*ID::``-suffixed key (e.g. ``DOCUMENT_TOKEN::`` /
+#     ``PARENT_ID::``) from substring-leaking as a clean existence hit
+#     (issue #85 — the previous template had no line-start anchor), and
+#   - line END via ``(?:\s*$)`` (only trailing whitespace, then end-of-line) so:
+#       - a shorter token (HO-FOO-20260101) never prefix-matches a longer one, and
+#       - a trailing-garbage line (TOKEN::"<value>" junk) is NOT counted as a
+#         clean existence hit (cubic P2 — the quoted branches were previously
+#         unanchored, and a (?=\s|$) lookahead was satisfied by the leading
+#         space of the junk).
 _FIELD_EXACT_RE_TEMPLATE = (
-    r'(?m)(?:TOKEN::\s*(?:"{token}"|{token})\s*$' r'|ID::\s*(?:"{token}"|{token})\s*$)'
+    r'(?m)(?:^\s*TOKEN::\s*(?:"{token}"|{token})\s*$' r'|^\s*ID::\s*(?:"{token}"|{token})\s*$)'
 )
 
 

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -30,8 +30,14 @@ from hestai_context_mcp.tools.governance.lexer import lookup_token_deterministic
 # Pattern: starts with ===TYPENAME=== on the very first line.
 _SENTINEL_RE = re.compile(r"\A===([A-Z_]+)===\s*(?:\r?\n|$)")
 
-# TYPE field in META block
-_TYPE_RE = re.compile(r"(?m)TYPE::(\w+)")
+# TYPE field in META block. LINE-ANCHORED (issue #85): the KEY must be exactly
+# ``TYPE`` at line start — a leading whitespace-only indent is admitted (OCTAVE
+# META bodies are indented) but NO other characters may precede it, so a
+# ``*TYPE::``-suffixed key such as ``DOCUMENT_TYPE::`` / ``CONTENT_TYPE::`` no
+# longer substring-leaks via ``.search()``. The trailing ``\s*$`` end-anchor
+# rejects trailing garbage (``TYPE::DECISION_RECORD EXTRA``). Mirrors the
+# read-side ``agr_read._TYPE_IS_DECISION_RECORD_RE`` anchored approach.
+_TYPE_RE = re.compile(r"(?m)^\s*TYPE::(\w+)\s*$")
 
 # TOKEN field (DECISION_RECORD): quote-optional (AGR canonical-form convergence).
 # Accepts BOTH the bare canonical form  TOKEN::VALUE  and the legacy quoted form
@@ -64,8 +70,12 @@ _DECISION_RECORD_TYPE = "DECISION_RECORD"
 _FACET_CARD_TYPES = frozenset({"CONCEPT_CARD", "FRAME_CARD", "CLUSTER_CARD", "PHASE_CARD"})
 _KNOWN_TYPES = frozenset([_DECISION_RECORD_TYPE]) | _FACET_CARD_TYPES
 
-# REPO_ID field for facet cards
-_REPO_ID_RE = re.compile(r"REPO_ID::([^\s]+)")
+# REPO_ID field for facet cards. LINE-ANCHORED (issue #85, same *FIELD:: class):
+# ``^\s*`` admits OCTAVE indentation but forbids a ``*REPO_ID::``-suffixed key
+# (e.g. ``SOURCE_REPO_ID::``) from substring-leaking via ``.search()``. The
+# trailing ``\s*$`` rejects a trailing-garbage line; the captured value's own
+# comma/whitespace cleanup still happens in ``_extract_repo_id``.
+_REPO_ID_RE = re.compile(r"(?m)^\s*REPO_ID::([^\s]+)\s*$")
 
 # Safe slug pattern for REPO_ID validation (alphanumeric, hyphens, underscores only)
 _SAFE_SLUG_RE = re.compile(r"^[a-zA-Z0-9_-]+$")

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -41,12 +41,14 @@ _TYPE_RE = re.compile(r"(?m)^\s*TYPE::(\w+)\s*$")
 
 # TOKEN field (DECISION_RECORD): quote-optional (AGR canonical-form convergence).
 # Accepts BOTH the bare canonical form  TOKEN::VALUE  and the legacy quoted form
-# TOKEN::"VALUE".  The end-anchor (\s*$) lives OUTSIDE the alternation so BOTH
-# branches are line-anchored: a trailing-garbage line such as
-# TOKEN::"HO-…-20260513" EXTRA  or  TOKEN::HO-…-20260513 EXTRA  does NOT match
-# (cubic P2 — the §1.3 _TOKEN_FORMAT_RE only checks the captured value, so it
-# cannot catch trailing junk; the anchor must).
-_TOKEN_RE = re.compile(r'(?m)TOKEN::(?:"([^"]+)"|([^"\s]+))\s*$')
+# TOKEN::"VALUE".  LINE-ANCHORED at BOTH ends (issue #85): the line-START anchor
+# ``^\s*`` admits OCTAVE indentation but forbids a ``*TOKEN::``-suffixed key
+# (e.g. ``DOCUMENT_TOKEN::``) from substring-leaking via ``.search()``; the
+# end-anchor (\s*$) lives OUTSIDE the alternation so BOTH branches reject a
+# trailing-garbage line such as  TOKEN::"HO-…-20260513" EXTRA  /
+# TOKEN::HO-…-20260513 EXTRA  (cubic P2 — the §1.3 _TOKEN_FORMAT_RE only checks
+# the captured value, so it cannot catch trailing junk; the anchor must).
+_TOKEN_RE = re.compile(r'(?m)^\s*TOKEN::(?:"([^"]+)"|([^"\s]+))\s*$')
 
 # ID field (facet cards): quote-optional. Accepts bare  ID::VALUE  and quoted
 # ID::"VALUE".  The end-anchor (\s*$) lives OUTSIDE the alternation so BOTH the
@@ -54,8 +56,13 @@ _TOKEN_RE = re.compile(r'(?m)TOKEN::(?:"([^"]+)"|([^"\s]+))\s*$')
 # (cubic P2 — the quoted branch was previously unanchored).
 _ID_QUOTED_RE = re.compile(r'(?m)^  ID::(?:"([^"]+)"|([^"\s]+))\s*$')
 
-# SUPERSEDED_BY field: quoted string
-_SUPERSEDED_BY_RE = re.compile(r'SUPERSEDED_BY::"([^"]+)"')
+# SUPERSEDED_BY field: quoted string. LINE-ANCHORED (issue #85): ``^\s*`` admits
+# OCTAVE indentation but forbids a ``*SUPERSEDED_BY::``-suffixed key (e.g.
+# ``PARENT_SUPERSEDED_BY::``) from substring-leaking a supersedure target via
+# ``.search()`` — this is the supersedure-corruption vector the issue exists to
+# kill. ``\s*$`` rejects trailing garbage; the quoted-only value behavior is
+# unchanged (only anchors added).
+_SUPERSEDED_BY_RE = re.compile(r'(?m)^\s*SUPERSEDED_BY::"([^"]+)"\s*$')
 
 # TOKEN format validation per ADR-RFC-ARCH-004 §1.3
 # ^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$

--- a/tests/unit/tools/governance/test_field_anchor_class_issue_85.py
+++ b/tests/unit/tools/governance/test_field_anchor_class_issue_85.py
@@ -142,9 +142,7 @@ class TestLeakDownstreamEffectPinned:
         assert result.token is None
 
     @pytest.mark.unit
-    def test_suffixed_superseded_by_does_not_trigger_supersedure_path(
-        self, tmp_path: Path
-    ) -> None:
+    def test_suffixed_superseded_by_does_not_trigger_supersedure_path(self, tmp_path: Path) -> None:
         """A ``PARENT_SUPERSEDED_BY::`` key must NOT drive the supersedure-target check.
 
         If the leak fired, ``_extract_superseded_by`` would return a value and
@@ -191,14 +189,9 @@ _FIELD_EXTRACTOR_FAMILY = [
     ("manifest._ID_BARE_RE", manifest_mod._ID_BARE_RE, "ID", "GATE_A_TEST_CONCEPT", False),
 ]
 
-# The ID-family extractors are anchored to EXACTLY two leading spaces (``^  ``)
-# rather than ``^\s*``; they only ever match a 2-space-indented META body line.
-# Render their genuine line with that exact indent so the accept-case is fair.
-_TWO_SPACE_INDENT_IDS = {
-    "tc._ID_QUOTED_RE",
-    "manifest._ID_RE",
-    "manifest._ID_BARE_RE",
-}
+# Genuine META body lines are rendered with a two-space indent. This is exact
+# for the ID-family extractors anchored to ``^  `` and admitted by the ``^\s*``
+# members too, so the accept-case is fair for every family member.
 
 
 def _render_field_line(field_key: str, value: str, quoted: bool, indent: str) -> str:
@@ -228,7 +221,6 @@ class TestFieldAnchorClassGuard:
         quoted: bool,
     ) -> None:
         """A ``PREFIX<FIELD>::value`` decoy line must NOT match (no substring leak)."""
-        indent = "  " if extractor_id in _TWO_SPACE_INDENT_IDS else "  "
         decoy = _render_field_line(field_key, value, quoted, indent="  PREFIX_")
         # Decoy renders as e.g. ``  PREFIX_TOKEN::"<tok>"`` — a *FIELD:: suffixed key.
         assert compiled.search(decoy) is None, f"{extractor_id} leaked on decoy: {decoy!r}"  # type: ignore[attr-defined]

--- a/tests/unit/tools/governance/test_field_anchor_class_issue_85.py
+++ b/tests/unit/tools/governance/test_field_anchor_class_issue_85.py
@@ -1,0 +1,277 @@
+"""Class-closer regression tests for issue #85 — the FULL *FIELD:: substring-leak class.
+
+CE re-gate on PR #91 found the audit incomplete: two MORE same-class siblings live
+in ``type_checker.py``'s OWN regexes (distinct from the already-anchored manifest
+copies):
+
+  * ``_TOKEN_RE = (?m)TOKEN::(?:"..."|...)\\s*$`` — end-anchored but NO ``^``
+    line-start, so ``DOCUMENT_TOKEN::<tok>`` leaks via ``_extract_token``.
+  * ``_SUPERSEDED_BY_RE = SUPERSEDED_BY::"([^"]+)"`` — NO anchors at all, so
+    ``PARENT_SUPERSEDED_BY::"<tok>"`` leaks straight into the supersedure-target
+    path (the exact corruption class #85 exists to kill).
+
+This module:
+  1. Pins the two confirmed leak vectors (+ shadow + downstream e2e) — RED.
+  2. Adds a TABLE-DRIVEN CLASS-GUARD meta-test enumerating EVERY ``FIELD::value``
+     META extractor in type_checker.py AND lexer.py, asserting each is
+     line-anchored (rejects a ``PREFIX<FIELD>::value`` decoy, accepts the real
+     ``^\\s*<FIELD>::value``). This prevents any future sibling from regressing
+     the class. The already-anchored family members (type_checker _TYPE_RE /
+     _REPO_ID_RE / _ID_QUOTED_RE, lexer field template, manifest _TOKEN_RE /
+     _TOKEN_BARE_RE / _ID_RE / _ID_BARE_RE) are included so they are proven to
+     STAY anchored; _SENTINEL_RE (the ===NAME=== doc-start form) is asserted to
+     stay \\A-anchored separately.
+
+TDD RED: the two unanchored siblings fail the meta-test and the targeted leak
+tests; everything else passes. GREEN adds the two ``^\\s*`` anchors.
+
+North Star §4 regex-only; PROD I4 structured returns; tighten-only.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.tools.governance import lexer as lexer_mod
+from hestai_context_mcp.tools.governance import manifest as manifest_mod
+from hestai_context_mcp.tools.governance import type_checker as tc
+
+# A token whose shape is irrelevant to the anchoring (these extractors do not
+# validate token shape — that is _TOKEN_FORMAT_RE's job downstream).
+_TOK = "HO-FOO-BAR-20260101"
+
+
+# ---------------------------------------------------------------------------
+# Targeted leak vectors — _extract_token
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTokenLineAnchored:
+    """``_extract_token`` must reject a ``*TOKEN::``-suffixed key."""
+
+    @pytest.mark.unit
+    def test_document_token_does_not_leak(self) -> None:
+        """``DOCUMENT_TOKEN::<tok>`` (no real TOKEN) must extract None."""
+        content = f"===DECISION_RECORD===\nMETA:\n  DOCUMENT_TOKEN::{_TOK}\n===END===\n"
+        assert tc._extract_token(content) is None
+
+    @pytest.mark.unit
+    def test_suffixed_token_does_not_shadow_real_token(self) -> None:
+        """A ``DOCUMENT_TOKEN::`` line ABOVE the real TOKEN must not win (.search first-match)."""
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  DOCUMENT_TOKEN::HO-EVIL-XX-20260101\n"
+            '  TOKEN::"HO-REAL-YY-20260101"\n'
+            "===END===\n"
+        )
+        assert tc._extract_token(content) == "HO-REAL-YY-20260101"
+
+    @pytest.mark.unit
+    def test_real_quoted_token_still_extracts(self) -> None:
+        """A real indented quoted ``TOKEN::"..."`` line still extracts (no loosening)."""
+        assert tc._extract_token('  TOKEN::"HO-REAL-YY-20260101"\n') == "HO-REAL-YY-20260101"
+
+    @pytest.mark.unit
+    def test_real_bare_token_still_extracts(self) -> None:
+        """The bare canonical ``TOKEN::<value>`` form still extracts."""
+        assert tc._extract_token("  TOKEN::HO-REAL-YY-20260101\n") == "HO-REAL-YY-20260101"
+
+
+# ---------------------------------------------------------------------------
+# Targeted leak vectors — _extract_superseded_by
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSupersededByLineAnchored:
+    """``_extract_superseded_by`` must reject a ``*SUPERSEDED_BY::``-suffixed key."""
+
+    @pytest.mark.unit
+    def test_parent_superseded_by_does_not_leak(self) -> None:
+        """``PARENT_SUPERSEDED_BY::"X"`` (no real field) must extract None."""
+        content = (
+            '===DECISION_RECORD===\nMETA:\n  PARENT_SUPERSEDED_BY::"HO-X-AB-20260101"\n===END===\n'
+        )
+        assert tc._extract_superseded_by(content) is None
+
+    @pytest.mark.unit
+    def test_suffixed_superseded_by_does_not_shadow_real(self) -> None:
+        """A ``PARENT_SUPERSEDED_BY::`` line ABOVE the real one must not win."""
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            '  PARENT_SUPERSEDED_BY::"HO-EVIL-AB-20260101"\n'
+            '  SUPERSEDED_BY::"HO-REAL-CD-20260101"\n'
+            "===END===\n"
+        )
+        assert tc._extract_superseded_by(content) == "HO-REAL-CD-20260101"
+
+    @pytest.mark.unit
+    def test_real_superseded_by_still_extracts(self) -> None:
+        """A real indented ``SUPERSEDED_BY::"X"`` line still extracts (no loosening)."""
+        assert (
+            tc._extract_superseded_by('  SUPERSEDED_BY::"HO-REAL-CD-20260101"\n')
+            == "HO-REAL-CD-20260101"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the leaks must not corrupt validate_octave_content / supersedure
+# ---------------------------------------------------------------------------
+
+
+class TestLeakDownstreamEffectPinned:
+    """The leaks' downstream Gate-A effects are pinned (mirrors issue-85 e2e style)."""
+
+    @pytest.mark.unit
+    def test_document_token_only_record_reports_missing_token(self, tmp_path: Path) -> None:
+        """A DECISION_RECORD whose only token-like line is ``DOCUMENT_TOKEN::`` must
+        be rejected for a MISSING TOKEN — not silently accepted with the leaked value.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            f"  DOCUMENT_TOKEN::{_TOK}\n"
+            "===END===\n"
+        )
+        result = tc.validate_octave_content(tmp_path, content)
+
+        assert result.valid is False
+        assert any("requires a TOKEN field" in e for e in result.errors)
+        assert result.token is None
+
+    @pytest.mark.unit
+    def test_suffixed_superseded_by_does_not_trigger_supersedure_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``PARENT_SUPERSEDED_BY::`` key must NOT drive the supersedure-target check.
+
+        If the leak fired, ``_extract_superseded_by`` would return a value and
+        validation would error that the (non-existent) SUPERSEDED_BY target is
+        missing from the store. Anchored, the field is invisible, so a valid
+        record with NO real SUPERSEDED_BY passes without any supersedure error.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  TOKEN::"HO-CONTEXT-MCP-REAL-20260101"\n'
+            '  PARENT_SUPERSEDED_BY::"HO-GHOST-ZZ-20260101"\n'
+            "===END===\n"
+        )
+        result = tc.validate_octave_content(tmp_path, content)
+
+        assert not any("SUPERSEDED_BY target" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# CLASS-GUARD META-TEST — the real class-closer
+# ---------------------------------------------------------------------------
+
+# Family of ``FIELD::value`` META-line extractors across type_checker + lexer +
+# manifest. Each entry: (id, compiled_or_template, field_key, sample_value,
+# quoted). ``quoted`` controls whether the value is wrapped in double quotes on
+# the rendered line (some extractors are quoted-only). The lexer template is a
+# format string keyed on ``{token}`` and is handled specially below.
+#
+# Every member MUST be line-anchored: it must REJECT a ``PREFIX<FIELD>::value``
+# decoy line and ACCEPT the genuine ``  <FIELD>::value`` (indented) line.
+_FIELD_EXTRACTOR_FAMILY = [
+    # type_checker.py
+    ("tc._TYPE_RE", tc._TYPE_RE, "TYPE", "DECISION_RECORD", False),
+    ("tc._TOKEN_RE", tc._TOKEN_RE, "TOKEN", _TOK, True),
+    ("tc._REPO_ID_RE", tc._REPO_ID_RE, "REPO_ID", "hestai-context-mcp", False),
+    ("tc._SUPERSEDED_BY_RE", tc._SUPERSEDED_BY_RE, "SUPERSEDED_BY", _TOK, True),
+    ("tc._ID_QUOTED_RE", tc._ID_QUOTED_RE, "ID", "GATE_A_TEST_CONCEPT", True),
+    # manifest.py (already anchored — must STAY anchored)
+    ("manifest._TOKEN_RE", manifest_mod._TOKEN_RE, "TOKEN", _TOK, True),
+    ("manifest._TOKEN_BARE_RE", manifest_mod._TOKEN_BARE_RE, "TOKEN", _TOK, False),
+    ("manifest._ID_RE", manifest_mod._ID_RE, "ID", "GATE_A_TEST_CONCEPT", True),
+    ("manifest._ID_BARE_RE", manifest_mod._ID_BARE_RE, "ID", "GATE_A_TEST_CONCEPT", False),
+]
+
+# The ID-family extractors are anchored to EXACTLY two leading spaces (``^  ``)
+# rather than ``^\s*``; they only ever match a 2-space-indented META body line.
+# Render their genuine line with that exact indent so the accept-case is fair.
+_TWO_SPACE_INDENT_IDS = {
+    "tc._ID_QUOTED_RE",
+    "manifest._ID_RE",
+    "manifest._ID_BARE_RE",
+}
+
+
+def _render_field_line(field_key: str, value: str, quoted: bool, indent: str) -> str:
+    rendered_value = f'"{value}"' if quoted else value
+    return f"{indent}{field_key}::{rendered_value}\n"
+
+
+class TestFieldAnchorClassGuard:
+    """Every ``FIELD::value`` META extractor in the family must be line-anchored.
+
+    This is the class-closer: it fails for ANY family member that lacks a
+    line-start anchor, so a future edit that drops ``^\\s*`` from a sibling is
+    caught here rather than shipping a fresh substring leak.
+    """
+
+    @pytest.mark.parametrize(
+        "extractor_id, compiled, field_key, value, quoted",
+        [pytest.param(*row, id=row[0]) for row in _FIELD_EXTRACTOR_FAMILY],
+    )
+    @pytest.mark.unit
+    def test_extractor_rejects_prefixed_decoy(
+        self,
+        extractor_id: str,
+        compiled: "object",
+        field_key: str,
+        value: str,
+        quoted: bool,
+    ) -> None:
+        """A ``PREFIX<FIELD>::value`` decoy line must NOT match (no substring leak)."""
+        indent = "  " if extractor_id in _TWO_SPACE_INDENT_IDS else "  "
+        decoy = _render_field_line(field_key, value, quoted, indent="  PREFIX_")
+        # Decoy renders as e.g. ``  PREFIX_TOKEN::"<tok>"`` — a *FIELD:: suffixed key.
+        assert compiled.search(decoy) is None, f"{extractor_id} leaked on decoy: {decoy!r}"  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize(
+        "extractor_id, compiled, field_key, value, quoted",
+        [pytest.param(*row, id=row[0]) for row in _FIELD_EXTRACTOR_FAMILY],
+    )
+    @pytest.mark.unit
+    def test_extractor_accepts_real_line(
+        self,
+        extractor_id: str,
+        compiled: "object",
+        field_key: str,
+        value: str,
+        quoted: bool,
+    ) -> None:
+        """The genuine indented ``<FIELD>::value`` line must still match (no loosening)."""
+        indent = "  "
+        real = _render_field_line(field_key, value, quoted, indent=indent)
+        assert compiled.search(real) is not None, f"{extractor_id} rejected real line: {real!r}"  # type: ignore[attr-defined]
+
+    @pytest.mark.unit
+    def test_lexer_field_template_is_line_anchored(self) -> None:
+        """The lexer field-exact template (keyed on {token}) rejects ``*TOKEN::``/``*ID::``."""
+        import re
+
+        pat = re.compile(lexer_mod._FIELD_EXACT_RE_TEMPLATE.format(token=re.escape(_TOK)))
+        # Decoys: suffixed keys must NOT match.
+        assert pat.search(f"  DOCUMENT_TOKEN::{_TOK}\n") is None
+        assert pat.search(f"  PARENT_ID::{_TOK}\n") is None
+        # Real lines: must match.
+        assert pat.search(f'  TOKEN::"{_TOK}"\n') is not None
+        assert pat.search(f"  ID::{_TOK}\n") is not None
+
+    @pytest.mark.unit
+    def test_sentinel_re_stays_doc_start_anchored(self) -> None:
+        """``_SENTINEL_RE`` is the ===NAME=== doc-start form — must stay \\A-anchored.
+
+        It is in the META-extractor family conceptually but not a ``FIELD::value``
+        line; this pins it so the doc-start anchor is not regressed either.
+        """
+        # Genuine first-line sentinel matches.
+        assert tc._SENTINEL_RE.match("===DECISION_RECORD===\n") is not None
+        # A sentinel NOT at document start must not match (\\A anchor).
+        assert tc._SENTINEL_RE.match("garbage\n===DECISION_RECORD===\n") is None

--- a/tests/unit/tools/governance/test_lexer_field_anchor_issue_85.py
+++ b/tests/unit/tools/governance/test_lexer_field_anchor_issue_85.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #85 — lexer TOKEN/ID existence match must be line-anchored.
+
+``lexer._FIELD_EXACT_RE_TEMPLATE`` end-anchors each branch with ``\\s*$`` but has
+NO line-START anchor, so a field whose KEY merely *ends* in ``TOKEN`` / ``ID``
+(e.g. ``DOCUMENT_TOKEN::<value>`` or ``PARENT_ID::<value>``) substring-leaks and
+registers as a clean existence hit. ``lookup_token_deterministic`` drives
+supersedure-target verification and duplicate detection in Gate A, so a leak
+here can cause a false "already exists" rejection or a false "supersedure target
+found".
+
+TDD RED: these MUST fail against the un-line-anchored template and pass once a
+``^`` (with ``^\\s*`` to admit OCTAVE indentation) line-start anchor is added,
+mirroring the read-side / manifest line-anchoring approach.
+
+North Star §4 regex-only; deterministic.
+"""
+
+import re
+
+import pytest
+
+from hestai_context_mcp.tools.governance.lexer import (
+    _FIELD_EXACT_RE_TEMPLATE,
+    lookup_token_deterministic,
+)
+
+_TOKEN = "HO-FOO-20260101"
+
+
+def _compiled(token: str) -> "re.Pattern[str]":
+    return re.compile(_FIELD_EXACT_RE_TEMPLATE.format(token=re.escape(token)))
+
+
+class TestFieldExactRegexLineAnchored:
+    """The compiled field-exact template must reject ``*TOKEN::`` / ``*ID::`` leaks."""
+
+    @pytest.mark.unit
+    def test_legitimate_token_line_still_matches(self) -> None:
+        """A real indented ``TOKEN::"<value>"`` line still matches (no loosening)."""
+        assert _compiled(_TOKEN).search(f'  TOKEN::"{_TOKEN}"\n') is not None
+
+    @pytest.mark.unit
+    def test_bare_token_line_still_matches(self) -> None:
+        """The bare canonical ``TOKEN::<value>`` form still matches."""
+        assert _compiled(_TOKEN).search(f"  TOKEN::{_TOKEN}\n") is not None
+
+    @pytest.mark.unit
+    def test_document_token_key_does_not_leak(self) -> None:
+        """``DOCUMENT_TOKEN::<value>`` must NOT register as a TOKEN existence hit."""
+        assert _compiled(_TOKEN).search(f"  DOCUMENT_TOKEN::{_TOKEN}\n") is None
+
+    @pytest.mark.unit
+    def test_suffix_id_key_does_not_leak(self) -> None:
+        """``PARENT_ID::<value>`` must NOT register as an ID existence hit."""
+        assert _compiled(_TOKEN).search(f"  PARENT_ID::{_TOKEN}\n") is None
+
+
+class TestLookupTokenDeterministicNoSuffixLeak:
+    """End-to-end: a ``*TOKEN::``-suffixed field must not satisfy a token lookup."""
+
+    @pytest.mark.unit
+    def test_suffixed_token_field_is_not_a_lookup_hit(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """A file containing only ``SOURCE_TOKEN::<value>`` must not count as existing.
+
+        No MANIFEST -> the filesystem grep runs ``_FIELD_EXACT_RE_TEMPLATE``.
+        Pre-fix the un-anchored template matches the ``SOURCE_TOKEN::`` line and
+        ``lookup_token_deterministic`` wrongly returns True; post-fix it returns
+        False because the KEY is not exactly ``TOKEN`` at line start.
+        """
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True)
+        (decisions / "x.oct.md").write_text(
+            f"===DECISION_RECORD===\nMETA:\n  SOURCE_TOKEN::{_TOKEN}\n===END===\n"
+        )
+
+        assert lookup_token_deterministic(tmp_path, _TOKEN) is False
+
+    @pytest.mark.unit
+    def test_real_token_field_is_a_lookup_hit(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """A genuine ``TOKEN::"<value>"`` line is still found (no loosening)."""
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True)
+        (decisions / "x.oct.md").write_text(
+            f'===DECISION_RECORD===\nMETA:\n  TOKEN::"{_TOKEN}"\n===END===\n'
+        )
+
+        assert lookup_token_deterministic(tmp_path, _TOKEN) is True

--- a/tests/unit/tools/governance/test_type_anchor_issue_85.py
+++ b/tests/unit/tools/governance/test_type_anchor_issue_85.py
@@ -1,0 +1,157 @@
+"""Regression tests for issue #85 — Gate-A TYPE:: extraction must be line-anchored.
+
+Write-side root of the read-side P2 closed in #83. The shared Gate-A extractor
+``type_checker._TYPE_RE = (?m)TYPE::(\\w+)`` uses an UNANCHORED substring
+``.search()``, so a META line such as ``DOCUMENT_TYPE::DECISION_RECORD`` or
+``CONTENT_TYPE::X`` false-matches as ``TYPE::...``. The read side worked around
+this locally (``agr_read._TYPE_IS_DECISION_RECORD_RE``); this module proves the
+shared write-side defect (and the same-class ``_REPO_ID_RE`` leak in the same
+file) so the fix can line-anchor the extractor without loosening real-record
+acceptance.
+
+TDD RED: every test below MUST fail against the unanchored extractor and pass
+once ``_TYPE_RE`` (and ``_REPO_ID_RE``) are line-anchored to ``^\\s*TYPE::`` /
+``^\\s*REPO_ID::`` (mirroring the read-side anchored approach).
+
+Constraints honoured (North Star §4 regex-only; PROD I4 structured returns):
+the change must only TIGHTEN — reject ``*FIELD::`` substring leaks — never
+loosen acceptance of a legitimately indented OCTAVE ``TYPE::`` line.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.tools.governance.type_checker import (
+    _extract_repo_id,
+    _extract_type,
+    validate_octave_content,
+)
+
+
+class TestExtractTypeLineAnchored:
+    """``_extract_type`` must reject ``*TYPE::`` substring leaks and trailing garbage."""
+
+    @pytest.mark.unit
+    def test_document_type_does_not_leak_as_type(self) -> None:
+        """``DOCUMENT_TYPE::DECISION_RECORD`` must NOT be extracted as the TYPE value.
+
+        With the unanchored ``(?m)TYPE::(\\w+)`` + ``.search()``, the substring
+        ``TYPE::DECISION_RECORD`` inside ``DOCUMENT_TYPE::DECISION_RECORD`` is
+        falsely returned. There is no genuine ``TYPE::`` line here, so the
+        anchored extractor must return ``None``.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  DOCUMENT_TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            "===END===\n"
+        )
+        assert _extract_type(content) is None
+
+    @pytest.mark.unit
+    def test_content_type_does_not_leak_as_type(self) -> None:
+        """``CONTENT_TYPE::CONCEPT_CARD`` must NOT be extracted as the TYPE value."""
+        content = "===CONCEPT_CARD===\nMETA:\n  CONTENT_TYPE::CONCEPT_CARD\n===END===\n"
+        assert _extract_type(content) is None
+
+    @pytest.mark.unit
+    def test_real_indented_type_still_extracts(self) -> None:
+        """A legitimately indented OCTAVE ``TYPE::`` line still extracts (no loosening)."""
+        content = "===DECISION_RECORD===\nMETA:\n  TYPE::DECISION_RECORD\n===END===\n"
+        assert _extract_type(content) == "DECISION_RECORD"
+
+    @pytest.mark.unit
+    def test_unindented_type_still_extracts(self) -> None:
+        """A column-0 ``TYPE::`` line also extracts (``^\\s*`` admits zero indent)."""
+        content = "===DECISION_RECORD===\nTYPE::DECISION_RECORD\n===END===\n"
+        assert _extract_type(content) == "DECISION_RECORD"
+
+    @pytest.mark.unit
+    def test_trailing_garbage_rejected(self) -> None:
+        """``TYPE::DECISION_RECORD EXTRA`` must NOT extract ``DECISION_RECORD``.
+
+        The end-anchor (\\s*$) rejects a trailing-garbage line so a malformed
+        TYPE declaration is not silently accepted as a clean value.
+        """
+        content = "===DECISION_RECORD===\nMETA:\n  TYPE::DECISION_RECORD EXTRA\n===END===\n"
+        assert _extract_type(content) is None
+
+    @pytest.mark.unit
+    def test_document_type_does_not_shadow_real_type(self) -> None:
+        """A ``DOCUMENT_TYPE::`` line preceding the real ``TYPE::`` must not win.
+
+        ``.search()`` returns the FIRST match; with the unanchored regex a
+        leading ``DOCUMENT_TYPE::CONCEPT_CARD`` line shadows the genuine
+        ``TYPE::DECISION_RECORD`` below it, mis-classifying the record. The
+        anchored extractor must skip the ``*TYPE::`` line and return the real
+        value ``DECISION_RECORD``.
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  DOCUMENT_TYPE::CONCEPT_CARD\n"
+            "  TYPE::DECISION_RECORD\n"
+            "===END===\n"
+        )
+        assert _extract_type(content) == "DECISION_RECORD"
+
+
+class TestValidateOctaveContentTypeLeak:
+    """End-to-end Gate-A: a ``*TYPE::``-only document must fail with the right error."""
+
+    @pytest.mark.unit
+    def test_document_type_only_reports_missing_type(self, tmp_path: Path) -> None:
+        """A record with only ``DOCUMENT_TYPE::`` (no real TYPE) must report a missing TYPE.
+
+        Pre-fix, the leak makes ``_extract_type`` return ``DECISION_RECORD`` so
+        validation advances past check 2 and emits a misleading "requires a
+        TOKEN field" error. Post-fix it must short-circuit with the correct
+        "No TYPE field found in META block." (PROD I4 structured return).
+        """
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  DOCUMENT_TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            "===END===\n"
+        )
+        result = validate_octave_content(tmp_path, content)
+
+        assert result.valid is False
+        assert any("No TYPE field found" in e for e in result.errors)
+        assert result.card_type is None
+
+
+class TestExtractRepoIdLineAnchored:
+    """Same-class ``*REPO_ID::`` substring leak in the same Gate-A file (#85 audit)."""
+
+    @pytest.mark.unit
+    def test_source_repo_id_does_not_leak_as_repo_id(self) -> None:
+        """``SOURCE_REPO_ID::evil`` must NOT be extracted as the REPO_ID value.
+
+        ``_REPO_ID_RE = REPO_ID::([^\\s]+)`` is unanchored, so the substring
+        ``REPO_ID::evil`` inside ``SOURCE_REPO_ID::evil`` leaks. With no genuine
+        ``REPO_ID::`` line the anchored extractor must return ``None``.
+        """
+        content = "===CONCEPT_CARD===\nMETA:\n  SOURCE_REPO_ID::evil-leak\n===END===\n"
+        assert _extract_repo_id(content) is None
+
+    @pytest.mark.unit
+    def test_source_repo_id_does_not_shadow_real_repo_id(self) -> None:
+        """A leading ``SOURCE_REPO_ID::`` line must not shadow the real ``REPO_ID::``."""
+        content = (
+            "===CONCEPT_CARD===\n"
+            "META:\n"
+            "  SOURCE_REPO_ID::evil-leak\n"
+            "  REPO_ID::real-repo\n"
+            "===END===\n"
+        )
+        assert _extract_repo_id(content) == "real-repo"
+
+    @pytest.mark.unit
+    def test_real_repo_id_still_extracts(self) -> None:
+        """A legitimately indented ``REPO_ID::`` line still extracts (no loosening)."""
+        content = "===CONCEPT_CARD===\nMETA:\n  REPO_ID::hestai-context-mcp\n===END===\n"
+        assert _extract_repo_id(content) == "hestai-context-mcp"


### PR DESCRIPTION
Closes #85. Write-side root of the read-side P2 closed in #83. Scope COMPLETE — the entire `*FIELD::` substring-leak class is closed.

## Defect class
The shared Gate-A extractors used UNANCHORED substring `.search()`, so a key that merely *ends* in the target field name leaked. All vectors reproduced before fixing (RED commits `04d6f30`, `ba24371`):

| Extractor | Decoy input | Pre-fix | Correct |
|---|---|---|---|
| `_TYPE_RE` | `DOCUMENT_TYPE::DECISION_RECORD` | `'DECISION_RECORD'` | `None` |
| `_TYPE_RE` (shadow) | `DOCUMENT_TYPE::CONCEPT_CARD` above real `TYPE::DECISION_RECORD` | `'CONCEPT_CARD'` | `'DECISION_RECORD'` |
| `_REPO_ID_RE` | `SOURCE_REPO_ID::evil` | `'evil'` | `None` |
| `_TOKEN_RE` | `DOCUMENT_TOKEN::<tok>` | `'<tok>'` | `None` |
| `_SUPERSEDED_BY_RE` | `PARENT_SUPERSEDED_BY::"<tok>"` | `'<tok>'` | `None` |
| lexer field template | `DOCUMENT_TOKEN::<tok>` / `PARENT_ID::<tok>` | match | no match |

Two impact classes: `.search()` first-match-wins lets a `*FIELD::` line **shadow** a genuine field (mis-classification); and the `*SUPERSEDED_BY::` leak feeds the **supersedure-target verification path** directly — the supersedure-corruption vector this issue exists to kill, now closed.

## All five Gate-A field extractors anchored
Each anchored to `^\s*FIELD::…\s*$` mirroring the read-side `agr_read._TYPE_IS_DECISION_RECORD_RE` (`^\s*` admits OCTAVE indentation; `\s*$` rejects trailing garbage; tighten-only):

- `type_checker._TYPE_RE`
- `type_checker._REPO_ID_RE`
- `type_checker._TOKEN_RE`
- `type_checker._SUPERSEDED_BY_RE` (quoted-only behavior preserved; anchors added) — **closes the `PARENT_SUPERSEDED_BY::` supersedure-corruption vector**
- `lexer._FIELD_EXACT_RE_TEMPLATE` (`^\s*` added to both `TOKEN::` and `ID::` branches)

## Class-guard meta-test (prevents future regression)
A table-driven meta-test enumerates the WHOLE `FIELD::value` family across `type_checker.py` + `manifest.py` (`_TYPE_RE`, `_TOKEN_RE`, `_REPO_ID_RE`, `_SUPERSEDED_BY_RE`, `_ID_QUOTED_RE`, `manifest._TOKEN_RE`/`_TOKEN_BARE_RE`/`_ID_RE`/`_ID_BARE_RE`) plus dedicated tests for the lexer template and `_SENTINEL_RE` (`\A` doc-start form). Each member must REJECT a `PREFIX<FIELD>::value` decoy and ACCEPT the real indented line — so any future sibling that drops its anchor is caught here rather than shipping a fresh leak.

## No-loosening proof
Guard tests prove every real record still extracts (indented + column-0 `TYPE::`, real `REPO_ID::`, quoted + bare `TOKEN::`, real `SUPERSEDED_BY::`). Tests:
- `tests/unit/tools/governance/test_type_anchor_issue_85.py`
- `tests/unit/tools/governance/test_lexer_field_anchor_issue_85.py`
- `tests/unit/tools/governance/test_field_anchor_class_issue_85.py` (class-guard)

## Audit — already-anchored siblings left untouched (MIP)
`manifest._TOKEN_RE`/`_TOKEN_BARE_RE`/`_ID_RE`/`_ID_BARE_RE`, `type_checker._ID_QUOTED_RE`/`_SENTINEL_RE`. Value-shape validators (`_TOKEN_FORMAT_RE`, `_FACET_ID_FORMAT_RE`, `_SAFE_SLUG_RE`) correctly excluded — they validate an already-extracted value, not a `FIELD::` line.

## Optional read-side cleanup — SKIPPED (rationale)
Collapsing `agr_read._TYPE_IS_DECISION_RECORD_RE` into the shared extractor was skipped: on a pathological multi-`TYPE::` doc the read-side `.search()` (True if a `TYPE::DECISION_RECORD` line exists anywhere) is NOT equivalent to `_extract_type(content) == DECISION_RECORD` (first TYPE line only). Swapping would silently change `is_decision_record` semantics and touch F1 co-located-scoping — a behavior change, not a refactor. Left untouched.

## Gates
- All issue-85 tests GREEN (16 + 29 class-closer); full suite **1298 passed, 0 regressions**
- Coverage: `type_checker.py` 97%, `lexer.py` 100% (≥85%)
- ruff / black / mypy clean
- North Star §4 regex-only; PROD I4 structured returns; deterministic

## Gate status
- TMG methodology gate: APPROVED (initial + re-confirm after CE-driven scope expansion; enumeration independently audited complete)
- CRS + CE re-confirm: PENDING

Do not merge until CRS+CE clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)