### PR TITLE
feat(governance): lookup_decision resolution_chain_status completeness signal (#87)

### DIFF
--- a/.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md
+++ b/.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md
@@ -264,9 +264,18 @@ Resolves a single AGR by `TOKEN`. Pure read.
     "path": "<repo-relative path to the .oct.md file>",
     "fields": { /* all other present fields, key→value */ }
   },
-  "resolution_chain": [ /* see trace_supersedure shape; populated when STATUS == SUPERSEDED */ ]
+  "resolution_chain": [ /* see trace_supersedure shape; populated when STATUS == SUPERSEDED */ ],
+  "resolution_chain_status": "complete" | "broken" | "cyclic"  // additive (issue #87); see note below
 }
 ```
+
+The `resolution_chain_status` field (additive per §3.1.1; issue #87) is a completeness signal so a caller can distinguish a `resolution_chain` that reached its terminal from one truncated by a broken link or a cycle. It is derived from the same `walk_supersession_chain` outcome that produces `resolution_chain`, with **no** extra read:
+
+- `"complete"` — the walk reached a terminal record (walk outcome `ok`). This is also the value for a non-`SUPERSEDED` record, whose `resolution_chain` is empty and therefore not truncated.
+- `"broken"` — a successor `TOKEN` referenced by `SUPERSEDED_BY` does not exist on disk (walk outcome `broken`, the same condition `trace_supersedure` reports as `CHAIN_BROKEN`). The partial chain gathered so far is still returned.
+- `"cyclic"` — a `SUPERSEDED_BY` cycle was detected by fail-closed cycle detection (walk outcome `cycle`, the same condition `trace_supersedure` reports as `CHAIN_CYCLE_DETECTED`). The partial chain is still returned; the walk never runs unbounded.
+
+The field is **always present** (a defined PROD::I4 key) and never removes or renames an existing key; a consumer that ignores it is unaffected. `trace_supersedure` remains the authoritative source for the broken/cyclic *error*; `resolution_chain_status` is an in-band observability signal on `lookup_decision` that agrees with it.
 
 **Error cases** (per §3.1.1 envelope):
 

--- a/src/hestai_context_mcp/tools/lookup_decision.py
+++ b/src/hestai_context_mcp/tools/lookup_decision.py
@@ -19,6 +19,20 @@ from hestai_context_mcp.tools.governance import agr_read
 _TOOL = "lookup_decision"
 _CONTRACT_REF = "ADR-RFC-ARCH-004 §3.2"
 
+# §3.2 (issue #87): map the walk_supersession_chain outcome to the additive
+# ``resolution_chain_status`` completeness signal. ``ok`` (reached a terminal)
+# is "complete"; a missing successor TOKEN is "broken"; a detected SUPERSEDED_BY
+# cycle is "cyclic". These mirror trace_supersedure's CHAIN_BROKEN /
+# CHAIN_CYCLE_DETECTED conditions. A record with no supersession chain (the
+# empty-chain / non-SUPERSEDED case) is "complete" — an empty chain is, by
+# definition, not truncated.
+_CHAIN_STATUS_DEFAULT = "complete"
+_WALK_OUTCOME_TO_STATUS = {
+    "ok": "complete",
+    "broken": "broken",
+    "cycle": "cyclic",
+}
+
 
 def lookup_decision(
     working_dir: str,
@@ -35,7 +49,12 @@ def lookup_decision(
             contract conformance (§3.2 — consumers must tolerate agent shape).
 
     Returns:
-        On success: ``{"ok": True, "record": {...}, "resolution_chain": [...]}``.
+        On success: ``{"ok": True, "record": {...}, "resolution_chain": [...],
+        "resolution_chain_status": "complete"|"broken"|"cyclic"}``. The
+        ``resolution_chain_status`` field (additive per §3.1.1, issue #87) is a
+        completeness signal derived from the same ``walk_supersession_chain``
+        outcome, so a caller can tell a chain that reached its terminal from one
+        truncated by a broken link or a cycle.
         On failure: the §3.1.1 error envelope.
     """
     working_path = agr_read.validate_working_dir(working_dir)
@@ -99,15 +118,23 @@ def lookup_decision(
     }
 
     resolution_chain: list[dict[str, Any]] = []
+    resolution_chain_status = _CHAIN_STATUS_DEFAULT
     if parsed["status"] == "SUPERSEDED":
         walk = agr_read.walk_supersession_chain(working_path, token)
         # §3.2: the resolution chain mirrors the trace_supersedure entry shape.
         # A broken/cyclic chain still surfaces the entries gathered so far so the
         # caller sees the partial resolution rather than nothing.
         resolution_chain = walk["chain"]
+        # §3.2 (issue #87): derive the completeness signal from the SAME walk
+        # outcome — no second read, so PROD I5 purity is preserved. ``ok`` falls
+        # back to the default "complete".
+        resolution_chain_status = _WALK_OUTCOME_TO_STATUS.get(
+            walk["outcome"], _CHAIN_STATUS_DEFAULT
+        )
 
     return {
         "ok": True,
         "record": record,
         "resolution_chain": resolution_chain,
+        "resolution_chain_status": resolution_chain_status,
     }

--- a/tests/unit/tools/governance/test_lookup_decision.py
+++ b/tests/unit/tools/governance/test_lookup_decision.py
@@ -1,4 +1,4 @@
-"""RED suite — ``lookup_decision`` MCP tool.
+"""Test suite — ``lookup_decision`` MCP tool.
 
 Contract: ADR-RFC-ARCH-004 §3.2 (return shape) + §3.1.1 (common error
 envelope). Pure read (PROD I5), structured return (PROD I4).
@@ -9,14 +9,12 @@ Happy path returns::
       "ok": true,
       "record": {token, type, version, status, tier, decision, because,
                  authored_at, path, fields{}},
-      "resolution_chain": [ ... ]   # populated when STATUS == SUPERSEDED
+      "resolution_chain": [ ... ],            # populated when STATUS == SUPERSEDED
+      "resolution_chain_status": "complete"   # | "broken" | "cyclic" (issue #87)
     }
 
 Error envelope (§3.1.1) for TOKEN_NOT_FOUND, TOKEN_MALFORMED,
 RECORD_PARSE_FAILED, WORKING_DIR_INVALID.
-
-RED: ``tools.lookup_decision`` does not exist yet — import raises
-ModuleNotFoundError (right-reason failure, not a collection error).
 """
 
 from __future__ import annotations
@@ -45,12 +43,11 @@ from ._agr_fixtures import (
 
 
 def _lookup_decision() -> Callable[..., dict]:
-    """Lazily import the not-yet-existing tool (RED discipline).
+    """Import the tool lazily, inside the call (collection-safe).
 
-    The import lives inside each test so COLLECTION succeeds and every test
-    FAILS individually with a 'missing implementation' reason rather than a
-    module-level collection error masking the file. GREEN creates
-    ``tools.lookup_decision.lookup_decision``.
+    Keeping the import here (rather than at module top) means a future import
+    regression surfaces as a per-test failure with a clear reason rather than a
+    module-level collection error that masks the whole file.
     """
     from hestai_context_mcp.tools.lookup_decision import lookup_decision
 

--- a/tests/unit/tools/governance/test_lookup_decision.py
+++ b/tests/unit/tools/governance/test_lookup_decision.py
@@ -27,11 +27,16 @@ from pathlib import Path
 import pytest
 
 from ._agr_fixtures import (
+    TOKEN_BROKEN,
+    TOKEN_CYCLE_A,
     TOKEN_MID,
+    TOKEN_MISSING,
     TOKEN_NEW,
     TOKEN_OLD,
     TOKEN_RATIFIED,
     snapshot_tree,
+    write_broken_chain,
+    write_cyclic_pair,
     write_malformed_record,
     write_non_agr_record,
     write_record,
@@ -121,6 +126,151 @@ class TestResolutionChain:
         chain_tokens = [entry["token"] for entry in result["resolution_chain"]]
         # Chain starts at the requested token and walks to the terminal.
         assert chain_tokens == [TOKEN_OLD, TOKEN_MID, TOKEN_NEW]
+
+
+class TestResolutionChainStatus:
+    """Issue #87 - additive ``resolution_chain_status`` completeness signal.
+
+    Contract (ADR-RFC-ARCH-004 3.2, additive per 3.1.1): when a SUPERSEDED
+    record's supersession chain is followed, lookup_decision exposes a
+    ``resolution_chain_status`` string so a caller can distinguish a chain that
+    reached its terminal from one truncated by a broken link or a cycle. The
+    value is derived from the existing ``walk_supersession_chain`` outcome:
+
+      * walk outcome ``"ok"``     -> ``"complete"``
+      * walk outcome ``"broken"`` -> ``"broken"``  (chain still returned)
+      * walk outcome ``"cycle"``  -> ``"cyclic"``  (chain still returned, no hang)
+
+    The signal is additive: it never removes/renames an existing key, and a
+    consumer that ignores it is unaffected (back-compat asserted below).
+    """
+
+    _FIELD = "resolution_chain_status"
+    _ALLOWED = {"complete", "broken", "cyclic"}
+
+    @pytest.mark.unit
+    def test_complete_chain_reports_complete(self, tmp_path: Path) -> None:
+        """A SUPERSEDED record whose chain reaches a terminal => 'complete'."""
+        lookup_decision = _lookup_decision()
+        write_supersession_chain(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_OLD)
+
+        assert result["ok"] is True
+        assert result["record"]["status"] == "SUPERSEDED"
+        chain_tokens = [entry["token"] for entry in result["resolution_chain"]]
+        assert chain_tokens == [TOKEN_OLD, TOKEN_MID, TOKEN_NEW]
+        assert result[self._FIELD] == "complete"
+
+    @pytest.mark.unit
+    def test_broken_chain_reports_broken_and_returns_partial(self, tmp_path: Path) -> None:
+        """A missing successor TOKEN => 'broken' + the partial chain still returned."""
+        lookup_decision = _lookup_decision()
+        write_broken_chain(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_BROKEN)
+
+        # The read itself still succeeds (the data is correct, just truncated).
+        assert result["ok"] is True
+        assert result["record"]["status"] == "SUPERSEDED"
+        assert result[self._FIELD] == "broken"
+        # The entry gathered so far is surfaced (partial resolution, not empty),
+        # and the missing successor is NOT fabricated into the chain.
+        chain_tokens = [entry["token"] for entry in result["resolution_chain"]]
+        assert chain_tokens == [TOKEN_BROKEN]
+        assert TOKEN_MISSING not in chain_tokens
+
+    @pytest.mark.unit
+    def test_cyclic_chain_reports_cyclic_without_hanging(self, tmp_path: Path) -> None:
+        """A SUPERSEDED_BY cycle => 'cyclic', returns (no unbounded walk/hang)."""
+        lookup_decision = _lookup_decision()
+        write_cyclic_pair(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_CYCLE_A)
+
+        assert result["ok"] is True
+        assert result["record"]["status"] == "SUPERSEDED"
+        assert result[self._FIELD] == "cyclic"
+        # Fail-closed cycle detection still surfaces the gathered partial chain.
+        assert result["resolution_chain"]
+
+    @pytest.mark.unit
+    def test_non_superseded_record_reports_complete(self, tmp_path: Path) -> None:
+        """A non-SUPERSEDED record has an empty (untruncated) chain => 'complete'.
+
+        Chosen contract: the empty chain of a terminal/active record is by
+        definition not truncated, so the completeness signal is 'complete'. The
+        field is always present (a defined PROD::I4 key), never broken/cyclic
+        for a record with no supersession chain.
+        """
+        lookup_decision = _lookup_decision()
+        write_record(tmp_path, token=TOKEN_RATIFIED, status="RATIFIED")
+        result = lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+
+        assert result["ok"] is True
+        assert result["resolution_chain"] == []
+        assert result[self._FIELD] == "complete"
+
+    @pytest.mark.unit
+    def test_status_value_is_in_allowed_domain(self, tmp_path: Path) -> None:
+        """The value is always a member of the closed enum (PROD::I4 defined field)."""
+        lookup_decision = _lookup_decision()
+        write_supersession_chain(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_OLD)
+        assert result[self._FIELD] in self._ALLOWED
+
+
+class TestResolutionChainStatusBackCompat:
+    """Back-compat: the additive field must not disturb any existing key.
+
+    ADR-RFC-ARCH-004 3.1.1 permits added fields but forbids removing/renaming
+    existing ones; consumers reading only the old keys MUST be unaffected.
+    """
+
+    _EXISTING_TOP_KEYS = {"ok", "record", "resolution_chain"}
+    _EXISTING_RECORD_KEYS = {
+        "token",
+        "type",
+        "version",
+        "status",
+        "tier",
+        "decision",
+        "because",
+        "authored_at",
+        "path",
+        "fields",
+    }
+
+    @pytest.mark.unit
+    def test_existing_keys_unchanged_for_superseded(self, tmp_path: Path) -> None:
+        """Every pre-#87 key is still present with its prior value/shape."""
+        lookup_decision = _lookup_decision()
+        write_supersession_chain(tmp_path)
+        result = lookup_decision(str(tmp_path), TOKEN_OLD)
+
+        # No existing key removed/renamed (additive-only: superset is allowed).
+        assert set(result) >= self._EXISTING_TOP_KEYS
+        assert set(result["record"]) >= self._EXISTING_RECORD_KEYS
+        # Existing values are byte-stable.
+        assert result["ok"] is True
+        assert result["record"]["token"] == TOKEN_OLD
+        assert result["record"]["status"] == "SUPERSEDED"
+        assert [e["token"] for e in result["resolution_chain"]] == [
+            TOKEN_OLD,
+            TOKEN_MID,
+            TOKEN_NEW,
+        ]
+        # The only new top-level key is the additive completeness signal.
+        assert set(result) - self._EXISTING_TOP_KEYS == {"resolution_chain_status"}
+
+    @pytest.mark.unit
+    def test_existing_keys_unchanged_for_non_superseded(self, tmp_path: Path) -> None:
+        """The non-superseded happy path keeps its exact pre-#87 key set."""
+        lookup_decision = _lookup_decision()
+        write_record(tmp_path, token=TOKEN_RATIFIED, scope="hestai-context-mcp")
+        result = lookup_decision(str(tmp_path), TOKEN_RATIFIED)
+
+        assert set(result) >= self._EXISTING_TOP_KEYS
+        assert set(result["record"]) >= self._EXISTING_RECORD_KEYS
+        assert result["resolution_chain"] == []
+        assert set(result) - self._EXISTING_TOP_KEYS == {"resolution_chain_status"}
 
 
 class TestErrorEnvelope:


### PR DESCRIPTION
Closes #87.

## What

Adds an **additive** `resolution_chain_status` field to `lookup_decision`'s return so a caller can tell a complete supersession chain from one truncated by a broken link or a cycle. Previously, a SUPERSEDED record with a broken/cyclic chain returned `ok:True` with a **partial** `resolution_chain` and no signal that it was cut short (cubic P2 on PR #86 / CRS §3.4 dangling-terminal advisory).

## The additive field — 3 states

`resolution_chain_status: "complete" | "broken" | "cyclic"`, derived from the **same** `walk_supersession_chain` outcome that already produces `resolution_chain` (no second read — PROD I5 purity preserved):

| walk outcome | `resolution_chain_status` | meaning |
|---|---|---|
| `ok`     | `"complete"` | reached a terminal record |
| `broken` | `"broken"`   | successor `TOKEN` missing on disk (= `trace_supersedure` `CHAIN_BROKEN`) |
| `cycle`  | `"cyclic"`   | `SUPERSEDED_BY` cycle, fail-closed walk (= `trace_supersedure` `CHAIN_CYCLE_DETECTED`) |

A non-SUPERSEDED record (empty, untruncated chain) is `"complete"`. The field is **always present** (a defined PROD I4 key). The broken/cyclic cases still return the partial chain gathered so far; the cyclic walk never runs unbounded (no hang).

`trace_supersedure` remains the authoritative `CHAIN_BROKEN` / `CHAIN_CYCLE_DETECTED` **error** source; this is the in-band observability signal on `lookup_decision` that agrees with it.

## Back-compat (additive-only, ADR-RFC-ARCH-004 §3.1.1)

No existing `§3.2` key is removed or renamed. Two dedicated back-compat tests assert the pre-#87 top-level and record key sets are intact and that the **only** new top-level key is `resolution_chain_status`. Consumers ignoring the field are unaffected.

## ADR doc

ADR-RFC-ARCH-004 **§3.2** return-shape updated to document the additive field, its value domain, the walk-outcome derivation, and the relationship to `trace_supersedure`.

## TDD evidence

- RED commit `c72b8c2`: 7 new tests fail for the right reason (`KeyError: 'resolution_chain_status'` / back-compat `AssertionError`); 10 existing stay green.
- GREEN commit `40e8d5b`: 17 `lookup_decision` tests pass (7 new + 10 back-compat). 29 pass across `lookup_decision` + `trace_supersedure`; 39 across the full read-side governance suite.
- Coverage **100%** on `lookup_decision.py`; ruff / black / mypy clean.
- Also removed stale "tool does not exist yet / ModuleNotFoundError" docstrings from the test file (the tool shipped in #86).

## Constraints honored

- PROD I4 structured return (additive defined key) · PROD I5 pure read (status from existing walk, no new read) · North Star §4 regex-only (no new parsing).

## Gate status

- TMG ✅ (RED methodology gate approved; GREEN authorized)
- CRS + CE — pending re-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `resolution_chain_status` to `lookup_decision` so callers can tell if a supersession chain is complete, broken, or cyclic. The response stays backward compatible and still returns a partial chain when truncated.

- **New Features**
  - Derived from existing `walk_supersession_chain` outcome (no extra reads).
  - Always present and additive; non-SUPERSEDED records report `"complete"`.
  - ADR §3.2 updated; tests cover enum values, cycles/broken chains, and back-compat.

<sup>Written for commit 0da6a9d4e62339c5c6aa3525464e1c8a4aea1961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

