### PR TITLE
fix: handle AI response truncation with accurate cost recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `AIClientTruncationError` in the AIClient port taxonomy — models output-token budget exhaustion (provider `finish_reason="length"`) distinctly from a malformed response, carrying the real `consumed_tokens` (issue #96)
+- Config-sourced provider upstream-routing pin: `HESTAI_AI_PROVIDER_ORDER` (comma-separated upstream slugs, OpenRouter) and `HESTAI_AI_PROVIDER_ROUTING=off` to disable. Defaults to a preferred order with `allow_fallbacks` preserved (prefer, not require), so a preferred-upstream outage degrades gracefully (issue #96)
+
+### Fixed
+- Stage-2 prose→OCTAVE (`submit_governance` prose mode) no longer fails non-deterministically when OpenRouter routes a reasoning model onto an upstream that truncates at the token cap: the pin reduces routing nondeterminism and `finish_reason="length"` is now surfaced as an actionable truncation error instead of an opaque protocol error (issue #96)
+- Truncated/budget-exhausted AI calls now record the **real** tokens and cost in the returned failure metrics instead of `tokens:0 / cost:0`; truncation is not retried (an identical re-issue would re-truncate and burn budget). Applies to `compile_prose_to_octave` and `review_governance` (issue #96)
+
 ---
 
 ## [0.8.0] — 2026-06-15 — AGR Read-Side & Gate-A Hardening

--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -45,6 +45,7 @@ __all__ = [
     "resolve_model",
     "resolve_api_key",
     "get_provider_base_url",
+    "resolve_provider_payload",
 ]
 
 # Keyring service names. See module docstring for migration rules.
@@ -78,6 +79,24 @@ _PROVIDER_ENV_VARS: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
 }
+
+# Issue #96 — provider upstream-routing pin (OpenRouter only).
+#
+# OpenRouter load-balances a model across multiple upstream providers per
+# request; for a reasoning model that non-determinism causes intermittent
+# output-cap truncation on the worse-fitted upstream. Pinning a *preferred*
+# upstream order removes the lottery while keeping ``allow_fallbacks`` True so a
+# preferred-upstream outage degrades gracefully (prefer, not require).
+#
+# The default order is intentionally minimal and fully env-overridable
+# (``HESTAI_AI_PROVIDER_ORDER``, comma-separated) so the upstream slug names can
+# be corrected without a code change. Routing can be disabled entirely via
+# ``HESTAI_AI_PROVIDER_ROUTING=off`` or by supplying an empty order list. Only
+# OpenRouter consumes a routing payload; other providers receive ``None``.
+_PROVIDER_ROUTING_DEFAULT_ORDER: dict[str, tuple[str, ...]] = {
+    "openrouter": ("MiniMax",),
+}
+_ROUTING_DISABLED_VALUES: frozenset[str] = frozenset({"off", "0", "false", "none", "disabled"})
 
 
 def resolve_provider() -> str:
@@ -128,6 +147,45 @@ def get_provider_base_url(provider: str) -> str:
         return _PROVIDER_BASE_URLS[provider]
     except KeyError as exc:
         raise ValueError(f"Unknown provider: {provider!r}") from exc
+
+
+def resolve_provider_payload(provider: str) -> dict[str, object] | None:
+    """Return the generic routing payload to merge into the request body.
+
+    The returned shape is the OpenRouter ``{"provider": {...}}`` envelope the
+    adapter merges verbatim into ``/chat/completions``. It is *config-sourced*
+    (there is no model-name branch here): the preferred upstream order comes
+    from :data:`_PROVIDER_ROUTING_DEFAULT_ORDER`, overridable via
+    ``HESTAI_AI_PROVIDER_ORDER`` (comma-separated upstream slugs).
+
+    ``allow_fallbacks`` is held True (prefer, not require) so a preferred
+    upstream outage degrades gracefully rather than hard-failing.
+
+    Returns ``None`` (no routing preference sent) when:
+        * the provider is not OpenRouter,
+        * ``HESTAI_AI_PROVIDER_ROUTING`` is set to a disabling value, or
+        * the resolved order list is empty.
+
+    Args:
+        provider: The configured provider identifier.
+    """
+    if provider != "openrouter":
+        return None
+
+    routing_flag = os.environ.get("HESTAI_AI_PROVIDER_ROUTING", "").strip().lower()
+    if routing_flag in _ROUTING_DISABLED_VALUES:
+        return None
+
+    order_override = os.environ.get("HESTAI_AI_PROVIDER_ORDER")
+    if order_override is not None:
+        order = [slug.strip() for slug in order_override.split(",") if slug.strip()]
+    else:
+        order = list(_PROVIDER_ROUTING_DEFAULT_ORDER.get(provider, ()))
+
+    if not order:
+        return None
+
+    return {"provider": {"order": order, "allow_fallbacks": True}}
 
 
 def _keyring_account(provider: str) -> str:

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -40,6 +40,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientAuthError,
     AIClientProtocolError,
     AIClientTransportError,
+    AIClientTruncationError,
     CompletionRequest,
 )
 
@@ -163,12 +164,52 @@ class OpenAICompatAIClient:
         message = first.get("message")
         if not isinstance(message, dict):
             raise AIClientProtocolError("provider response 'choices[0].message' is not an object")
+        # Issue #96: inspect the stop condition BEFORE the content type-check.
+        # ``finish_reason == "length"`` means the generation hit the output-token
+        # cap (budget exhaustion) — a well-formed envelope whose body is
+        # incomplete or null. This is a distinct, actionable condition, not a
+        # malformed response, so it must surface as ``AIClientTruncationError``
+        # carrying the real tokens billed. We deliberately do NOT fall back to
+        # ``reasoning``/``reasoning_content``: surfacing chain-of-thought as a
+        # compiled artifact is a safety hazard for governance content.
+        finish_reason = first.get("finish_reason")
+        if finish_reason == "length":
+            consumed, prompt_tokens, completion_tokens = self._extract_usage(body)
+            raise AIClientTruncationError(
+                "provider truncated output at the token cap (finish_reason='length')",
+                consumed_tokens=consumed,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
         content = message.get("content")
         if not isinstance(content, str):
             raise AIClientProtocolError(
                 "provider response 'choices[0].message.content' is not a string"
             )
         return content
+
+    @staticmethod
+    def _extract_usage(body: object) -> tuple[int, int | None, int | None]:
+        """Pull token counts from an OpenAI-compat ``usage`` block.
+
+        Returns ``(total_tokens, prompt_tokens, completion_tokens)``. Missing or
+        malformed fields degrade to ``0`` for the total and ``None`` for the
+        split — telemetry being unavailable must never mask the truncation.
+        """
+        usage = body.get("usage") if isinstance(body, dict) else None
+        if not isinstance(usage, dict):
+            return 0, None, None
+
+        def _as_int(value: object) -> int | None:
+            return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+        prompt_tokens = _as_int(usage.get("prompt_tokens"))
+        completion_tokens = _as_int(usage.get("completion_tokens"))
+        total = _as_int(usage.get("total_tokens"))
+        if total is None:
+            # Reconstruct the total from the split when the provider omits it.
+            total = (prompt_tokens or 0) + (completion_tokens or 0)
+        return total, prompt_tokens, completion_tokens
 
 
 def build_default_ai_client(*, tier: str = "default") -> AIClient | None:

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -218,7 +218,13 @@ class OpenAICompatAIClient:
             return 0, None, None
 
         def _as_int(value: object) -> int | None:
-            return value if isinstance(value, int) and not isinstance(value, bool) else None
+            # Issue #97: a negative count is invalid telemetry — treat it as
+            # absent so it can never bill negative tokens / negative cost.
+            return (
+                value
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+                else None
+            )
 
         prompt_tokens = _as_int(usage.get("prompt_tokens"))
         completion_tokens = _as_int(usage.get("completion_tokens"))

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -63,11 +63,20 @@ class OpenAICompatAIClient:
         model: str,
         timeout_seconds: float = 15.0,
         transport: httpx.AsyncBaseTransport | None = None,
+        provider_payload: dict[str, object] | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._timeout_seconds = float(timeout_seconds)
+        # Issue #96: a generic, opaque payload merged into every outgoing
+        # /chat/completions body (e.g. OpenRouter ``provider`` routing
+        # preferences). The adapter is agnostic about its contents; the
+        # vendor-specific shape is sourced from config (see
+        # ``build_default_ai_client``), keeping any provider/model magic-string
+        # branch out of this wire-protocol layer. Reserved completion keys
+        # (model/messages/max_tokens/temperature) are never overridden.
+        self._provider_payload = provider_payload
         # A test-only transport (``httpx.MockTransport`` is acceptable
         # because it implements ``AsyncBaseTransport`` for async clients)
         # may be injected; otherwise the real network transport is used.
@@ -108,15 +117,23 @@ class OpenAICompatAIClient:
             # here so misuse fails predictably rather than with a
             # ``NoneType`` attribute error.
             raise AIClientProtocolError("OpenAICompatAIClient used outside an async-with block")
-        payload = {
-            "model": self._model,
-            "messages": [
-                {"role": "system", "content": request.system_prompt},
-                {"role": "user", "content": request.user_prompt},
-            ],
-            "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
-        }
+        payload: dict[str, object] = {}
+        if self._provider_payload:
+            # Merge the opaque config-sourced payload first so the reserved
+            # completion fields below always win (a misconfigured payload must
+            # never redirect the model or clobber the messages).
+            payload.update(self._provider_payload)
+        payload.update(
+            {
+                "model": self._model,
+                "messages": [
+                    {"role": "system", "content": request.system_prompt},
+                    {"role": "user", "content": request.user_prompt},
+                ],
+                "max_tokens": request.max_tokens,
+                "temperature": request.temperature,
+            }
+        )
         timeout = httpx.Timeout(float(request.timeout_seconds))
         try:
             response = await self._client.post(
@@ -242,7 +259,17 @@ def build_default_ai_client(*, tier: str = "default") -> AIClient | None:
         logger.warning("Unknown HESTAI_AI_PROVIDER %r; cannot build AIClient", provider)
         return None
     model = ai_config.resolve_model(tier)
-    client = OpenAICompatAIClient(api_key=api_key, base_url=base_url, model=model)
+    # Issue #96: config-sourced upstream-routing pin (None for providers that
+    # take no routing preference). Resolved here, in the composition root, so
+    # the wire-protocol adapter stays free of any provider/model magic-string
+    # branch (PROD::I3 keeps vendor knowledge in adapters/config).
+    provider_payload = ai_config.resolve_provider_payload(provider)
+    client = OpenAICompatAIClient(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        provider_payload=provider_payload,
+    )
     # Construction-time guard (CRS gemini follow-up
     # ``crs_review_pr9_followup_ceeaa71``): ``runtime_checkable`` Protocol
     # only checks attribute *presence*, so a future adapter that defined

--- a/src/hestai_context_mcp/core/governance_reviewer.py
+++ b/src/hestai_context_mcp/core/governance_reviewer.py
@@ -55,6 +55,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientAuthError,
     AIClientError,
     AIClientTransportError,
+    AIClientTruncationError,
     CompletionRequest,
 )
 
@@ -370,6 +371,30 @@ async def review_governance(
             model,
             f"AIClient transport error (call failed): {exc}",
             [f"transport error: {exc}"],
+        )
+    except AIClientTruncationError as exc:
+        # Issue #96: the provider hit the output-token cap and BILLED for the
+        # truncated call. Record the REAL tokens/cost (no 0/0 leak) and do NOT
+        # retry — an identical re-issue would re-truncate. Never fabricate a
+        # verdict; degrade to BLOCKED.
+        consumed = exc.consumed_tokens
+        truncation_cost = (consumed / 1000.0) * price_per_1k
+        logger.warning(
+            "governance review truncated: model=%s consumed_tokens=%d billed_cost=$%.4f "
+            "(output cap hit; not retried)",
+            model,
+            consumed,
+            truncation_cost,
+        )
+        return _blocked(
+            model,
+            (
+                "AIClient truncation error (output hit the token cap; not retried): "
+                f"{exc}. Consumed {consumed} tokens."
+            ),
+            [f"truncation: {exc}"],
+            tokens=consumed,
+            cost=truncation_cost,
         )
     except AIClientError as exc:
         return _blocked(

--- a/src/hestai_context_mcp/core/intake_compiler.py
+++ b/src/hestai_context_mcp/core/intake_compiler.py
@@ -40,6 +40,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientAuthError,
     AIClientError,
     AIClientTransportError,
+    AIClientTruncationError,
     CompletionRequest,
 )
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
@@ -160,11 +161,11 @@ def _project_tokens(intake_context: IntakeContext, max_output_tokens: int) -> in
     return _estimate_input_tokens(intake_context) + max_output_tokens
 
 
-def _failure(model: str, error: str, tokens: int = 0) -> CompileResult:
+def _failure(model: str, error: str, tokens: int = 0, cost: float = 0.0) -> CompileResult:
     return {
         "ok": False,
         "octave": None,
-        "metrics": {"tokens": tokens, "cost": 0.0, "model": model},
+        "metrics": {"tokens": tokens, "cost": cost, "model": model},
         "error": error,
     }
 
@@ -240,6 +241,29 @@ async def compile_prose_to_octave(
         return _failure(model, f"AIClient auth error (permanent, no retry): {exc}")
     except AIClientTransportError as exc:
         return _failure(model, f"AIClient transport error (call failed): {exc}")
+    except AIClientTruncationError as exc:
+        # Issue #96: the provider hit the output-token cap (budget exhausted)
+        # and BILLED for the truncated call. Record the REAL tokens/cost so the
+        # metrics stop under-reporting as 0/0. Do NOT retry: an identical
+        # re-issue would re-truncate and burn budget for the same outcome.
+        consumed = exc.consumed_tokens
+        truncation_cost = (consumed / 1000.0) * price_per_1k
+        logger.warning(
+            "intake compile truncated: model=%s consumed_tokens=%d billed_cost=$%.4f "
+            "(output cap hit; not retried)",
+            model,
+            consumed,
+            truncation_cost,
+        )
+        return _failure(
+            model,
+            (
+                "AIClient truncation error (output hit the token cap; not retried): "
+                f"{exc}. Consumed {consumed} tokens."
+            ),
+            tokens=consumed,
+            cost=truncation_cost,
+        )
     except AIClientError as exc:
         return _failure(model, f"AIClient error: {exc.__class__.__name__}: {exc}")
 

--- a/src/hestai_context_mcp/ports/ai_client.py
+++ b/src/hestai_context_mcp/ports/ai_client.py
@@ -38,6 +38,7 @@ __all__ = [
     "AIClientAuthError",
     "AIClientTransportError",
     "AIClientProtocolError",
+    "AIClientTruncationError",
 ]
 
 
@@ -90,6 +91,39 @@ class AIClientProtocolError(AIClientError):
     """
 
 
+class AIClientTruncationError(AIClientError):
+    """Completion hit the output-token cap before finishing (budget exhausted).
+
+    Distinct from :class:`AIClientProtocolError`: the response *was*
+    well-formed; the generation simply ran out of budget (the provider
+    reported a length/cap stop condition) so the body is incomplete or
+    empty. Modelling this separately lets the application layer:
+
+        * record the *real* tokens billed for the truncated call instead
+          of collapsing the spend onto a generic error (closing the
+          ``tokens:0 / cost:0`` accounting leak), and
+        * decline to retry — an identical re-issue would re-truncate and
+          burn more budget for the same outcome.
+
+    ``consumed_tokens`` is the total tokens the provider reported as
+    billed for the call. ``prompt_tokens`` / ``completion_tokens`` carry
+    the split when the provider supplies it, else ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        consumed_tokens: int = 0,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.consumed_tokens = consumed_tokens
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
 @runtime_checkable
 class AIClient(Protocol):
     """Provider-agnostic text completion port.
@@ -119,5 +153,8 @@ class AIClient(Protocol):
             AIClientAuthError: No credential / credential rejected.
             AIClientTransportError: Timeout / connection / 5xx / 429.
             AIClientProtocolError: Malformed provider response.
+            AIClientTruncationError: Output hit the token cap before
+                finishing (budget exhausted); carries the real tokens
+                consumed.
         """
         ...

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -68,6 +68,8 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "HESTAI_AI_MODEL",
         "HESTAI_AI_MODEL_ANALYSIS",
         "HESTAI_AI_MODEL_CRITICAL",
+        "HESTAI_AI_PROVIDER_ROUTING",
+        "HESTAI_AI_PROVIDER_ORDER",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
     ):
@@ -392,6 +394,63 @@ def test_resolve_api_key_never_logs_secret_value(
             msg = rec.getMessage()
             assert "SECRET_AAA" not in msg, f"Secret leaked at level {level}: {msg!r}"
             assert "SECRET_BBB" not in msg, f"Secret leaked at level {level}: {msg!r}"
+
+
+class TestResolveProviderPayload:
+    """Issue #96: config-sourced OpenRouter upstream-routing pin.
+
+    ``resolve_provider_payload(provider)`` returns the generic
+    ``{"provider": {...}}`` payload the adapter merges into the request body —
+    or ``None`` to send no routing preference. The pin is:
+
+      * config-sourced (NOT a hardcoded ``if model == "minimax-m3"`` branch),
+      * **prefer, not require**: ``allow_fallbacks`` stays True so a preferred
+        upstream outage degrades gracefully instead of hard-failing,
+      * env-overridable (order list) and disableable, so it is not brittle.
+    """
+
+    def test_exposed_in_public_api(self):
+        from hestai_context_mcp.adapters import ai_config
+
+        assert hasattr(ai_config, "resolve_provider_payload")
+        assert "resolve_provider_payload" in ai_config.__all__
+
+    def test_openrouter_default_pins_preferred_order_with_fallbacks(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_provider_payload
+
+        payload = resolve_provider_payload("openrouter")
+        assert payload is not None
+        provider = payload["provider"]
+        assert isinstance(provider["order"], list) and provider["order"]
+        # Prefer, not require: graceful degradation on a preferred-upstream outage.
+        assert provider["allow_fallbacks"] is True
+
+    def test_non_openrouter_provider_has_no_routing_payload(self, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_provider_payload
+
+        assert resolve_provider_payload("openai") is None
+
+    def test_order_is_env_overridable(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_provider_payload
+
+        monkeypatch.setenv("HESTAI_AI_PROVIDER_ORDER", "Foo, Bar ,Baz")
+        payload = resolve_provider_payload("openrouter")
+        assert payload is not None
+        # Comma-separated, trimmed, order preserved.
+        assert payload["provider"]["order"] == ["Foo", "Bar", "Baz"]
+
+    def test_routing_disabled_by_env_returns_none(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_provider_payload
+
+        monkeypatch.setenv("HESTAI_AI_PROVIDER_ROUTING", "off")
+        assert resolve_provider_payload("openrouter") is None
+
+    def test_empty_order_env_disables_routing(self, monkeypatch: pytest.MonkeyPatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_provider_payload
+
+        # An explicitly empty / whitespace order list means "no preference".
+        monkeypatch.setenv("HESTAI_AI_PROVIDER_ORDER", "   ,  ")
+        assert resolve_provider_payload("openrouter") is None
 
 
 # Dead-import helper so ``Any`` stays reachable by mypy when adding fields.

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -470,6 +470,68 @@ class TestTruncationPath:
         assert excinfo.value.consumed_tokens == 0
 
     @pytest.mark.asyncio
+    async def test_negative_usage_counts_do_not_produce_negative_tokens(self):
+        """A malformed usage block with negative counts must not bill negatively.
+
+        Issue #97 (cubic P2): negative ``prompt_tokens``/``completion_tokens`` are
+        invalid telemetry — they must be treated as absent (clamped to 0), never
+        flow through to a negative ``consumed_tokens`` / negative cost record. The
+        accuracy this PR introduces must not be undone by a misbehaving provider.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "length"},
+                    ],
+                    # Negative split with no total → reconstruction must clamp.
+                    "usage": {"prompt_tokens": -100, "completion_tokens": -8000},
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        exc = excinfo.value
+        assert exc.consumed_tokens >= 0
+        assert exc.consumed_tokens == 0
+        # Negative split values are invalid → reported as absent (None), not negative.
+        assert exc.prompt_tokens is None
+        assert exc.completion_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_negative_total_tokens_is_clamped_to_zero(self):
+        """A negative ``total_tokens`` is invalid and must clamp to 0, not bill."""
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "length"},
+                    ],
+                    "usage": {"total_tokens": -8000},
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert excinfo.value.consumed_tokens == 0
+
+    @pytest.mark.asyncio
     async def test_null_content_without_length_still_protocol_error(self):
         """A null content with a *non*-length stop reason stays a protocol error.
 

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -31,6 +31,7 @@ def _build_client_with_transport(
     base_url: str = "https://openrouter.ai/api/v1",
     model: str = "google/gemini-2.0-flash-lite",
     timeout: float = 5.0,
+    provider_payload: dict | None = None,
 ):
     """Create adapter with an injected ``httpx.MockTransport`` for tests."""
     from hestai_context_mcp.adapters.openai_compat_ai_client import (
@@ -44,6 +45,7 @@ def _build_client_with_transport(
         model=model,
         timeout_seconds=timeout,
         transport=transport,
+        provider_payload=provider_payload,
     )
 
 
@@ -288,6 +290,81 @@ class TestProtocolErrorPath:
                 await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
 
 
+class TestProviderPayloadRouting:
+    """Issue #96: a generic provider_payload is merged into the outgoing JSON.
+
+    The adapter is provider-agnostic about *what* the payload says — it only
+    knows how to attach it to the wire request. The OpenRouter-specific routing
+    preference (preferred upstream order, allow_fallbacks) is sourced from
+    config (ai_config), not hardcoded here, so there is no magic model-name
+    branch in the adapter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_provider_payload_merged_into_request_body(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        seen: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content.decode())
+            return _ok_response("x")
+
+        payload = {"provider": {"order": ["MiniMax"], "allow_fallbacks": True}}
+        client = _build_client_with_transport(handler, provider_payload=payload)
+        async with client as c:
+            await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        body = seen["body"]
+        assert isinstance(body, dict)
+        assert body["provider"] == {"order": ["MiniMax"], "allow_fallbacks": True}
+        # The core completion fields remain intact alongside the merged payload.
+        assert body["model"]
+        assert body["messages"]
+
+    @pytest.mark.asyncio
+    async def test_no_provider_payload_means_no_provider_key(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        seen: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content.decode())
+            return _ok_response("x")
+
+        client = _build_client_with_transport(handler, provider_payload=None)
+        async with client as c:
+            await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        body = seen["body"]
+        assert isinstance(body, dict)
+        assert "provider" not in body
+
+    @pytest.mark.asyncio
+    async def test_provider_payload_does_not_overwrite_core_fields(self):
+        """A payload key colliding with a reserved field must not clobber it."""
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        seen: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content.decode())
+            return _ok_response("x")
+
+        # A malicious/misconfigured payload attempting to override the model.
+        payload = {"model": "evil/override", "provider": {"order": ["MiniMax"]}}
+        client = _build_client_with_transport(
+            handler, model="google/gemini-2.0-flash-lite", provider_payload=payload
+        )
+        async with client as c:
+            await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        body = seen["body"]
+        assert isinstance(body, dict)
+        assert body["model"] == "google/gemini-2.0-flash-lite"
+        assert body["provider"] == {"order": ["MiniMax"]}
+
+
 class TestTruncationPath:
     """Issue #96: finish_reason='length' is budget exhaustion, not malformed.
 
@@ -512,6 +589,44 @@ class TestBuildDefaultFactory:
 
         client = build_default_ai_client()
         assert client is None
+
+    def test_factory_wires_config_sourced_provider_payload(self, monkeypatch: pytest.MonkeyPatch):
+        """Issue #96: the factory injects the routing pin from ai_config.
+
+        The vendor-specific routing preference is resolved in ``ai_config``
+        (config-sourced, not a magic model-name branch) and threaded into the
+        adapter constructor as the generic ``provider_payload``.
+        """
+        import hestai_context_mcp.adapters.ai_config as cfg
+        import hestai_context_mcp.adapters.openai_compat_ai_client as adapter_mod
+
+        class _NoKR:
+            def get_password(self, *_a, **_kw):
+                return None
+
+            def set_password(self, *_a, **_kw):
+                return None
+
+            def delete_password(self, *_a, **_kw):
+                return None
+
+        monkeypatch.setattr(cfg, "keyring", _NoKR(), raising=True)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "ENV_KEY")
+
+        sentinel = {"provider": {"order": ["MiniMax"], "allow_fallbacks": True}}
+        monkeypatch.setattr(cfg, "resolve_provider_payload", lambda _provider: sentinel)
+
+        captured: dict[str, object] = {}
+        real_cls = adapter_mod.OpenAICompatAIClient
+
+        def _capturing_ctor(**kwargs):
+            captured.update(kwargs)
+            return real_cls(**kwargs)
+
+        monkeypatch.setattr(adapter_mod, "OpenAICompatAIClient", _capturing_ctor)
+        client = adapter_mod.build_default_ai_client()
+        assert client is not None
+        assert captured.get("provider_payload") == sentinel
 
     def test_factory_raises_typeerror_if_complete_text_is_sync(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -288,6 +288,138 @@ class TestProtocolErrorPath:
                 await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
 
 
+class TestTruncationPath:
+    """Issue #96: finish_reason='length' is budget exhaustion, not malformed.
+
+    A reasoning model routed onto an upstream that hits the output cap returns
+    a well-formed envelope with ``finish_reason='length'`` and (often) a null
+    ``content``. The adapter must inspect ``finish_reason``/``usage`` BEFORE the
+    ``isinstance(content, str)`` check and raise ``AIClientTruncationError``
+    carrying the real tokens consumed — never collapse the spend onto a generic
+    ``AIClientProtocolError`` (which would lose the cost telemetry).
+    """
+
+    @pytest.mark.asyncio
+    async def test_length_with_null_content_raises_truncation_with_usage(self):
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "length"},
+                    ],
+                    "usage": {
+                        "prompt_tokens": 200,
+                        "completion_tokens": 8000,
+                        "total_tokens": 8200,
+                    },
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        exc = excinfo.value
+        assert exc.consumed_tokens == 8200
+        assert exc.prompt_tokens == 200
+        assert exc.completion_tokens == 8000
+
+    @pytest.mark.asyncio
+    async def test_length_takes_precedence_over_content_type_check(self):
+        """finish_reason='length' wins even when content IS a (partial) string.
+
+        Truncation must be detected from the stop condition, not inferred from a
+        null body; a partial string with finish_reason='length' is still a
+        truncated, untrustworthy result.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {"content": "partial text"},
+                            "index": 0,
+                            "finish_reason": "length",
+                        },
+                    ],
+                    "usage": {"total_tokens": 8000},
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert excinfo.value.consumed_tokens == 8000
+
+    @pytest.mark.asyncio
+    async def test_length_without_usage_raises_truncation_zero_tokens(self):
+        """No usage block → still a truncation, consumed_tokens degrades to 0.
+
+        Better to surface the truncation (and not retry) than to mislabel it as
+        a protocol error; the cost telemetry is simply unavailable.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "length"},
+                    ],
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert excinfo.value.consumed_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_null_content_without_length_still_protocol_error(self):
+        """A null content with a *non*-length stop reason stays a protocol error.
+
+        Only ``finish_reason='length'`` is reclassified; genuinely malformed
+        shapes (null content on a 'stop') keep the existing protocol-error path.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "stop"},
+                    ],
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        with pytest.raises(AIClientProtocolError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+
 class TestRequestShape:
     @pytest.mark.asyncio
     async def test_request_body_contains_prompts_and_model(self):

--- a/tests/unit/core/test_governance_reviewer.py
+++ b/tests/unit/core/test_governance_reviewer.py
@@ -31,6 +31,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientError,
     AIClientProtocolError,
     AIClientTransportError,
+    AIClientTruncationError,
     CompletionRequest,
 )
 
@@ -248,6 +249,25 @@ class TestFailSoftErrorPaths:
         patch_client(stub)
         result = await review_governance(_SAMPLE_AGR)
         assert result["verdict"] == "BLOCKED"
+
+    async def test_truncation_records_real_cost_and_is_blocked(
+        self, patch_client, monkeypatch
+    ) -> None:
+        """Issue #96: a truncated review records REAL tokens/cost, never APPROVED.
+
+        Mirrors the intake_compiler accounting fix so the shared AIClient path
+        is handled consistently: finish_reason=length is billed, so the metrics
+        must reflect the real spend instead of collapsing to 0/0.
+        """
+        monkeypatch.setenv("HESTAI_REVIEW_USD_PER_1K_TOKENS", "1.0")
+        monkeypatch.setenv("HESTAI_REVIEW_MAX_COST_USD", "1000000")  # never abort pre-call
+        stub = _StubClient(raises=AIClientTruncationError("truncated", consumed_tokens=2000))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["verdict"] != "APPROVED"
+        assert result["metrics"]["tokens"] == 2000
+        assert result["metrics"]["cost"] == pytest.approx(2.0)
 
 
 class TestCostCap:

--- a/tests/unit/core/test_intake_compiler.py
+++ b/tests/unit/core/test_intake_compiler.py
@@ -29,6 +29,7 @@ from hestai_context_mcp.core.intake_compiler import compile_prose_to_octave
 from hestai_context_mcp.ports.ai_client import (
     AIClientAuthError,
     AIClientTransportError,
+    AIClientTruncationError,
     CompletionRequest,
 )
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
@@ -138,6 +139,69 @@ class TestErrorPaths:
         result = await compile_prose_to_octave(_ctx())
         assert result["ok"] is False
         assert result["octave"] is None
+
+
+class _CountingStub:
+    """AIClient stub that counts how many times complete_text is invoked."""
+
+    def __init__(self, *, raises: BaseException) -> None:
+        self._raises = raises
+        self.calls = 0
+
+    async def __aenter__(self) -> _CountingStub:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def complete_text(self, request: CompletionRequest) -> str:
+        self.calls += 1
+        raise self._raises
+
+
+class TestTruncationAccounting:
+    """Issue #96: truncation records REAL cost and is never retried.
+
+    The adapter raises ``AIClientTruncationError`` (finish_reason='length')
+    carrying the tokens the provider actually billed. The compiler must:
+      * return a structured failure (PROD::I4) — never a fabricated AGR,
+      * record the REAL consumed tokens and a NON-zero cost (closing the
+        ``tokens:0 / cost:0`` accounting leak), and
+      * NOT retry (an identical re-issue would re-truncate and burn budget).
+    """
+
+    async def test_truncation_is_structured_failure(self, patch_client) -> None:
+        stub = _StubClient(raises=AIClientTruncationError("truncated", consumed_tokens=8000))
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["ok"] is False
+        assert result["octave"] is None
+        assert result["error"]
+        assert "truncat" in result["error"].lower()
+
+    async def test_truncation_records_real_tokens_and_cost(self, patch_client, monkeypatch) -> None:
+        # Deterministic pricing so cost is exactly tokens/1000 * price.
+        monkeypatch.setenv("HESTAI_INTAKE_USD_PER_1K_TOKENS", "1.0")
+        # Raise the abort cap so the pre-call cost guard does not short-circuit;
+        # we want the truncation branch (post-call) to be exercised.
+        monkeypatch.setenv("HESTAI_INTAKE_MAX_COST_USD", "1000000")
+        stub = _StubClient(raises=AIClientTruncationError("truncated", consumed_tokens=8000))
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        metrics = result["metrics"]
+        # The REAL billed tokens, not 0.
+        assert metrics["tokens"] == 8000
+        # NON-zero cost computed from consumed tokens at the configured price.
+        assert metrics["cost"] == pytest.approx(8.0)
+        assert metrics["model"]
+
+    async def test_truncation_is_not_retried(self, patch_client) -> None:
+        stub = _CountingStub(raises=AIClientTruncationError("truncated", consumed_tokens=8000))
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["ok"] is False
+        # Exactly one backend call — no retry on truncation.
+        assert stub.calls == 1
 
 
 class TestCostCaps:

--- a/tests/unit/ports/test_ai_client.py
+++ b/tests/unit/ports/test_ai_client.py
@@ -228,7 +228,13 @@ class TestExceptionTaxonomyInstantiable:
 
     @pytest.mark.parametrize(
         "exc_name",
-        ["AIClientError", "AIClientAuthError", "AIClientTransportError", "AIClientProtocolError"],
+        [
+            "AIClientError",
+            "AIClientAuthError",
+            "AIClientTransportError",
+            "AIClientProtocolError",
+            "AIClientTruncationError",
+        ],
     )
     def test_exception_instantiates_with_message(self, exc_name):
         import hestai_context_mcp.ports.ai_client as mod
@@ -237,6 +243,66 @@ class TestExceptionTaxonomyInstantiable:
         inst = exc_cls("boom")
         assert isinstance(inst, Exception)
         assert "boom" in str(inst)
+
+
+class TestTruncationErrorTaxonomy:
+    """Issue #96: budget-exhaustion (finish_reason=length) is a distinct condition.
+
+    ``AIClientTruncationError`` models a completion that hit the output-token
+    cap, carrying the *real* tokens consumed so the application layer can record
+    accurate cost (closing the ``tokens:0/cost:0`` accounting leak) instead of
+    collapsing the spend onto a generic protocol error.
+    """
+
+    def test_exported_in_all(self):
+        import hestai_context_mcp.ports.ai_client as mod
+
+        assert "AIClientTruncationError" in mod.__all__
+
+    def test_subclasses_ai_client_error(self):
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientError,
+            AIClientTruncationError,
+        )
+
+        assert issubclass(AIClientTruncationError, AIClientError)
+
+    def test_carries_consumed_tokens(self):
+        from hestai_context_mcp.ports.ai_client import AIClientTruncationError
+
+        exc = AIClientTruncationError("output truncated", consumed_tokens=8000)
+        assert exc.consumed_tokens == 8000
+        assert "truncated" in str(exc)
+
+    def test_carries_optional_prompt_completion_split(self):
+        from hestai_context_mcp.ports.ai_client import AIClientTruncationError
+
+        exc = AIClientTruncationError(
+            "output truncated",
+            consumed_tokens=8200,
+            prompt_tokens=200,
+            completion_tokens=8000,
+        )
+        assert exc.consumed_tokens == 8200
+        assert exc.prompt_tokens == 200
+        assert exc.completion_tokens == 8000
+
+    def test_split_defaults_to_none(self):
+        from hestai_context_mcp.ports.ai_client import AIClientTruncationError
+
+        exc = AIClientTruncationError("output truncated", consumed_tokens=8000)
+        assert exc.prompt_tokens is None
+        assert exc.completion_tokens is None
+
+    def test_is_vendor_free(self):
+        """PROD::I3: the new exception must not name a provider in source."""
+        import inspect as _inspect
+
+        import hestai_context_mcp.ports.ai_client as mod
+
+        source = _inspect.getsource(mod)
+        for token in ("openrouter", "minimax", "atlascloud", "anthropic", "openai"):
+            assert token.lower() not in source.lower(), f"PROD::I3 violation: found {token!r}"
 
 
 # Helper Protocol re-export to avoid name shadowing in this test module.


### PR DESCRIPTION
## Summary
- Fixed issue where truncated AI responses (finish_reason=length) were incorrectly retried instead of being recorded with actual costs
- Added truncation detection in OpenAI-compatible adapter to identify when responses exceed token limits
- Implemented config-sourced OpenRouter upstream routing to support multiple AI providers with accurate cost tracking

## Changes
- **Truncation Detection**: Enhanced `openai_compat_ai_client.py` to detect `finish_reason=length` and raise `AIClientTruncationError` instead of retrying
- **Cost Recording**: Modified `governance_reviewer.py` and `intake_compiler.py` to record real costs on truncation without retry attempts
- **Provider Configuration**: Added OpenRouter upstream-routing pin support in `ai_config.py` for flexible provider selection
- **Port Taxonomy**: Extended `ai_client.py` port with `AIClientTruncationError` exception type
- **Test Coverage**: Added comprehensive unit tests for truncation detection, cost recording, and config-sourced routing across adapters and core modules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect truncated responses without retry, record real tokens and cost, add config-driven OpenRouter upstream routing, and clamp invalid usage counts to prevent negative costs. Addresses issues #96 and #97.

- **Bug Fixes**
  - Detect `finish_reason="length"` and raise `AIClientTruncationError` instead of retrying.
  - In governance review and intake compile, catch truncation, return BLOCKED/failure, and record real `tokens` and `cost`.
  - Clamp negative `usage` token counts to non-negative so `consumed_tokens` and cost never go below zero.

- **New Features**
  - Added `AIClientTruncationError` (with consumed token counts) to the client port.
  - Config-sourced OpenRouter routing: `HESTAI_AI_PROVIDER_ORDER` (preferred upstreams) and `HESTAI_AI_PROVIDER_ROUTING` to disable; `allow_fallbacks` remains true; injected via `provider_payload` in the default client.

<sup>Written for commit 1e7536ef022f69ba060a59cc5ad5d3798c43df6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

