### PR TITLE
docs: add decision lookup discipline configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,83 @@
 # hestai-context-mcp
 
-Memory and Environment MCP server providing session lifecycle, context synthesis, learnings extraction, and review infrastructure via stdio transport.
+Persistent memory and environmental context for AI-assisted development. An MCP server that gives any AI agent instant project awareness — decisions made, learnings accumulated, current git and project state — without human explanation.
+
+## Overview
+
+`hestai-context-mcp` is the **Memory and Environment** service in the HestAI three-service architecture:
+
+| Service | Role |
+|---------|------|
+| **Workbench** | Eyes and Hands — UI, dispatch, agent orchestration |
+| **Vault** | DNA — agent definitions, skills, governance standards |
+| **hestai-context-mcp** | Memory and Environment — session state, context synthesis, learnings, governance records |
+
+Each development session reads from accumulated memory (decisions, learnings, git state, project context) and writes back to it (learnings extraction, governance records). The next agent session starts smarter than the last.
+
+## Quick Start
+
+**Prerequisites:** Python 3.11+, `uv`, Git
+
+```bash
+# Clone and install
+git clone https://github.com/elevanaltd/hestai-context-mcp.git
+cd hestai-context-mcp
+uv sync                      # core dependencies only
+uv sync --extra validation   # adds real OCTAVE validator (recommended)
+
+# Register with your AI clients
+bash setup_local_configs.sh  # registers with Claude Code, Gemini CLI, Codex, Goose
+```
+
+The server runs over stdio JSON-RPC. No daemon, no ports — your AI client spawns it per session via the MCP protocol.
+
+## MCP Tools
+
+Eight tools, all returning structured dicts with defined fields. See [`docs/tools.md`](docs/tools.md) for full parameter and return-shape reference.
+
+### Session Lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `clock_in(role, working_dir, focus?)` | Start a session. Discovers North Stars, project context, phase constraints, and git state. Restores portable session state from prior sessions. |
+| `clock_out(session_id, transcript_parser?, transcript_content?)` | End a session. Extracts learnings, redacts credentials (fail-closed), archives transcript, publishes portable state. |
+
+### Context Synthesis
+
+| Tool | Description |
+|------|-------------|
+| `get_context(working_dir)` | Pure read. Same context structure as `clock_in` without session creation. Zero side effects — safe for repeated or parallel calls. |
+
+### Review Infrastructure
+
+| Tool | Description |
+|------|-------------|
+| `submit_review(repo, pr_number, role, verdict, assessment, commit_sha?, dry_run?)` | Post a structured PR review verdict (8 reviewer roles, 3 verdicts: APPROVED / BLOCKED / CONDITIONAL). |
+
+### Governance
+
+| Tool | Description |
+|------|-------------|
+| `submit_governance(working_dir, octave_content?, prose_input?, dry_run?)` | Create a governance record. Accepts raw OCTAVE or plain prose (AI-compiled). Handles validation, token assignment, and PR creation automatically. |
+| `list_decisions(working_dir, scope?, status?, tier?)` | List Agent-Readable Governance Records (AGRs) with optional filtering by scope, status, or tier. |
+| `lookup_decision(working_dir, token, audience?)` | Resolve a single AGR by TOKEN. Returns the full record and supersession resolution chain. |
+| `trace_supersedure(working_dir, token)` | Walk the supersession chain from a TOKEN to its terminal ratified state. Detects cycles and broken links. |
+
+## Configuration
+
+The server loads configuration at startup from these sources, in priority order:
+
+1. Process environment variables
+2. Keyring (service name: `ai_config`)
+3. `.env` file in the repo root or current working directory
+
+**Variables:**
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `OPENROUTER_API_KEY` | AI provider key for prose-mode governance compilation | Only if using `prose_input` in `submit_governance` |
+| `HESTAI_AI_MODEL` | Model for prose compilation (e.g. `openai/gpt-4o`) | Only if using prose mode |
+| `GITHUB_TOKEN` | GitHub PAT for `submit_review` and `submit_governance` PR creation | For governance and review tools |
 
 ## Claude / Agent Configuration
 
