### PR TITLE
fix: report real provider cost/tokens in metrics, not local estimates (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - `AIClientTruncationError` in the AIClient port taxonomy — models output-token budget exhaustion (provider `finish_reason="length"`) distinctly from a malformed response, carrying the real `consumed_tokens` (issue #96)
 - Config-sourced provider upstream-routing pin: `HESTAI_AI_PROVIDER_ORDER` (comma-separated upstream slugs, OpenRouter) and `HESTAI_AI_PROVIDER_ROUTING=off` to disable. Defaults to a preferred order with `allow_fallbacks` preserved (prefer, not require), so a preferred-upstream outage degrades gracefully (issue #96)
+- `CompletionResult` in the AIClient port — `complete_text` returns content plus the provider's real token usage and real cost (vendor-free) so callers report accurate metrics (issue #98)
+- `metrics.cost_is_estimate` flag on `submit_governance` prose-mode and governance-review results — `true` when the cost is a flat-rate local estimate (provider reported none), so an estimate is never mistaken for a billed actual (issue #98)
+
+### Changed
+- `metrics.cost` and `metrics.tokens` now report the provider's **real** figures from the OpenRouter response (via `usage: {include: true}`) instead of local estimates. Previously `cost` overstated real spend by ~15× (flat $0.01/1k) and `tokens` were char-estimated. The flat-rate estimate is retained only for the pre-call cost-projection / abort guard, and as a clearly-labelled fallback when the provider reports no cost (issue #98)
 
 ### Fixed
 - Stage-2 prose→OCTAVE (`submit_governance` prose mode) no longer fails non-deterministically when OpenRouter routes a reasoning model onto an upstream that truncates at the token cap: the pin reduces routing nondeterminism and `finish_reason="length"` is now surfaced as an actionable truncation error instead of an opaque protocol error (issue #96)

--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -185,7 +185,12 @@ def resolve_provider_payload(provider: str) -> dict[str, object] | None:
     if not order:
         return None
 
-    return {"provider": {"order": order, "allow_fallbacks": True}}
+    # Issue #99: include OpenRouter real-usage accounting alongside the routing
+    # pin. Both are OpenRouter-specific knobs that belong in the config layer
+    # (PROD::I3 — keep vendor knowledge in adapters/config, not in the generic
+    # wire-protocol adapter). ``usage.include=True`` tells OpenRouter to return
+    # the provider's real token counts and real USD cost in the response body.
+    return {"provider": {"order": order, "allow_fallbacks": True}, "usage": {"include": True}}
 
 
 def _keyring_account(provider: str) -> str:

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -171,11 +171,6 @@ class OpenAICompatAIClient:
                 ],
                 "max_tokens": request.max_tokens,
                 "temperature": request.temperature,
-                # Issue #98: opt in to OpenRouter usage accounting so the response
-                # carries the provider's real token counts and real USD cost. This
-                # is a vendor-specific request knob and so lives in the adapter
-                # (same layer as the routing pin), keeping the port vendor-free.
-                "usage": {"include": True},
             }
         )
         timeout = httpx.Timeout(float(request.timeout_seconds))

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from dataclasses import dataclass
 from types import TracebackType
 from typing import cast
 
@@ -42,6 +43,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientTransportError,
     AIClientTruncationError,
     CompletionRequest,
+    CompletionResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,6 +52,43 @@ __all__ = [
     "OpenAICompatAIClient",
     "build_default_ai_client",
 ]
+
+
+@dataclass(frozen=True)
+class _Usage:
+    """Adapter-internal parsed view of a provider ``usage`` block.
+
+    Distinct from the port's :class:`CompletionResult`: this is a transient
+    parse result used to build both the success result and the truncation error.
+    """
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    cost: float | None = None
+
+
+def _coerce_non_negative_int(value: object) -> int | None:
+    """Return ``value`` if it is a non-negative, non-bool int, else ``None``.
+
+    Issue #97: a negative count is invalid telemetry — treat it as absent so it
+    can never bill negative tokens.
+    """
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _coerce_non_negative_float(value: object) -> float | None:
+    """Return ``value`` as a non-negative float, else ``None``.
+
+    Accepts int or float (but not bool). A negative or non-numeric cost is
+    invalid telemetry and degrades to ``None`` so the caller falls back to its
+    labelled estimate rather than reporting a bogus actual (issue #98).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value >= 0:
+        return float(value)
+    return None
 
 
 class OpenAICompatAIClient:
@@ -110,8 +149,8 @@ class OpenAICompatAIClient:
             await self._client.aclose()
             self._client = None
 
-    async def complete_text(self, request: CompletionRequest) -> str:
-        """Execute a chat completion call and return the raw text content."""
+    async def complete_text(self, request: CompletionRequest) -> CompletionResult:
+        """Execute a chat completion call and return content + real usage/cost."""
         if self._client is None:
             # Guarded by the async-context-manager contract; defensive
             # here so misuse fails predictably rather than with a
@@ -132,6 +171,11 @@ class OpenAICompatAIClient:
                 ],
                 "max_tokens": request.max_tokens,
                 "temperature": request.temperature,
+                # Issue #98: opt in to OpenRouter usage accounting so the response
+                # carries the provider's real token counts and real USD cost. This
+                # is a vendor-specific request knob and so lives in the adapter
+                # (same layer as the routing pin), keeping the port vendor-free.
+                "usage": {"include": True},
             }
         )
         timeout = httpx.Timeout(float(request.timeout_seconds))
@@ -153,7 +197,7 @@ class OpenAICompatAIClient:
 
         return self._interpret_response(response)
 
-    def _interpret_response(self, response: httpx.Response) -> str:
+    def _interpret_response(self, response: httpx.Response) -> CompletionResult:
         status = response.status_code
         if status in (401, 403):
             # Do NOT include the response body — it may contain the key
@@ -189,50 +233,60 @@ class OpenAICompatAIClient:
         # carrying the real tokens billed. We deliberately do NOT fall back to
         # ``reasoning``/``reasoning_content``: surfacing chain-of-thought as a
         # compiled artifact is a safety hazard for governance content.
+        usage = self._extract_usage(body)
         finish_reason = first.get("finish_reason")
         if finish_reason == "length":
-            consumed, prompt_tokens, completion_tokens = self._extract_usage(body)
             raise AIClientTruncationError(
                 "provider truncated output at the token cap (finish_reason='length')",
-                consumed_tokens=consumed,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
+                consumed_tokens=usage.total_tokens or 0,
+                prompt_tokens=usage.prompt_tokens,
+                completion_tokens=usage.completion_tokens,
+                cost=usage.cost,
             )
         content = message.get("content")
         if not isinstance(content, str):
             raise AIClientProtocolError(
                 "provider response 'choices[0].message.content' is not a string"
             )
-        return content
+        # Issue #98: return the provider's real usage + cost alongside content so
+        # the application layer reports accurate metrics, not local estimates.
+        return CompletionResult(
+            content=content,
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            total_tokens=usage.total_tokens,
+            cost=usage.cost,
+        )
 
     @staticmethod
-    def _extract_usage(body: object) -> tuple[int, int | None, int | None]:
-        """Pull token counts from an OpenAI-compat ``usage`` block.
+    def _extract_usage(body: object) -> _Usage:
+        """Pull real token counts and cost from an OpenAI-compat ``usage`` block.
 
-        Returns ``(total_tokens, prompt_tokens, completion_tokens)``. Missing or
-        malformed fields degrade to ``0`` for the total and ``None`` for the
-        split — telemetry being unavailable must never mask the truncation.
+        Returns a :class:`_Usage` carrying ``total_tokens`` / ``prompt_tokens`` /
+        ``completion_tokens`` (``None`` when absent) and the real ``cost``
+        (``None`` when the provider reports none). Missing or malformed numeric
+        fields degrade to ``None`` rather than masking a truncation or billing a
+        bogus figure. ``total_tokens`` is reconstructed from the split when the
+        provider omits it but supplies the parts.
         """
         usage = body.get("usage") if isinstance(body, dict) else None
         if not isinstance(usage, dict):
-            return 0, None, None
+            return _Usage()
 
-        def _as_int(value: object) -> int | None:
-            # Issue #97: a negative count is invalid telemetry — treat it as
-            # absent so it can never bill negative tokens / negative cost.
-            return (
-                value
-                if isinstance(value, int) and not isinstance(value, bool) and value >= 0
-                else None
-            )
-
-        prompt_tokens = _as_int(usage.get("prompt_tokens"))
-        completion_tokens = _as_int(usage.get("completion_tokens"))
-        total = _as_int(usage.get("total_tokens"))
-        if total is None:
-            # Reconstruct the total from the split when the provider omits it.
+        prompt_tokens = _coerce_non_negative_int(usage.get("prompt_tokens"))
+        completion_tokens = _coerce_non_negative_int(usage.get("completion_tokens"))
+        total = _coerce_non_negative_int(usage.get("total_tokens"))
+        if total is None and (prompt_tokens is not None or completion_tokens is not None):
+            # Reconstruct the total from the split when the provider omits it but
+            # supplies at least one part. If nothing is reported, leave it None.
             total = (prompt_tokens or 0) + (completion_tokens or 0)
-        return total, prompt_tokens, completion_tokens
+        cost = _coerce_non_negative_float(usage.get("cost"))
+        return _Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total,
+            cost=cost,
+        )
 
 
 def build_default_ai_client(*, tier: str = "default") -> AIClient | None:

--- a/src/hestai_context_mcp/core/governance_reviewer.py
+++ b/src/hestai_context_mcp/core/governance_reviewer.py
@@ -386,20 +386,25 @@ async def review_governance(
 
     client = build_default_ai_client(tier=tier)
     if client is None:
+        # Issue #99 (Finding 3): no credential → definitively $0; the provider
+        # was never called so cost_is_estimate=False (not an approximation).
         return _blocked(
             model,
             "No AIClient available (no credential configured); cannot run semantic review.",
             ["No AI client/credential available for the semantic review."],
+            cost_is_estimate=False,
         )
 
     user_prompt = f"BEGIN_RECORD\n{octave_content}\nEND_RECORD"
     try:
         result = await _run_completion(client, _REVIEW_SYSTEM_PROMPT, user_prompt, out_cap)
     except AIClientAuthError as exc:
+        # Issue #99 (Finding 3): auth rejection is pre-billing; definitively $0.
         return _blocked(
             model,
             f"AIClient auth error (permanent, no retry): {exc}",
             [f"auth error: {exc}"],
+            cost_is_estimate=False,
         )
     except AIClientTransportError as exc:
         return _blocked(

--- a/src/hestai_context_mcp/core/governance_reviewer.py
+++ b/src/hestai_context_mcp/core/governance_reviewer.py
@@ -57,6 +57,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientTransportError,
     AIClientTruncationError,
     CompletionRequest,
+    CompletionResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,11 +94,17 @@ _REQUEST_TIMEOUT_SECONDS = 60
 
 
 class ReviewMetrics(TypedDict):
-    """Per-call metrics (PROD::I4). ``cost`` is the projected USD cost."""
+    """Per-call metrics (PROD::I4).
+
+    ``tokens`` / ``cost`` are the provider's REAL figures when available
+    (issue #98). ``cost_is_estimate`` is ``True`` when the provider reported no
+    cost and the value is a flat-rate local estimate, not a billed actual.
+    """
 
     tokens: int
     cost: float
     model: str
+    cost_is_estimate: bool
 
 
 class ReviewResult(TypedDict):
@@ -212,6 +219,20 @@ def _estimate_input_tokens(octave_content: str) -> int:
     return _ceil_div(input_chars, _CHARS_PER_TOKEN)
 
 
+def _resolve_cost(
+    provider_cost: float | None, tokens: int, price_per_1k: float
+) -> tuple[float, bool]:
+    """Return ``(cost, is_estimate)`` preferring the provider's real cost.
+
+    Issue #98: a real provider cost is used verbatim and marked actual; absence
+    falls back to the flat-rate projection and is marked an estimate so consumers
+    never mistake the local approximation for a billed figure.
+    """
+    if provider_cost is not None:
+        return provider_cost, False
+    return (tokens / 1000.0) * price_per_1k, True
+
+
 def _blocked(
     model: str,
     assessment: str,
@@ -219,13 +240,19 @@ def _blocked(
     *,
     tokens: int = 0,
     cost: float = 0.0,
+    cost_is_estimate: bool = True,
 ) -> ReviewResult:
     """Build a fail-soft BLOCKED result. NEVER fabricates an APPROVED verdict."""
     return {
         "verdict": "BLOCKED",
         "assessment": assessment,
         "concerns": concerns,
-        "metrics": {"tokens": tokens, "cost": cost, "model": model},
+        "metrics": {
+            "tokens": tokens,
+            "cost": cost,
+            "model": model,
+            "cost_is_estimate": cost_is_estimate,
+        },
     }
 
 
@@ -240,7 +267,9 @@ def _parse_concerns(raw_block: str) -> list[str]:
     return [p.strip() for p in parts if p.strip()]
 
 
-def _parse_review(raw: str, model: str, tokens: int, cost: float) -> ReviewResult:
+def _parse_review(
+    raw: str, model: str, tokens: int, cost: float, *, cost_is_estimate: bool
+) -> ReviewResult:
     """Parse the model's line-oriented response into a structured result.
 
     An unparseable verdict degrades to ``CONCERNS`` (never silently
@@ -257,6 +286,12 @@ def _parse_review(raw: str, model: str, tokens: int, cost: float) -> ReviewResul
         if assessment_match
         else raw.strip()[:500] or "No assessment text returned."
     )
+    metrics: ReviewMetrics = {
+        "tokens": tokens,
+        "cost": cost,
+        "model": model,
+        "cost_is_estimate": cost_is_estimate,
+    }
 
     if verdict_match is None:
         # No recognisable verdict -> do not approve; route to a human.
@@ -265,7 +300,7 @@ def _parse_review(raw: str, model: str, tokens: int, cost: float) -> ReviewResul
             "verdict": "CONCERNS",
             "assessment": assessment,
             "concerns": concerns,
-            "metrics": {"tokens": tokens, "cost": cost, "model": model},
+            "metrics": metrics,
         }
 
     verdict: Verdict = verdict_match.group(1)  # type: ignore[assignment]
@@ -273,13 +308,13 @@ def _parse_review(raw: str, model: str, tokens: int, cost: float) -> ReviewResul
         "verdict": verdict,
         "assessment": assessment,
         "concerns": concerns,
-        "metrics": {"tokens": tokens, "cost": cost, "model": model},
+        "metrics": metrics,
     }
 
 
 async def _run_completion(
     client: AIClient, system_prompt: str, user_prompt: str, max_tokens: int
-) -> str:
+) -> CompletionResult:
     async with client as c:
         return await c.complete_text(
             CompletionRequest(
@@ -359,7 +394,7 @@ async def review_governance(
 
     user_prompt = f"BEGIN_RECORD\n{octave_content}\nEND_RECORD"
     try:
-        raw = await _run_completion(client, _REVIEW_SYSTEM_PROMPT, user_prompt, out_cap)
+        result = await _run_completion(client, _REVIEW_SYSTEM_PROMPT, user_prompt, out_cap)
     except AIClientAuthError as exc:
         return _blocked(
             model,
@@ -374,17 +409,19 @@ async def review_governance(
         )
     except AIClientTruncationError as exc:
         # Issue #96: the provider hit the output-token cap and BILLED for the
-        # truncated call. Record the REAL tokens/cost (no 0/0 leak) and do NOT
-        # retry — an identical re-issue would re-truncate. Never fabricate a
-        # verdict; degrade to BLOCKED.
+        # truncated call. Record the REAL tokens (no 0/0 leak) and do NOT retry —
+        # an identical re-issue would re-truncate. Never fabricate a verdict;
+        # degrade to BLOCKED. Issue #98: price with the provider's REAL cost when
+        # reported; else a labelled flat-rate estimate.
         consumed = exc.consumed_tokens
-        truncation_cost = (consumed / 1000.0) * price_per_1k
+        billed_cost, cost_is_estimate = _resolve_cost(exc.cost, consumed, price_per_1k)
         logger.warning(
-            "governance review truncated: model=%s consumed_tokens=%d billed_cost=$%.4f "
+            "governance review truncated: model=%s consumed_tokens=%d cost=$%.4f estimate=%s "
             "(output cap hit; not retried)",
             model,
             consumed,
-            truncation_cost,
+            billed_cost,
+            cost_is_estimate,
         )
         return _blocked(
             model,
@@ -394,7 +431,8 @@ async def review_governance(
             ),
             [f"truncation: {exc}"],
             tokens=consumed,
-            cost=truncation_cost,
+            cost=billed_cost,
+            cost_is_estimate=cost_is_estimate,
         )
     except AIClientError as exc:
         return _blocked(
@@ -403,21 +441,28 @@ async def review_governance(
             [f"{exc.__class__.__name__}: {exc}"],
         )
 
-    if not isinstance(raw, str) or not raw.strip():
+    raw = result.content
+    if not raw.strip():
         return _blocked(
             model,
             "Backend returned an empty response; no semantic verdict produced.",
             ["Empty reviewer response."],
         )
 
-    # Reported metric = input estimate + ACTUAL output (NOT the output ceiling).
-    actual_output_tokens = _ceil_div(len(raw), _CHARS_PER_TOKEN)
-    actual_tokens = _estimate_input_tokens(octave_content) + actual_output_tokens
-    cost = (actual_tokens / 1000.0) * price_per_1k
+    # Issue #98: report the provider's REAL usage and cost. Prefer the provider
+    # total; fall back to a char-based estimate only when usage is absent. Prefer
+    # the real cost; fall back to a labelled flat-rate estimate when None.
+    if result.total_tokens is not None:
+        actual_tokens = result.total_tokens
+    else:
+        actual_output_tokens = _ceil_div(len(raw), _CHARS_PER_TOKEN)
+        actual_tokens = _estimate_input_tokens(octave_content) + actual_output_tokens
+    cost, cost_is_estimate = _resolve_cost(result.cost, actual_tokens, price_per_1k)
     logger.info(
-        "governance review ok: model=%s actual_tokens=%d est_cost=$%.4f",
+        "governance review ok: model=%s tokens=%d cost=$%.4f estimate=%s",
         model,
         actual_tokens,
         cost,
+        cost_is_estimate,
     )
-    return _parse_review(raw, model, actual_tokens, cost)
+    return _parse_review(raw, model, actual_tokens, cost, cost_is_estimate=cost_is_estimate)

--- a/src/hestai_context_mcp/core/intake_compiler.py
+++ b/src/hestai_context_mcp/core/intake_compiler.py
@@ -42,6 +42,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientTransportError,
     AIClientTruncationError,
     CompletionRequest,
+    CompletionResult,
 )
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
 
@@ -70,11 +71,18 @@ _REQUEST_TIMEOUT_SECONDS = 60
 
 
 class CompileMetrics(TypedDict):
-    """Per-call metrics (PROD::I4). ``cost`` is the projected USD cost."""
+    """Per-call metrics (PROD::I4).
+
+    ``tokens`` / ``cost`` are the provider's REAL figures when available
+    (issue #98). ``cost_is_estimate`` is ``True`` when the provider reported no
+    cost and the value is a flat-rate local estimate rather than an actual — so
+    consumers never mistake an estimate for a billed figure.
+    """
 
     tokens: int
     cost: float
     model: str
+    cost_is_estimate: bool
 
 
 class CompileResult(TypedDict):
@@ -161,16 +169,45 @@ def _project_tokens(intake_context: IntakeContext, max_output_tokens: int) -> in
     return _estimate_input_tokens(intake_context) + max_output_tokens
 
 
-def _failure(model: str, error: str, tokens: int = 0, cost: float = 0.0) -> CompileResult:
+def _resolve_cost(
+    provider_cost: float | None, tokens: int, price_per_1k: float
+) -> tuple[float, bool]:
+    """Return ``(cost, is_estimate)`` preferring the provider's real cost.
+
+    Issue #98: when the provider reports a real cost, use it verbatim and mark
+    it as actual. Otherwise fall back to the flat-rate projection
+    (``tokens / 1000 * price_per_1k``) and mark it as an estimate so consumers
+    never mistake the local approximation for a billed figure.
+    """
+    if provider_cost is not None:
+        return provider_cost, False
+    return (tokens / 1000.0) * price_per_1k, True
+
+
+def _failure(
+    model: str,
+    error: str,
+    tokens: int = 0,
+    cost: float = 0.0,
+    *,
+    cost_is_estimate: bool = True,
+) -> CompileResult:
     return {
         "ok": False,
         "octave": None,
-        "metrics": {"tokens": tokens, "cost": cost, "model": model},
+        "metrics": {
+            "tokens": tokens,
+            "cost": cost,
+            "model": model,
+            "cost_is_estimate": cost_is_estimate,
+        },
         "error": error,
     }
 
 
-async def _run_completion(client: AIClient, prompt: str, user_prompt: str, max_tokens: int) -> str:
+async def _run_completion(
+    client: AIClient, prompt: str, user_prompt: str, max_tokens: int
+) -> CompletionResult:
     async with client as c:
         return await c.complete_text(
             CompletionRequest(
@@ -236,24 +273,27 @@ async def compile_prose_to_octave(
 
     user_prompt = f"BEGIN_REQUEST\n{intake_context.prose_input}\nEND_REQUEST"
     try:
-        raw = await _run_completion(client, intake_context.prompt, user_prompt, out_cap)
+        result = await _run_completion(client, intake_context.prompt, user_prompt, out_cap)
     except AIClientAuthError as exc:
         return _failure(model, f"AIClient auth error (permanent, no retry): {exc}")
     except AIClientTransportError as exc:
         return _failure(model, f"AIClient transport error (call failed): {exc}")
     except AIClientTruncationError as exc:
         # Issue #96: the provider hit the output-token cap (budget exhausted)
-        # and BILLED for the truncated call. Record the REAL tokens/cost so the
+        # and BILLED for the truncated call. Record the REAL tokens so the
         # metrics stop under-reporting as 0/0. Do NOT retry: an identical
         # re-issue would re-truncate and burn budget for the same outcome.
+        # Issue #98: price with the provider's REAL cost when reported; else
+        # fall back to a labelled flat-rate estimate.
         consumed = exc.consumed_tokens
-        truncation_cost = (consumed / 1000.0) * price_per_1k
+        billed_cost, cost_is_estimate = _resolve_cost(exc.cost, consumed, price_per_1k)
         logger.warning(
-            "intake compile truncated: model=%s consumed_tokens=%d billed_cost=$%.4f "
+            "intake compile truncated: model=%s consumed_tokens=%d cost=$%.4f estimate=%s "
             "(output cap hit; not retried)",
             model,
             consumed,
-            truncation_cost,
+            billed_cost,
+            cost_is_estimate,
         )
         return _failure(
             model,
@@ -262,29 +302,42 @@ async def compile_prose_to_octave(
                 f"{exc}. Consumed {consumed} tokens."
             ),
             tokens=consumed,
-            cost=truncation_cost,
+            cost=billed_cost,
+            cost_is_estimate=cost_is_estimate,
         )
     except AIClientError as exc:
         return _failure(model, f"AIClient error: {exc.__class__.__name__}: {exc}")
 
-    if not isinstance(raw, str) or not raw.strip():
+    raw = result.content
+    if not raw.strip():
         return _failure(model, "Backend returned empty response; no OCTAVE produced.")
 
-    # Reported metric = input estimate + ACTUAL output (NOT the output ceiling).
-    # The pre-call guard used out_cap as a worst case; the post-call metric must
-    # reflect the real output size so tokens/cost are not double-counted.
-    actual_output_tokens = _ceil_div(len(raw), _CHARS_PER_TOKEN)
-    actual_tokens = _estimate_input_tokens(intake_context) + actual_output_tokens
-    cost = (actual_tokens / 1000.0) * price_per_1k
+    # Issue #98: report the provider's REAL usage and cost. The pre-call guard
+    # used out_cap as a worst case; the post-call metric reflects reality.
+    # Tokens: prefer the provider total; fall back to a char-based estimate only
+    # when the provider reports no usage. Cost: prefer the provider's real cost;
+    # fall back to a labelled flat-rate estimate when None.
+    if result.total_tokens is not None:
+        actual_tokens = result.total_tokens
+    else:
+        actual_output_tokens = _ceil_div(len(raw), _CHARS_PER_TOKEN)
+        actual_tokens = _estimate_input_tokens(intake_context) + actual_output_tokens
+    cost, cost_is_estimate = _resolve_cost(result.cost, actual_tokens, price_per_1k)
     logger.info(
-        "intake compile ok: model=%s actual_tokens=%d est_cost=$%.4f",
+        "intake compile ok: model=%s tokens=%d cost=$%.4f estimate=%s",
         model,
         actual_tokens,
         cost,
+        cost_is_estimate,
     )
     return {
         "ok": True,
         "octave": raw,
-        "metrics": {"tokens": actual_tokens, "cost": cost, "model": model},
+        "metrics": {
+            "tokens": actual_tokens,
+            "cost": cost,
+            "model": model,
+            "cost_is_estimate": cost_is_estimate,
+        },
         "error": None,
     }

--- a/src/hestai_context_mcp/core/intake_compiler.py
+++ b/src/hestai_context_mcp/core/intake_compiler.py
@@ -269,13 +269,20 @@ async def compile_prose_to_octave(
 
     client = build_default_ai_client()
     if client is None:
-        return _failure(model, "No AIClient available (no credential configured).")
+        # Issue #99 (Finding 2): no credential → definitively $0; the provider
+        # was never called so cost_is_estimate=False (not an approximation).
+        return _failure(
+            model, "No AIClient available (no credential configured).", cost_is_estimate=False
+        )
 
     user_prompt = f"BEGIN_REQUEST\n{intake_context.prose_input}\nEND_REQUEST"
     try:
         result = await _run_completion(client, intake_context.prompt, user_prompt, out_cap)
     except AIClientAuthError as exc:
-        return _failure(model, f"AIClient auth error (permanent, no retry): {exc}")
+        # Issue #99 (Finding 2): auth rejection is pre-billing; definitively $0.
+        return _failure(
+            model, f"AIClient auth error (permanent, no retry): {exc}", cost_is_estimate=False
+        )
     except AIClientTransportError as exc:
         return _failure(model, f"AIClient transport error (call failed): {exc}")
     except AIClientTruncationError as exc:

--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -129,7 +129,12 @@ async def run_intake_pipeline(
         ZERO linker calls.
     """
     ctx = intake_context
-    last_metrics: CompileMetrics = {"tokens": 0, "cost": 0.0, "model": ""}
+    last_metrics: CompileMetrics = {
+        "tokens": 0,
+        "cost": 0.0,
+        "model": "",
+        "cost_is_estimate": True,
+    }
     last_errors: list[str] = []
 
     for attempt in range(1, _MAX_ATTEMPTS + 1):

--- a/src/hestai_context_mcp/core/synthesis.py
+++ b/src/hestai_context_mcp/core/synthesis.py
@@ -293,11 +293,17 @@ async def _run_completion(
     system_prompt: str,
     user_prompt: str,
 ) -> str:
-    """Invoke the AIClient once inside its async-context-manager."""
+    """Invoke the AIClient once inside its async-context-manager.
+
+    Issue #98: ``complete_text`` now returns a ``CompletionResult``; the
+    clock-in synthesis path only needs the generated content (it discards usage
+    and cost — clock-in does not report per-call cost metrics).
+    """
     async with client as c:
-        return await c.complete_text(
+        result = await c.complete_text(
             CompletionRequest(system_prompt=system_prompt, user_prompt=user_prompt)
         )
+        return result.content
 
 
 def _sanitise_single_line(value: str) -> str:

--- a/src/hestai_context_mcp/ports/ai_client.py
+++ b/src/hestai_context_mcp/ports/ai_client.py
@@ -33,6 +33,7 @@ from typing import Protocol, runtime_checkable
 
 __all__ = [
     "CompletionRequest",
+    "CompletionResult",
     "AIClient",
     "AIClientError",
     "AIClientAuthError",
@@ -57,6 +58,27 @@ class CompletionRequest:
     max_tokens: int = 1024
     temperature: float = 0.3
     timeout_seconds: int = 15
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    """Provider-agnostic completion result with real usage accounting.
+
+    Carries the generated ``content`` plus the provider's *real* token usage
+    and *real* cost so the application layer reports accurate metrics rather
+    than local estimates (issue #98). All fields are vendor-free primitives.
+
+    ``cost`` is the real USD cost the provider billed for the call, or ``None``
+    when the provider does not report one. A ``None`` cost signals the caller to
+    fall back to its flat-rate estimate (and to label it as an estimate, not an
+    actual). The token fields are ``None`` when the provider omits a usage block.
+    """
+
+    content: str
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    cost: float | None = None
 
 
 class AIClientError(Exception):
@@ -107,7 +129,11 @@ class AIClientTruncationError(AIClientError):
 
     ``consumed_tokens`` is the total tokens the provider reported as
     billed for the call. ``prompt_tokens`` / ``completion_tokens`` carry
-    the split when the provider supplies it, else ``None``.
+    the split when the provider supplies it, else ``None``. ``cost`` is
+    the provider's real USD cost for the (billed) truncated call when
+    reported, else ``None`` — the caller prices the real consumed tokens
+    with the real cost when available, and otherwise falls back to a
+    labelled flat-rate estimate (issue #98).
     """
 
     def __init__(
@@ -117,11 +143,13 @@ class AIClientTruncationError(AIClientError):
         consumed_tokens: int = 0,
         prompt_tokens: int | None = None,
         completion_tokens: int | None = None,
+        cost: float | None = None,
     ) -> None:
         super().__init__(message)
         self.consumed_tokens = consumed_tokens
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
+        self.cost = cost
 
 
 @runtime_checkable
@@ -146,8 +174,13 @@ class AIClient(Protocol):
         exc_tb: object | None,
     ) -> None: ...
 
-    async def complete_text(self, request: CompletionRequest) -> str:
-        """Return raw completion text for ``request``.
+    async def complete_text(self, request: CompletionRequest) -> CompletionResult:
+        """Return the completion result for ``request``.
+
+        The result carries the generated content plus the provider's real
+        token usage and real cost (issue #98) so callers report accurate
+        metrics. ``cost``/usage fields are ``None`` when the provider does
+        not report them.
 
         Raises:
             AIClientAuthError: No credential / credential rejected.
@@ -155,6 +188,6 @@ class AIClient(Protocol):
             AIClientProtocolError: Malformed provider response.
             AIClientTruncationError: Output hit the token cap before
                 finishing (budget exhausted); carries the real tokens
-                consumed.
+                consumed and the real cost when reported.
         """
         ...

--- a/tests/contract/test_ai_client_protocol.py
+++ b/tests/contract/test_ai_client_protocol.py
@@ -34,7 +34,11 @@ class TestProtocolConformance:
 
     def test_test_stub_satisfies_protocol(self):
         """Stubs used by other tests must track the Protocol (regression guard)."""
-        from hestai_context_mcp.ports.ai_client import AIClient, CompletionRequest
+        from hestai_context_mcp.ports.ai_client import (
+            AIClient,
+            CompletionRequest,
+            CompletionResult,
+        )
 
         class _Stub:
             async def __aenter__(self):
@@ -43,8 +47,8 @@ class TestProtocolConformance:
             async def __aexit__(self, exc_type, exc, tb):
                 return None
 
-            async def complete_text(self, request: CompletionRequest) -> str:
-                return "ok"
+            async def complete_text(self, request: CompletionRequest) -> CompletionResult:
+                return CompletionResult(content="ok")
 
         assert isinstance(_Stub(), AIClient)
 

--- a/tests/integration/test_clock_in_ai_synthesis.py
+++ b/tests/integration/test_clock_in_ai_synthesis.py
@@ -46,10 +46,12 @@ class _Stub:
     async def __aexit__(self, exc_type, exc, tb):
         return None
 
-    async def complete_text(self, request: Any) -> str:
+    async def complete_text(self, request: Any):  # -> CompletionResult
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
         if self._raises is not None:
             raise self._raises
-        return self._text
+        return CompletionResult(content=self._text)
 
 
 class TestClockInAiSynthesisIntegration:

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -116,7 +116,8 @@ class TestSuccessPath:
         client = _build_client_with_transport(handler)
         async with client as c:
             out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
-        assert out == "synthesised-octave"
+        # Issue #98: complete_text now returns a CompletionResult, not a bare str.
+        assert out.content == "synthesised-octave"
         assert len(calls) == 1
 
     @pytest.mark.asyncio
@@ -134,6 +135,113 @@ class TestSuccessPath:
             await c.complete_text(CompletionRequest(system_prompt="", user_prompt=""))
         auth = seen_headers.get("authorization", "")
         assert auth == "Bearer THE_KEY"
+
+
+class TestSuccessUsageAccounting:
+    """Issue #98: the success path reports the provider's real usage and cost."""
+
+    @pytest.mark.asyncio
+    async def test_request_opts_into_usage_accounting(self):
+        """The outgoing body asks the provider to include real usage/cost."""
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        seen: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content.decode())
+            return _ok_response("x")
+
+        client = _build_client_with_transport(handler)
+        async with client as c:
+            await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        body = seen["body"]
+        assert isinstance(body, dict)
+        assert body.get("usage") == {"include": True}
+
+    @pytest.mark.asyncio
+    async def test_success_returns_real_usage_and_cost(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": "octave"}, "index": 0, "finish_reason": "stop"},
+                    ],
+                    "usage": {
+                        "prompt_tokens": 6900,
+                        "completion_tokens": 3100,
+                        "total_tokens": 10000,
+                        "cost": 0.0043,
+                    },
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert out.content == "octave"
+        assert out.prompt_tokens == 6900
+        assert out.completion_tokens == 3100
+        assert out.total_tokens == 10000
+        assert out.cost == 0.0043
+
+    @pytest.mark.asyncio
+    async def test_success_cost_none_when_provider_omits_it(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": "octave"}, "index": 0, "finish_reason": "stop"},
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert out.total_tokens == 30
+        assert out.cost is None
+
+    @pytest.mark.asyncio
+    async def test_success_with_no_usage_block_has_none_usage_and_cost(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        client = _build_client_with_transport(lambda req: _ok_response("octave"))
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert out.content == "octave"
+        assert out.prompt_tokens is None
+        assert out.completion_tokens is None
+        assert out.total_tokens is None
+        assert out.cost is None
+
+    @pytest.mark.asyncio
+    async def test_negative_cost_is_treated_as_absent(self):
+        """A negative cost is invalid telemetry (mirrors issue #97 token clamp)."""
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": "octave"}, "index": 0, "finish_reason": "stop"},
+                    ],
+                    "usage": {"total_tokens": 30, "cost": -0.5},
+                },
+            )
+
+        client = _build_client_with_transport(handler)
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        assert out.cost is None
 
 
 class TestAuthErrorPath:
@@ -394,6 +502,7 @@ class TestTruncationPath:
                         "prompt_tokens": 200,
                         "completion_tokens": 8000,
                         "total_tokens": 8200,
+                        "cost": 0.0142,
                     },
                 },
             )
@@ -406,6 +515,8 @@ class TestTruncationPath:
         assert exc.consumed_tokens == 8200
         assert exc.prompt_tokens == 200
         assert exc.completion_tokens == 8000
+        # Issue #98: the real cost is threaded into the truncation error.
+        assert exc.cost == 0.0142
 
     @pytest.mark.asyncio
     async def test_length_takes_precedence_over_content_type_check(self):

--- a/tests/unit/adapters/test_openai_compat_ai_client.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client.py
@@ -141,8 +141,14 @@ class TestSuccessUsageAccounting:
     """Issue #98: the success path reports the provider's real usage and cost."""
 
     @pytest.mark.asyncio
-    async def test_request_opts_into_usage_accounting(self):
-        """The outgoing body asks the provider to include real usage/cost."""
+    async def test_usage_field_absent_when_no_provider_payload(self):
+        """Issue #99 (Finding 1): usage must be config-sourced, not hardcoded.
+
+        When ``provider_payload`` is None (no OpenRouter config), the outgoing
+        request body must NOT contain a ``usage`` key. Hardcoding
+        ``{"usage": {"include": True}}`` into the adapter violates PROD::I3 by
+        injecting an OpenRouter-specific knob into every provider.
+        """
         from hestai_context_mcp.ports.ai_client import CompletionRequest
 
         seen: dict[str, object] = {}
@@ -151,7 +157,42 @@ class TestSuccessUsageAccounting:
             seen["body"] = json.loads(req.content.decode())
             return _ok_response("x")
 
-        client = _build_client_with_transport(handler)
+        # No provider_payload → no OpenRouter-specific keys in the payload.
+        client = _build_client_with_transport(handler, provider_payload=None)
+        async with client as c:
+            await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        body = seen["body"]
+        assert isinstance(body, dict)
+        assert "usage" not in body, (
+            "PROD::I3 violation: 'usage' is an OpenRouter-specific field and "
+            "must not be hardcoded in the generic adapter; it must come from "
+            "provider_payload in ai_config.py"
+        )
+
+    @pytest.mark.asyncio
+    async def test_usage_field_present_when_in_provider_payload(self):
+        """Issue #99 (Finding 1): usage is forwarded when config-sourced.
+
+        When ``provider_payload`` carries ``{"usage": {"include": True}}`` (set
+        by ``ai_config.resolve_provider_payload`` for OpenRouter), the adapter
+        must forward it verbatim to the provider. This validates the positive
+        path after the config-sourcing fix.
+        """
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        seen: dict[str, object] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["body"] = json.loads(req.content.decode())
+            return _ok_response("x")
+
+        # Simulate what ai_config.resolve_provider_payload returns for OpenRouter.
+        payload = {
+            "provider": {"order": ["MiniMax"], "allow_fallbacks": True},
+            "usage": {"include": True},
+        }
+        client = _build_client_with_transport(handler, provider_payload=payload)
         async with client as c:
             await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
 

--- a/tests/unit/core/test_governance_reviewer.py
+++ b/tests/unit/core/test_governance_reviewer.py
@@ -33,6 +33,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientTransportError,
     AIClientTruncationError,
     CompletionRequest,
+    CompletionResult,
 )
 
 _SAMPLE_AGR = (
@@ -62,11 +63,29 @@ _BLOCKED_RESPONSE = (
 
 
 class _StubClient:
-    """Async-context AIClient stub capturing the request it received."""
+    """Async-context AIClient stub capturing the request it received.
 
-    def __init__(self, *, text: str = "", raises: BaseException | None = None) -> None:
+    Returns a ``CompletionResult`` (issue #98). Usage/cost default to ``None`` so
+    a bare stub exercises the estimate-fallback path; pass them to exercise the
+    real-usage path.
+    """
+
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        raises: BaseException | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        cost: float | None = None,
+    ) -> None:
         self._text = text
         self._raises = raises
+        self._prompt_tokens = prompt_tokens
+        self._completion_tokens = completion_tokens
+        self._total_tokens = total_tokens
+        self._cost = cost
         self.request: CompletionRequest | None = None
         self.entered = False
         self.closed = False
@@ -78,11 +97,17 @@ class _StubClient:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         self.closed = True
 
-    async def complete_text(self, request: CompletionRequest) -> str:
+    async def complete_text(self, request: CompletionRequest) -> CompletionResult:
         self.request = request
         if self._raises is not None:
             raise self._raises
-        return self._text
+        return CompletionResult(
+            content=self._text,
+            prompt_tokens=self._prompt_tokens,
+            completion_tokens=self._completion_tokens,
+            total_tokens=self._total_tokens,
+            cost=self._cost,
+        )
 
 
 @pytest.fixture
@@ -115,10 +140,27 @@ class TestReviewSuccess:
         assert isinstance(result["assessment"], str) and result["assessment"]
         assert isinstance(result["concerns"], list)
         metrics = result["metrics"]
-        assert set(metrics) == {"tokens", "cost", "model"}
+        assert set(metrics) == {"tokens", "cost", "model", "cost_is_estimate"}
         assert isinstance(metrics["tokens"], int) and metrics["tokens"] > 0
         assert isinstance(metrics["cost"], float) and metrics["cost"] >= 0.0
         assert isinstance(metrics["model"], str) and metrics["model"]
+        # Bare stub → no provider cost → labelled estimate.
+        assert metrics["cost_is_estimate"] is True
+
+    async def test_real_usage_and_cost_reported(self, patch_client) -> None:
+        stub = _StubClient(
+            text=_APPROVED_RESPONSE,
+            prompt_tokens=900,
+            completion_tokens=120,
+            total_tokens=1020,
+            cost=0.0021,
+        )
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        metrics = result["metrics"]
+        assert metrics["tokens"] == 1020
+        assert metrics["cost"] == pytest.approx(0.0021)
+        assert metrics["cost_is_estimate"] is False
 
     async def test_concerns_verdict_carries_concern_list(self, patch_client) -> None:
         stub = _StubClient(text=_CONCERNS_RESPONSE)
@@ -267,7 +309,23 @@ class TestFailSoftErrorPaths:
         assert result["verdict"] == "BLOCKED"
         assert result["verdict"] != "APPROVED"
         assert result["metrics"]["tokens"] == 2000
+        # No provider cost on the error → labelled flat-rate estimate.
         assert result["metrics"]["cost"] == pytest.approx(2.0)
+        assert result["metrics"]["cost_is_estimate"] is True
+
+    async def test_truncation_records_real_cost_when_available(
+        self, patch_client, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("HESTAI_REVIEW_MAX_COST_USD", "1000000")
+        stub = _StubClient(
+            raises=AIClientTruncationError("truncated", consumed_tokens=2000, cost=0.0031)
+        )
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["metrics"]["tokens"] == 2000
+        assert result["metrics"]["cost"] == pytest.approx(0.0031)
+        assert result["metrics"]["cost_is_estimate"] is False
 
 
 class TestCostCap:

--- a/tests/unit/core/test_governance_reviewer.py
+++ b/tests/unit/core/test_governance_reviewer.py
@@ -242,6 +242,45 @@ class TestPromptIsSemanticScoped:
             assert ("do not produce a facet" in prompt) or ("no facet" in prompt)
 
 
+class TestCostIsEstimateSemantics:
+    """Issue #99 (Finding 3): cost_is_estimate must be False on zero-cost paths.
+
+    Mirrors Finding 2 in intake_compiler: auth errors and no-credential failures
+    cost definitively $0. Transport errors remain ``True`` (unknown billing).
+    """
+
+    async def test_no_credential_blocked_has_cost_is_estimate_false(self, patch_client) -> None:
+        """No AIClient → definitively $0; cost_is_estimate must be False."""
+        patch_client(None)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["metrics"]["cost_is_estimate"] is False, (
+            "No-credential BLOCKED is definitively $0 (provider never called); "
+            "cost_is_estimate must be False, not True"
+        )
+
+    async def test_auth_error_blocked_has_cost_is_estimate_false(self, patch_client) -> None:
+        """Auth error → provider rejected before billing; cost_is_estimate must be False."""
+        stub = _StubClient(raises=AIClientAuthError("no key"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["metrics"]["cost_is_estimate"] is False, (
+            "Auth error is a pre-billing rejection; cost is definitively $0; "
+            "cost_is_estimate must be False"
+        )
+
+    async def test_transport_error_blocked_retains_cost_is_estimate_true(
+        self, patch_client
+    ) -> None:
+        """Transport error → unknown whether provider billed; cost_is_estimate stays True."""
+        stub = _StubClient(raises=AIClientTransportError("timeout"))
+        patch_client(stub)
+        result = await review_governance(_SAMPLE_AGR)
+        assert result["verdict"] == "BLOCKED"
+        assert result["metrics"]["cost_is_estimate"] is True
+
+
 class TestNoClientAvailable:
     async def test_returns_structured_failure_when_no_client(self, patch_client) -> None:
         patch_client(None)

--- a/tests/unit/core/test_intake_compiler.py
+++ b/tests/unit/core/test_intake_compiler.py
@@ -201,6 +201,49 @@ class TestRealUsageAccounting:
         assert ctx.prose_input in stub.request.user_prompt
 
 
+class TestCostIsEstimateSemantics:
+    """Issue #99 (Finding 2): cost_is_estimate must be False on zero-cost paths.
+
+    Auth errors and no-credential failures cost definitively $0 — the provider
+    never billed. Marking them ``cost_is_estimate=True`` is semantically wrong;
+    the cost is not estimated, it is exactly $0.
+
+    Transport errors and generic AIClientError are left as ``True`` (genuinely
+    unknown whether the provider billed before the connection was lost).
+    """
+
+    async def test_no_credential_failure_has_cost_is_estimate_false(self, patch_client) -> None:
+        """No AIClient → definitively $0; cost_is_estimate must be False."""
+        patch_client(None)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["ok"] is False
+        assert result["metrics"]["cost_is_estimate"] is False, (
+            "No-credential failure is definitively $0 (provider never called); "
+            "cost_is_estimate must be False, not True"
+        )
+
+    async def test_auth_error_failure_has_cost_is_estimate_false(self, patch_client) -> None:
+        """Auth error → provider rejected before billing; cost_is_estimate must be False."""
+        stub = _StubClient(raises=AIClientAuthError("no key"))
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["ok"] is False
+        assert result["metrics"]["cost_is_estimate"] is False, (
+            "Auth error is a pre-billing rejection; cost is definitively $0; "
+            "cost_is_estimate must be False"
+        )
+
+    async def test_transport_error_failure_retains_cost_is_estimate_true(
+        self, patch_client
+    ) -> None:
+        """Transport error → unknown whether provider billed; cost_is_estimate stays True."""
+        stub = _StubClient(raises=AIClientTransportError("timeout"))
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["ok"] is False
+        assert result["metrics"]["cost_is_estimate"] is True
+
+
 class TestNoClientAvailable:
     async def test_returns_structured_failure_when_no_client(self, patch_client) -> None:
         patch_client(None)

--- a/tests/unit/core/test_intake_compiler.py
+++ b/tests/unit/core/test_intake_compiler.py
@@ -31,6 +31,7 @@ from hestai_context_mcp.ports.ai_client import (
     AIClientTransportError,
     AIClientTruncationError,
     CompletionRequest,
+    CompletionResult,
 )
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
 
@@ -45,11 +46,30 @@ def _ctx(prose: str = "record a provider routing decision") -> IntakeContext:
 
 
 class _StubClient:
-    """Async-context AIClient stub capturing the request it received."""
+    """Async-context AIClient stub capturing the request it received.
 
-    def __init__(self, *, text: str = "", raises: BaseException | None = None) -> None:
+    Returns a ``CompletionResult`` (issue #98). ``prompt_tokens`` /
+    ``completion_tokens`` / ``total_tokens`` / ``cost`` default to ``None`` so a
+    bare ``_StubClient(text=...)`` exercises the estimate-fallback path; pass
+    them explicitly to exercise the real-usage path.
+    """
+
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        raises: BaseException | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        cost: float | None = None,
+    ) -> None:
         self._text = text
         self._raises = raises
+        self._prompt_tokens = prompt_tokens
+        self._completion_tokens = completion_tokens
+        self._total_tokens = total_tokens
+        self._cost = cost
         self.request: CompletionRequest | None = None
         self.entered = False
         self.closed = False
@@ -61,11 +81,17 @@ class _StubClient:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         self.closed = True
 
-    async def complete_text(self, request: CompletionRequest) -> str:
+    async def complete_text(self, request: CompletionRequest) -> CompletionResult:
         self.request = request
         if self._raises is not None:
             raise self._raises
-        return self._text
+        return CompletionResult(
+            content=self._text,
+            prompt_tokens=self._prompt_tokens,
+            completion_tokens=self._completion_tokens,
+            total_tokens=self._total_tokens,
+            cost=self._cost,
+        )
 
 
 @pytest.fixture
@@ -88,10 +114,80 @@ class TestCompileSuccess:
         assert result["octave"] == octave
         assert result["error"] is None
         metrics = result["metrics"]
-        assert set(metrics) == {"tokens", "cost", "model"}
+        assert set(metrics) == {"tokens", "cost", "model", "cost_is_estimate"}
         assert isinstance(metrics["tokens"], int) and metrics["tokens"] > 0
         assert isinstance(metrics["cost"], float) and metrics["cost"] >= 0.0
         assert isinstance(metrics["model"], str) and metrics["model"]
+        # No provider cost on this bare stub → flat-rate estimate, labelled.
+        assert metrics["cost_is_estimate"] is True
+
+
+class TestRealUsageAccounting:
+    """Issue #98: success metrics report the provider's REAL tokens + cost."""
+
+    async def test_real_usage_and_cost_reported_not_estimated(self, patch_client) -> None:
+        octave = "===DECISION_RECORD===\nMETA:\n  TYPE::DECISION_RECORD\n===END==="
+        stub = _StubClient(
+            text=octave,
+            prompt_tokens=6900,
+            completion_tokens=3137,
+            total_tokens=10037,
+            cost=0.0043,
+        )
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        metrics = result["metrics"]
+        # Real provider totals, not the char-based estimate.
+        assert metrics["tokens"] == 10037
+        assert metrics["cost"] == pytest.approx(0.0043)
+        assert metrics["cost_is_estimate"] is False
+
+    async def test_real_total_tokens_used_verbatim(self, patch_client) -> None:
+        # The adapter delivers a reconstructed/real total; the caller trusts it.
+        stub = _StubClient(
+            text="===DECISION_RECORD===\n===END===",
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            cost=0.001,
+        )
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        assert result["metrics"]["tokens"] == 150
+        assert result["metrics"]["cost"] == pytest.approx(0.001)
+        assert result["metrics"]["cost_is_estimate"] is False
+
+    async def test_no_provider_usage_falls_back_to_char_estimate_tokens(self, patch_client) -> None:
+        # total_tokens absent (provider sent no usage) → char-based token estimate.
+        stub = _StubClient(text="===DECISION_RECORD===\n===END===", total_tokens=None, cost=None)
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        # Falls back to the char estimate (>0) and labels the cost an estimate.
+        assert result["metrics"]["tokens"] > 0
+        assert result["metrics"]["cost_is_estimate"] is True
+
+    async def test_cost_none_falls_back_to_labelled_estimate(
+        self, patch_client, monkeypatch
+    ) -> None:
+        # Real tokens present but NO provider cost → estimate cost, real tokens.
+        monkeypatch.setenv("HESTAI_INTAKE_USD_PER_1K_TOKENS", "1.0")
+        # Raise the abort cap so the pre-call guard does not short-circuit.
+        monkeypatch.setenv("HESTAI_INTAKE_MAX_COST_USD", "1000000")
+        stub = _StubClient(
+            text="===DECISION_RECORD===\n===END===",
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+            cost=None,
+        )
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        metrics = result["metrics"]
+        # Real tokens are still used even when cost is estimated.
+        assert metrics["tokens"] == 150
+        # Estimate = real tokens * flat rate, clearly labelled.
+        assert metrics["cost"] == pytest.approx(150 / 1000.0)
+        assert metrics["cost_is_estimate"] is True
 
     async def test_uses_jit_prompt_from_context(self, patch_client) -> None:
         stub = _StubClient(text="===DECISION_RECORD===\n===END===")
@@ -154,7 +250,7 @@ class _CountingStub:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         return None
 
-    async def complete_text(self, request: CompletionRequest) -> str:
+    async def complete_text(self, request: CompletionRequest) -> CompletionResult:
         self.calls += 1
         raise self._raises
 
@@ -179,21 +275,40 @@ class TestTruncationAccounting:
         assert result["error"]
         assert "truncat" in result["error"].lower()
 
-    async def test_truncation_records_real_tokens_and_cost(self, patch_client, monkeypatch) -> None:
-        # Deterministic pricing so cost is exactly tokens/1000 * price.
+    async def test_truncation_records_real_tokens_estimated_cost(
+        self, patch_client, monkeypatch
+    ) -> None:
+        # Deterministic pricing so the estimate is exactly tokens/1000 * price.
         monkeypatch.setenv("HESTAI_INTAKE_USD_PER_1K_TOKENS", "1.0")
         # Raise the abort cap so the pre-call cost guard does not short-circuit;
         # we want the truncation branch (post-call) to be exercised.
         monkeypatch.setenv("HESTAI_INTAKE_MAX_COST_USD", "1000000")
+        # No real cost on the error → fall back to the labelled estimate.
         stub = _StubClient(raises=AIClientTruncationError("truncated", consumed_tokens=8000))
         patch_client(stub)
         result = await compile_prose_to_octave(_ctx())
         metrics = result["metrics"]
         # The REAL billed tokens, not 0.
         assert metrics["tokens"] == 8000
-        # NON-zero cost computed from consumed tokens at the configured price.
+        # No provider cost → estimate from consumed tokens at the configured price.
         assert metrics["cost"] == pytest.approx(8.0)
+        assert metrics["cost_is_estimate"] is True
         assert metrics["model"]
+
+    async def test_truncation_records_real_cost_when_available(
+        self, patch_client, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("HESTAI_INTAKE_MAX_COST_USD", "1000000")
+        # Issue #98: the error carries the provider's real cost → use it verbatim.
+        stub = _StubClient(
+            raises=AIClientTruncationError("truncated", consumed_tokens=8000, cost=0.0142)
+        )
+        patch_client(stub)
+        result = await compile_prose_to_octave(_ctx())
+        metrics = result["metrics"]
+        assert metrics["tokens"] == 8000
+        assert metrics["cost"] == pytest.approx(0.0142)
+        assert metrics["cost_is_estimate"] is False
 
     async def test_truncation_is_not_retried(self, patch_client) -> None:
         stub = _CountingStub(raises=AIClientTruncationError("truncated", consumed_tokens=8000))

--- a/tests/unit/core/test_synthesis_ai_path.py
+++ b/tests/unit/core/test_synthesis_ai_path.py
@@ -55,10 +55,12 @@ class _StubClient:
     async def __aexit__(self, exc_type, exc, tb) -> None:
         self.closed = True
 
-    async def complete_text(self, request: Any) -> str:  # CompletionRequest
+    async def complete_text(self, request: Any):  # -> CompletionResult
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
         if self._raises is not None:
             raise self._raises
-        return self._text
+        return CompletionResult(content=self._text)
 
 
 @pytest.fixture

--- a/tests/unit/ports/test_ai_client.py
+++ b/tests/unit/ports/test_ai_client.py
@@ -246,7 +246,11 @@ class TestAIClientProtocol:
 
     def test_satisfies_isinstance_with_conforming_stub(self):
         """A stub implementing __aenter__/__aexit__/complete_text is an AIClient."""
-        from hestai_context_mcp.ports.ai_client import AIClient, CompletionRequest
+        from hestai_context_mcp.ports.ai_client import (
+            AIClient,
+            CompletionRequest,
+            CompletionResult,
+        )
 
         class _Stub:
             async def __aenter__(self):
@@ -255,8 +259,8 @@ class TestAIClientProtocol:
             async def __aexit__(self, exc_type, exc, tb):
                 return None
 
-            async def complete_text(self, request: CompletionRequest) -> str:
-                return "ok"
+            async def complete_text(self, request: CompletionRequest) -> CompletionResult:
+                return CompletionResult(content="ok")
 
         assert isinstance(_Stub(), AIClient) is True
 

--- a/tests/unit/ports/test_ai_client.py
+++ b/tests/unit/ports/test_ai_client.py
@@ -100,6 +100,64 @@ class TestCompletionRequestShape:
             assert hint in allowed, f"CompletionRequest.{name} has non-primitive hint: {hint!r}"
 
 
+class TestCompletionResultShape:
+    """Issue #98: ``complete_text`` returns a vendor-free result with real usage.
+
+    The port carries the provider's real token usage and real cost so callers
+    can report accurate metrics instead of local estimates. ``cost`` is
+    ``float | None`` (None when the provider reports no cost → caller falls back
+    to a labelled estimate). All names stay vendor-agnostic (PROD::I3).
+    """
+
+    def test_exported_in_all(self):
+        import hestai_context_mcp.ports.ai_client as mod
+
+        assert "CompletionResult" in mod.__all__
+
+    def test_required_fields(self):
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
+        res = CompletionResult(
+            content="hello",
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            cost=0.0042,
+        )
+        assert res.content == "hello"
+        assert res.prompt_tokens == 10
+        assert res.completion_tokens == 20
+        assert res.total_tokens == 30
+        assert res.cost == 0.0042
+
+    def test_usage_and_cost_default_to_none(self):
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
+        res = CompletionResult(content="hello")
+        assert res.prompt_tokens is None
+        assert res.completion_tokens is None
+        assert res.total_tokens is None
+        assert res.cost is None
+
+    def test_is_frozen(self):
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
+        res = CompletionResult(content="x")
+        with pytest.raises((AttributeError, Exception)):
+            res.content = "other"  # type: ignore[misc]
+
+    def test_type_hints_are_vendor_free_primitives(self):
+        from hestai_context_mcp.ports.ai_client import CompletionResult
+
+        hints = get_type_hints(CompletionResult)
+        expected = {"content", "prompt_tokens", "completion_tokens", "total_tokens", "cost"}
+        assert set(hints.keys()) == expected
+        # str, int|None, float|None — assert no vendor type leaked.
+        for hint in hints.values():
+            assert "anthropic" not in repr(hint).lower()
+            assert "openai" not in repr(hint).lower()
+
+
 class TestAIClientProtocol:
     """``AIClient`` is a runtime-checkable Protocol with ``complete_text`` coroutine."""
 
@@ -293,6 +351,24 @@ class TestTruncationErrorTaxonomy:
         exc = AIClientTruncationError("output truncated", consumed_tokens=8000)
         assert exc.prompt_tokens is None
         assert exc.completion_tokens is None
+
+    def test_carries_optional_real_cost(self):
+        """Issue #98: the truncation error also carries the provider's real cost.
+
+        A truncated call is still billed; when the provider reports the cost the
+        caller prices the real consumed tokens with the real cost rather than the
+        flat-rate estimate. ``cost`` defaults to None when unavailable.
+        """
+        from hestai_context_mcp.ports.ai_client import AIClientTruncationError
+
+        exc = AIClientTruncationError("output truncated", consumed_tokens=8000, cost=0.0142)
+        assert exc.cost == 0.0142
+
+    def test_cost_defaults_to_none(self):
+        from hestai_context_mcp.ports.ai_client import AIClientTruncationError
+
+        exc = AIClientTruncationError("output truncated", consumed_tokens=8000)
+        assert exc.cost is None
 
     def test_is_vendor_free(self):
         """PROD::I3: the new exception must not name a provider in source."""


### PR DESCRIPTION
Closes #98.

## What

`submit_governance` prose-mode and the governance reviewer reported `metrics.cost`/`metrics.tokens` as **local estimates** — cost overstated real spend ~15× (flat \$0.01/1k) and tokens were char-estimated. This PR reports the provider's **real** usage and cost from the OpenRouter response, keeping the flat-rate estimate only where it belongs: the pre-call abort guard, and a clearly-labelled fallback.

## How (4 parts, TDD RED→GREEN per part)

1. **Port** (`ports/ai_client.py`): `complete_text` now returns a vendor-free frozen `CompletionResult` (content + prompt/completion/total tokens + `cost: float | None`) instead of `str`. `AIClientTruncationError` gains an optional real `cost`. Added to `__all__`; source-invariant test still passes (PROD::I3).
2. **Adapter** (`adapters/openai_compat_ai_client.py`): sends `usage: {include: true}` (vendor knob, adapter layer); parses real `usage.{prompt_tokens,completion_tokens,total_tokens,cost}` on the success path and threads real cost into the truncation error. `_extract_usage` refactored to a parsed `_Usage` (negative tokens/cost clamped to absent, #97 carry-over).
3. **Callers** (`core/intake_compiler.py`, `core/governance_reviewer.py`): success + truncation paths report real tokens/cost; new `metrics.cost_is_estimate` flag is `True` only when falling back to the flat-rate estimate (provider reported no cost), so an estimate is never presented as actual. Pre-call projection/abort guard unchanged.
4. **Synthesis** (`core/synthesis.py`): adjusts to the new return type (discards all but content on the clock-in fallback path).

Breaking port-contract change handled coordinated: all AIClient test stubs return `CompletionResult`; `intake_pipeline` seeds the new metrics key.

## OpenRouter cost field shape

Verified against current OpenRouter docs/community: the response `usage` block carries `prompt_tokens`/`completion_tokens`/`total_tokens` plus `cost` (total USD) and `cost_details`. We parse `usage.cost` as `float | None` (missing → None → labelled estimate fallback). `usage:{include:true}` is sent for explicit opt-in (harmless even where now always-on).

## Acceptance criteria (#98)

- [x] Success metrics report real cost (matches dashboard within rounding) and real prompt+completion tokens
- [x] `cost=None` → labelled flat-rate estimate (`cost_is_estimate=true`), never presented as actual
- [x] Pre-call abort guard unchanged (flat-rate projection)
- [x] Truncation path prices real consumed tokens with real cost when available
- [x] PROD::I3 source-invariant passes; port stays vendor-free
- [x] Full gate chain green; coverage 93% (≥85%)

## Gates

- ruff check src tests — pass
- black --check src tests — pass
- mypy src — pass (0 issues, 58 files)
- pytest — **1359 passed, 2 failed**; the 2 failures are the pre-existing known issue #66 (`test_clock_in.py ...test_ai_synthesis_always_present_as_structured_dict`) full-suite ordering pollution — they pass in isolation and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report real provider tokens and USD cost in metrics by reading `usage` from OpenRouter responses, and mark zero-cost auth/no-credential paths as not estimates. Moves the OpenRouter `usage: {include: true}` opt-in to `ai_config` so vendor knobs live in config; the pre-call cost guard stays the same.

- **New Features**
  - `AIClient.complete_text` now returns `CompletionResult` (content + `prompt_tokens`, `completion_tokens`, `total_tokens`, `cost`); `AIClientTruncationError` gains optional `cost`.
  - OpenRouter adapter parses real `usage.*` and `cost` to return actual tokens and USD cost; negatives are treated as absent. The `usage: {include: true}` opt-in is now provided by `adapters/ai_config.py` via the provider payload (not hardcoded).
  - `intake_compiler` and `governance_reviewer` report real tokens/cost and set `metrics.cost_is_estimate=true` only when falling back to the flat-rate estimate; zero-cost auth/no-credential paths set `cost_is_estimate=false`. `synthesis` reads `.content` only.

- **Migration**
  - Update any `AIClient` callers/stubs to expect `CompletionResult` and read `.content`.
  - If you consume metrics, expect a new `metrics.cost_is_estimate` boolean; `metrics.cost` and `metrics.tokens` now reflect provider-reported values.

<sup>Written for commit 589436662b164f44ed277ac0fc7bab980db314b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