@@ -37,3 +114,38 @@ EXCEPTION_DECISION_RECORD::[.hestai/decisions/[DECISION_RECORD]→mcp__hestai-co
 - New decisions are authored via `submit_governance(prose_input, working_dir)` —
   the tool handles OCTAVE compilation, token assignment, and PR creation
 - `octave_write` is NOT used for governance records
+
+## Design Principles
+
+Six immutable constraints govern this service. Any change that violates one requires
+escalation to the requirements steward — they are not negotiable at implementation time.
+
+1. **Session Lifecycle Integrity** — Every session has a clean create-and-archive lifecycle. Orphaned sessions are failures, not acceptable state.
+2. **Credential Safety** — Zero credentials persist in archives. Redaction is fail-closed: no archive rather than an unredacted one.
+3. **Provider Agnostic Context** — Context synthesis is identical across Claude, Codex, Gemini, and Goose. No provider-specific fields.
+4. **Structured Return Shapes** — All tools return structured dicts with defined fields, never unstructured blobs.
+5. **Read-Only Context Query** — `get_context` has zero side effects. Pure read, idempotent, safe for parallel calls.
+6. **Legacy Independence** — No runtime dependency on the legacy `hestai-mcp` package, enabling A/B comparison without cascade.
+
+## Development
+
+```bash
+# Lint and type check
+.venv/bin/python -m ruff check src
+.venv/bin/python -m mypy src
+
+# Run tests
+.venv/bin/python -m pytest
+
+# With coverage report
+.venv/bin/python -m pytest --cov=hestai_context_mcp --cov-report=term-missing
+```
+
+CI enforces 85% coverage minimum, strict mypy, ruff, and black on every push.
+
+## Further Reading
+
+- [`docs/tools.md`](docs/tools.md) — Full tool reference: parameters, return shapes, error envelopes
+- [`docs/architecture.md`](docs/architecture.md) — Module layout, internal abstractions, key design decisions
+- [`.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR.md`](.hestai/north-star/000-HESTAI-CONTEXT-MCP-NORTH-STAR.md) — Full product North Star (immutables, assumptions, gates, escalation)
+- [`.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md`](.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md) — AGR format spec and tool contracts

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 # hestai-context-mcp
 
 Memory and Environment MCP server providing session lifecycle, context synthesis, learnings extraction, and review infrastructure via stdio transport.
+
+## Claude / Agent Configuration
+
+Add the following block to `~/.claude/CLAUDE.md` (applies to all repos) to wire up
+the decision lookup discipline and governance record exception:
+
+```
+===DECISION_LOOKUP_DISCIPLINE===
+⚠️::BLOCKING_DIRECTIVE
+SCOPE::ALL_repos[hestai-context_enabled]
+TRIGGER::before_work[architectural∨scope_affecting∨security∨db_schema]
+PRECONDITION:
+  STEP_0::[token_unknown→mcp__hestai-context__list_decisions[working_dir]→identify_relevant_token]
+  STEP_1::mcp__hestai-context__lookup_decision[token∧working_dir]
+  STEP_2::[token_resolves→mcp__hestai-context__trace_supersedure[token∧working_dir]→terminal_ratified_state]
+RESULT_HANDLING::[honour_ratified_decisions∧NO_relitigate→escalate_requirements-steward]
+CREATION_PATH::[new_decisions→mcp__hestai-context__submit_governance[prose_input∧working_dir]]
+===END_DECISION_LOOKUP_DISCIPLINE===
+```
+
+If your project also uses the `octave` MCP server, add this exception line inside your
+existing `===OCTAVE_WRITE_GATE===` block (after `MAIN_AUTHOR::octave-secretary`):
+
+```
+EXCEPTION_DECISION_RECORD::[.hestai/decisions/[DECISION_RECORD]→mcp__hestai-context__submit_governance[prose_input∧working_dir]∧NOT_octave_write]
+```
+
+**What this does:**
+- Before any architectural, scope, security, or DB-schema work: scan the decision
+  corpus (`list_decisions`), resolve a specific record (`lookup_decision`), walk the
+  supersedure chain to the terminal ratified state (`trace_supersedure`)
+- Ratified decisions are binding — no re-litigation without escalating to
+  requirements-steward
+- New decisions are authored via `submit_governance(prose_input, working_dir)` —
+  the tool handles OCTAVE compilation, token assignment, and PR creation
+- `octave_write` is NOT used for governance records

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,7 +194,7 @@ try:
     from octave_mcp import validate
     return RealOctaveValidator(validate)
 except ImportError:
-    return NullOctaveValidator()  # Gate B skipped, Gate A (regex) still enforced
+    return UnavailableOctaveValidator()  # Gate B skipped, Gate A (regex) still enforced
 ```
 
 This means the server works without octave-mcp installed. Installing `--extra validation`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,236 @@
+# Architecture
+
+## Role in the HestAI Ecosystem
+
+`hestai-context-mcp` is the **Memory and Environment** service in the HestAI three-service model (ADR-0353):
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    AI Agent (any provider)               │
+└────────────────┬──────────────────┬─────────────────────┘
+                 │ MCP (stdio)      │ MCP (stdio)
+        ┌────────▼───────┐  ┌───────▼────────┐
+        │    Workbench   │  │      Vault     │
+        │  Eyes & Hands  │  │      DNA       │
+        │  UI, dispatch  │  │  agent defs,   │
+        │  orchestration │  │  skills, stds  │
+        └────────────────┘  └────────────────┘
+                 │ MCP (stdio)
+        ┌────────▼───────────────────────────┐
+        │       hestai-context-mcp           │
+        │       Memory & Environment         │
+        │  sessions, context, learnings,     │
+        │  governance records                │
+        └────────────────────────────────────┘
+```
+
+The memory service accumulates over time. When an agent calls `clock_in`, it receives
+the full project context — North Stars, decisions, git state, phase constraints, and
+portable state from prior sessions — without any human explanation.
+
+## Transport
+
+Stdio JSON-RPC (MCP protocol). The server is spawned per invocation by the AI client.
+No daemon, no ports, no persistent process. Configuration is loaded once at startup
+from environment variables, keyring, and `.env`.
+
+## Module Layout
+
+```
+src/hestai_context_mcp/
+├── server.py                    # FastMCP instance, tool registration, .env loading
+├── tools/                       # MCP tool implementations (thin layer, delegates to core/)
+│   ├── clock_in.py
+│   ├── clock_out.py
+│   ├── get_context.py           # PURITY_GUARD::G3 — zero storage/ imports allowed here
+│   ├── submit_review.py
+│   ├── submit_governance.py
+│   ├── list_decisions.py
+│   ├── lookup_decision.py
+│   ├── trace_supersedure.py
+│   ├── governance/              # AGR read primitives and write pipeline
+│   │   ├── agr_read.py          # Shared: TOKEN resolution, chain walking, OCTAVE parsing
+│   │   ├── type_checker.py      # Gate A: regex content validation
+│   │   ├── linker.py            # AMENDS/EXTENDS edge resolution, PR creation
+│   │   ├── manifest.py          # .hestai/MANIFEST.md TOKEN index generation
+│   │   ├── lexer.py             # OCTAVE tokenization
+│   │   └── lineage.py           # SUPERSEDED_BY edge tracking
+│   └── shared/
+│       ├── github_auth.py       # GitHub token: env → gh CLI → error
+│       └── review_formats.py    # Review comment formatting, gate-clear checks
+├── core/                        # Domain logic
+│   ├── session.py               # SessionManager: lifecycle, focus conflict detection
+│   ├── synthesis.py             # AI synthesis seam (provider-agnostic AIClient port)
+│   ├── context_steward.py       # Phase-constraint extraction from workflow files
+│   ├── git_state.py             # Branch, ahead/behind, modified files
+│   ├── north_star_parser.py     # Extracts scope_boundaries and immutables from North Star
+│   ├── focus.py                 # Focus resolution: explicit > GitHub issue > branch > default
+│   ├── phase.py                 # Phase resolution from .hestai state
+│   ├── redaction.py             # Credential redaction (7 patterns, fail-closed)
+│   ├── intake_pipeline.py       # Gate C prose mode: Stage 1-2 (context + AI compilation)
+│   ├── intake_compiler.py       # AI prose→OCTAVE compilation with cost capping
+│   ├── governance_reviewer.py   # Stage 5: async semantic review at analysis tier
+│   ├── agent_readable_governance_parser.py  # OCTAVE DECISION_RECORD parsing, UPOG compliance
+│   └── transcript/
+│       ├── base.py              # TranscriptMessage value type
+│       ├── claude.py            # Claude-format transcript parser
+│       └── registry.py         # detect_parser: multi-provider adapter factory
+├── ports/                       # Dependency-inversion boundary (protocols only, no impl)
+│   ├── ai_client.py             # AIClient protocol: CompletionRequest, CompletionResponse
+│   └── octave_validator.py      # OctaveValidator port: feature-detects octave-mcp, degrades gracefully
+├── adapters/                    # Implementations of ports
+│   ├── openai_compat_ai_client.py  # OpenAI-compat HTTP client via httpx
+│   └── ai_config.py             # Credential resolution: env → keyring → .env
+└── storage/                     # Portable Session State (ADR-0013)
+    ├── protocol.py              # StorageAdapter @runtime_checkable Protocol
+    ├── local_filesystem.py      # LocalFilesystemAdapter: append-first, hash-validated
+    ├── identity.py              # IdentityTuple validation
+    ├── identity_resolver.py     # Resolves identity from project context
+    ├── schema.py                # Artifact schema validation, version negotiation
+    ├── types.py                 # PortableMemoryArtifact, TombstoneArtifact, unions
+    ├── projection.py            # Applies tombstones → derives active artifact set
+    ├── snapshots.py             # Named session snapshots bound to session_id
+    ├── outbox.py                # Durable outbox for failed publishes (R7)
+    └── provenance.py            # Redaction source tracking, fail-closed (RISK_010)
+```
+
+## Key Abstractions
+
+### Ports and Adapters
+
+External dependencies (AI providers, OCTAVE validator) are hidden behind protocol interfaces
+in `ports/`. Adapters in `adapters/` provide the implementations. This is what makes the
+server provider-agnostic (North Star PROD::I3) and legacy-independent (PROD::I6).
+
+```
+tools/ → core/ → ports/AIClient ←→ adapters/openai_compat_ai_client.py
+                  ports/OctaveValidator ←→ (optional) octave-mcp
+```
+
+### Storage and Portable Session State
+
+The `storage/` subsystem implements Portable Session State (ADR-0013). When `clock_out`
+runs, it writes `PortableMemoryArtifact` objects to the local filesystem. When `clock_in`
+runs in a subsequent session, it restores those artifacts, giving the new agent continuity
+with prior sessions.
+
+Tombstones (`TombstoneArtifact`) mark deleted artifacts. `projection.py` applies tombstones
+to derive the active set. Failed writes go to a durable outbox (`outbox.py`) for manual retry.
+
+### AGR Read Primitives
+
+`tools/governance/agr_read.py` is the single source of truth for working with
+Agent-Readable Governance Records on disk:
+
+- `iter_record_paths(working_dir)` — yields all `.oct.md` files under `.hestai/decisions/`
+- `discover_record(working_dir, token)` — finds a specific record by TOKEN
+- `load_parsed(path)` — parses OCTAVE DECISION_RECORD content into structured fields
+- `walk_supersession_chain(working_dir, token)` — follows SUPERSEDED_BY pointers to terminal state
+
+All three read tools (`list_decisions`, `lookup_decision`, `trace_supersedure`) delegate to
+these primitives. The primitives are pure read — no writes, no side effects.
+
+### Governance Intake Pipeline
+
+`submit_governance` supports two mutually-exclusive modes:
+
+```
+Mode A (octave_content):
+  Raw OCTAVE → Gate A (regex) → Gate B (octave-mcp, optional) → link edges → PR
+
+Mode C (prose_input):
+  Prose → Stage 1 (context assembly) → Stage 2 (AI compilation) →
+  Gate A → Gate B → Stage 5 (semantic review) → link edges → PR
+```
+
+Gate B requires the `validation` extra (`uv sync --extra validation`). Without it, Gate B
+is skipped — Gate A (regex) is always enforced. This preserves PROD::I6: octave-mcp is
+optional, not a hard dependency.
+
+## Design Decisions
+
+### Fail-Closed Credential Redaction
+
+`clock_out` runs the `RedactionEngine` against the transcript before writing the archive.
+If redaction raises an exception or detects that it would produce an unsafe output, the
+archive write is blocked. The session record shows an error rather than writing a
+potentially-sensitive file. This implements PROD::I2 (Credential Safety): data loss is
+preferred over data exposure.
+
+Seven credential patterns are detected: AI API keys, AWS credentials, database URIs
+(Postgres, MySQL, Redis), GitHub PATs, generic high-entropy tokens, and common API key
+patterns.
+
+### Pure Read Enforcement for `get_context`
+
+`get_context` is called by the Payload Compiler (Position 3), which may invoke it
+repeatedly, in parallel, or speculatively. It must have zero side effects (PROD::I5).
+
+This is enforced at two levels:
+1. **Source-level**: `get_context.py` imports nothing from `storage/`. A static test
+   (`tests/storage/test_source_invariants_pss.py`) verifies this assertion.
+2. **Design-level**: The function is a pure computation over files it reads — no writes,
+   no session creation, no PSS restoration.
+
+### Supersession DAG
+
+Governance records can supersede prior records via the `SUPERSEDED_BY` field. This creates
+a directed acyclic graph of decisions. `trace_supersedure` walks this DAG to find the
+terminal ratified state for any given token.
+
+Cycle detection is fail-closed: the tool tracks visited tokens and returns
+`CHAIN_CYCLE_DETECTED` if a token appears twice, rather than looping indefinitely.
+A broken link (`CHAIN_BROKEN`) signals a governance integrity problem — a `SUPERSEDED_BY`
+pointer references a token that does not exist on disk.
+
+### Optional octave-mcp Integration
+
+The OCTAVE validator runs inside the governance intake pipeline (Gate B). It is exposed
+as a port (`OctaveValidator`) and feature-detected at runtime:
+
+```python
+# ports/octave_validator.py — simplified
+try:
+    from octave_mcp import validate
+    return RealOctaveValidator(validate)
+except ImportError:
+    return NullOctaveValidator()  # Gate B skipped, Gate A (regex) still enforced
+```
+
+This means the server works without octave-mcp installed. Installing `--extra validation`
+enables stricter governance record checking.
+
+### Provider Agnostic Transcript Parsing
+
+`core/transcript/registry.py` implements `detect_parser(transcript_content)`. It inspects
+the transcript structure and returns the appropriate parser:
+
+- Claude Code JSONL format → `ClaudeTranscriptParser`
+- (Future providers: Gemini, Codex, Goose parsers can be added without changing callers)
+
+Callers in `clock_out` never reference a specific parser — they call `detect_parser` and
+receive an adapter. This preserves PROD::I3.
+
+## `.hestai/` Directory
+
+The `.hestai/` directory is both consumed and written by this server. Key paths:
+
+```
+.hestai/
+  north-star/            # Product North Star (OCTAVE) — read by get_context, clock_in
+  decisions/             # AGR corpus — read by list/lookup/trace, written by submit_governance
+    rfc-arch/            # Architectural ADRs (OCTAVE and prose)
+    security/            # Security design records
+  state/
+    sessions/active/     # Live session metadata and transcripts
+    portable/pss/        # Portable session state artifacts
+    outbox/              # Failed publish queue
+  context/
+    PROJECT-CONTEXT.oct.md  # Project state summary — read by clock_in, get_context
+  workflow/
+    OPERATIONAL-WORKFLOW.oct.md  # Phase constraints — read by ContextSteward
+  MANIFEST.md            # TOKEN index (auto-generated by submit_governance)
+```
+
+The server never writes to `north-star/` or `workflow/` — those are human-maintained.
+It writes to `state/`, `decisions/`, and `MANIFEST.md`.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,345 @@
+# Tool Reference
+
+All tools are exposed over stdio JSON-RPC via the MCP protocol. All return structured dicts
+with defined fields — never unstructured blobs (North Star PROD::I4).
+
+---
+
+## `clock_in`
+
+Register the start of an agent session. Returns a full context snapshot the agent can use
+immediately without further queries.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `role` | string | yes | Agent role identifier (e.g. `implementation-lead`, `holistic-orchestrator`) |
+| `working_dir` | string | yes | Absolute path to the project root |
+| `focus` | string | no | Optional focus override (GitHub issue URL, topic string, or branch-derived) |
+
+**Return shape:**
+
+```json
+{
+  "session_id": "uuid",
+  "role": "implementation-lead",
+  "focus": "issue #42 — add trace_supersedure tool",
+  "focus_source": "explicit | github_issue | branch | default",
+  "branch": "feat/trace-supersedure",
+  "working_dir": "/path/to/project",
+  "phase": "B1_FOUNDATION_COMPLETE",
+  "context_paths": ["path/to/north-star.md", "..."],
+  "ai_synthesis": "...",
+  "context": {
+    "product_north_star": "...",
+    "project_context": "...",
+    "phase_constraints": "...",
+    "git_state": { "branch": "...", "modified_files": [], "ahead": 0, "behind": 0 },
+    "active_sessions": [],
+    "conflicts": []
+  },
+  "portable_state": {
+    "restore_status": "restored | no_artifacts | identity_mismatch",
+    "artifact_count": 3
+  }
+}
+```
+
+**Notes:**
+- Detects focus conflicts when multiple sessions are active on the same working directory.
+- Restores portable session state from prior sessions via the `LocalFilesystemAdapter`.
+- Does not fail if North Star or project context files are absent — returns what is available.
+
+---
+
+## `clock_out`
+
+Archive a session. Extracts learnings from the transcript, redacts credentials, and publishes
+portable session state for the next agent.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `session_id` | string | yes | UUID returned by `clock_in` |
+| `transcript_parser` | string | no | Parser hint: `"claude"` or omit for auto-detection |
+| `transcript_content` | string | no | Raw transcript JSON/text to archive |
+
+**Return shape:**
+
+```json
+{
+  "session_id": "uuid",
+  "archive_path": ".hestai/state/sessions/active/{uuid}/transcript-archive/...",
+  "learnings": {
+    "decisions": ["ADR: decided to use stdio transport because..."],
+    "blockers": ["BLOCKER: octave-mcp validation unavailable in CI"],
+    "learnings": ["LEARNING: redaction must run before archival, not after"]
+  },
+  "portable_publication": {
+    "restore_status": "published | failed | empty",
+    "identity": { "project_id": "...", "workspace_id": "...", "user_id": "..." },
+    "artifact_count": 3,
+    "snapshot_path": ".hestai/state/portable/pss/...",
+    "errors": []
+  }
+}
+```
+
+**Notes:**
+- Credential redaction is **fail-closed**: if redaction fails, no archive is written (North Star PROD::I2).
+  The tool returns an error rather than writing a potentially-sensitive archive.
+- Learnings are extracted by scanning transcript content for `DECISION:`, `BLOCKER:`, and `LEARNING:` markers.
+- If `transcript_content` is omitted, archives an empty transcript record (session bookkeeping only).
+
+---
+
+## `get_context`
+
+Pure read — no session created, no files written. Returns the same context structure as
+`clock_in` minus session metadata. Safe for repeated and parallel calls (North Star PROD::I5).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `working_dir` | string | yes | Absolute path to the project root |
+
+**Return shape:**
+
+```json
+{
+  "working_dir": "/path/to/project",
+  "context": {
+    "product_north_star": "...",
+    "project_context": "...",
+    "phase_constraints": "...",
+    "git_state": { "branch": "...", "modified_files": [], "ahead": 0, "behind": 0 },
+    "active_sessions": []
+  }
+}
+```
+
+**Notes:**
+- Intended for the Payload Compiler (Position 3) which may call it repeatedly or in parallel.
+- Enforced at source level: `get_context.py` has zero imports from the `storage/` subsystem
+  (`PURITY_GUARD::G3`). This is verified by a static test.
+- Equivalent to `clock_in` context without focus resolution, conflict detection, or PSS restore.
+
+---
+
+## `submit_review`
+
+Post a structured PR review verdict to GitHub.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `repo` | string | yes | GitHub repo in `owner/repo` format |
+| `pr_number` | integer | yes | Pull request number |
+| `role` | string | yes | Reviewer role: `CE`, `CIV`, `CRS`, `HO`, `IL`, `PE`, `SR`, or `TMG` |
+| `verdict` | string | yes | `APPROVED`, `BLOCKED`, or `CONDITIONAL` |
+| `assessment` | string | yes | Prose assessment text |
+| `commit_sha` | string | no | Specific commit SHA to review against |
+| `dry_run` | boolean | no | If true, validates without posting to GitHub |
+
+**Return shape:**
+
+```json
+{
+  "success": true,
+  "pr_url": "https://github.com/owner/repo/pull/42",
+  "role": "CRS",
+  "verdict": "APPROVED",
+  "would_clear_gate": true,
+  "error": null
+}
+```
+
+**Reviewer roles:**
+
+| Code | Role |
+|------|------|
+| `CE` | Continuity Evaluator |
+| `CIV` | Critical Implementation Validator |
+| `CRS` | Code Review Specialist |
+| `HO` | Holistic Orchestrator |
+| `IL` | Implementation Lead |
+| `PE` | Product Evaluator |
+| `SR` | Security Reviewer |
+| `TMG` | Test Methodology Guardian |
+
+---
+
+## `submit_governance`
+
+Create an Agent-Readable Governance Record (AGR). Accepts raw OCTAVE content (Gate A/B)
+or plain prose (Gate C, AI-compiled). Handles validation, TOKEN assignment, and PR creation.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `working_dir` | string | yes | Absolute path to the project root |
+| `octave_content` | string | no* | Pre-authored OCTAVE governance record |
+| `prose_input` | string | no* | Plain prose description — compiled to OCTAVE by AI |
+| `dry_run` | boolean | no | If true, validates without writing files or creating a PR |
+
+*Exactly one of `octave_content` or `prose_input` must be provided.
+
+**Intake pipeline:**
+
+```
+octave_content → Gate A (regex check) → Gate B (octave-mcp validation) → link → PR
+prose_input    → Stage 1-2 (context + AI compilation) → Gate A → Gate B → Stage 5 (semantic review) → link → PR
+```
+
+**Return shape:**
+
+```json
+{
+  "success": true,
+  "token": "HO-MY-DECISION-TITLE-20260613",
+  "card_type": "DECISION_RECORD",
+  "target_path": ".hestai/decisions/HO-MY-DECISION-TITLE-20260613.oct.md",
+  "branch": "governance/HO-MY-DECISION-TITLE-20260613",
+  "pr_url": "https://github.com/owner/repo/pull/99",
+  "validation_errors": [],
+  "octave_validation": { "valid": true, "errors": [] },
+  "semantic_review": { "verdict": "APPROVED", "notes": "..." },
+  "metrics": { "stage_1_ms": 120, "stage_2_ms": 3400, "total_ms": 3800 },
+  "dry_run": false
+}
+```
+
+**Notes:**
+- TOKEN format: `{NAMESPACE}-{SLUG}-{YYYYMMDD}` (e.g. `HO-CREDENTIAL-SAFETY-RATIFIED-20260611`)
+- Prose mode requires `OPENROUTER_API_KEY` and `HESTAI_AI_MODEL` to be configured.
+- Gate B (real OCTAVE validation) requires the `validation` extra: `uv sync --extra validation`.
+  Without it, Gate B is skipped and Gate A (regex) is the only validator.
+- `octave_write` is NOT the authoring path for governance records — use this tool.
+
+---
+
+## `list_decisions`
+
+List Agent-Readable Governance Records in the project's decision corpus.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `working_dir` | string | yes | Absolute path to the project root |
+| `scope` | string | no | Filter by scope prefix (e.g. `"HO"`, `"ADR-RFC-ARCH"`) |
+| `status` | string | no | Filter by status: `"PROPOSED"`, `"RATIFIED"`, or `"SUPERSEDED"` |
+| `tier` | string | no | Filter by tier: `"DIRECTIVE"`, `"STANDARD"`, `"GUIDELINE"`, `"PATTERN"` |
+
+**Return shape:**
+
+```json
+{
+  "ok": true,
+  "records": [
+    {
+      "token": "HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611",
+      "status": "RATIFIED",
+      "tier": "DIRECTIVE",
+      "decision": "Semantic review runs at analysis tier against the full AGR corpus",
+      "authored_at": "2026-06-11",
+      "path": ".hestai/decisions/HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611.oct.md"
+    }
+  ],
+  "total": 1
+}
+```
+
+**Error envelope (on failure):**
+
+```json
+{ "ok": false, "error": "FILTER_INVALID | WORKING_DIR_INVALID | RECORD_PARSE_FAILED", "detail": "..." }
+```
+
+**Notes:**
+- Pure read. Zero side effects. Sorted by `authored_at` descending.
+- Use this as Step 0 of the decision lookup discipline when the TOKEN is unknown.
+
+---
+
+## `lookup_decision`
+
+Resolve a single AGR by TOKEN.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `working_dir` | string | yes | Absolute path to the project root |
+| `token` | string | yes | Full TOKEN string (e.g. `HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611`) |
+| `audience` | string | no | `"agent"` (default) or `"human"` — controls verbosity of return |
+
+**Return shape:**
+
+```json
+{
+  "ok": true,
+  "record": {
+    "token": "HO-AGR-SEMANTIC-REVIEWER-ANALYSIS-TIER-20260611",
+    "type": "DECISION_RECORD",
+    "version": "1",
+    "status": "RATIFIED",
+    "tier": "DIRECTIVE",
+    "decision": "Semantic review runs at analysis tier against the full AGR corpus",
+    "because": "Analysis-tier reviews surface systemic incoherence that single-record reviewers miss",
+    "authored_at": "2026-06-11",
+    "path": ".hestai/decisions/...",
+    "fields": { "SUPERSEDED_BY": null, "AMENDS": null, "EXTENDS": null }
+  },
+  "resolution_chain": [],
+  "resolution_chain_status": "complete"
+}
+```
+
+**When STATUS is SUPERSEDED**, `resolution_chain` contains entries describing the supersession path, and `resolution_chain_status` is `"complete"`, `"broken"`, or `"cyclic"`.
+
+---
+
+## `trace_supersedure`
+
+Walk the supersession chain from a TOKEN to the terminal ratified state. Use this as Step 2
+of the decision lookup discipline to confirm a record has not been superseded.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `working_dir` | string | yes | Absolute path to the project root |
+| `token` | string | yes | Starting TOKEN to trace from |
+
+**Return shape:**
+
+```json
+{
+  "ok": true,
+  "chain": [
+    { "token": "HO-OLD-DECISION-20260501", "status": "SUPERSEDED", "decision": "..." },
+    { "token": "HO-NEW-DECISION-20260611", "status": "RATIFIED", "decision": "..." }
+  ],
+  "terminal_token": "HO-NEW-DECISION-20260611",
+  "terminal_status": "RATIFIED"
+}
+```
+
+**Error envelope (on failure):**
+
+```json
+{ "ok": false, "error": "TOKEN_NOT_FOUND | CHAIN_BROKEN | CHAIN_CYCLE_DETECTED", "detail": "..." }
+```
+
+**Notes:**
+- Pure read. Zero side effects.
+- Cycle detection is fail-closed: if a cycle is detected, the tool returns an error rather than
+  looping indefinitely.
+- A `CHAIN_BROKEN` error means a `SUPERSEDED_BY` pointer references a TOKEN that does not
+  exist on disk — this is a governance integrity issue requiring human attention.


### PR DESCRIPTION
## Summary
- Added comprehensive "Claude / Agent Configuration" section to README documenting the decision lookup discipline from HO-DECISION-LOOKUP-DISCIPLINE-20260612
- Provided copy-paste configuration blocks for `~/.claude/CLAUDE.md` and octave MCP server integration
- Created supplementary architecture and tools documentation to support governance and decision workflows

## Changes
- **README.md**: Added "Claude / Agent Configuration" section with blocking directive for decision lookup, precondition steps (list/lookup/trace), result handling rules, and creation path for new governance records
- **docs/architecture.md**: New comprehensive architecture documentation covering system design patterns and decision governance framework
- **docs/tools.md**: New tools reference documenting MCP server integration (hestai-context, octave) and decision submission workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a config guide that wires up the decision lookup discipline and governance authoring for agents. Also adds new architecture and full tool reference docs for `hestai-context-mcp`, and fixes the validator class name in the architecture example.

- **Migration**
  - Paste the provided DECISION_LOOKUP_DISCIPLINE block into `~/.claude/CLAUDE.md`.
  - If you use the `octave` MCP server, add the exception inside your OCTAVE_WRITE_GATE to route `.hestai/decisions` through `submit_governance` (not `octave_write`).

- **Bug Fixes**
  - Corrected the architecture doc example to use `UnavailableOctaveValidator` (matches `ports/octave_validator.py`).

<sup>Written for commit 45fda930e372243d7d1617086ce25f188d18511a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

