### PR TITLE
chore: release version 0.9.0

### DIFF
--- a/.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md
+++ b/.hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md
@@ -315,17 +315,27 @@ Lists AGRs with optional filtering. Pure read.
     },
     …
   ],
-  "total": <integer>
+  "total": <integer>,
+  "skipped": [
+    {
+      "path": "<repo-relative path>",
+      "parse_error": "<reason the record could not be parsed>"
+    },
+    …
+  ]
 }
 ```
 
 The list is sorted by `authored_at` descending. No paging in v1; implementations MUST handle the full set in a single response. If repository scale requires paging, that is a MINOR schema addition for v1.1.
 
+`skipped` (additive per §3.1.1) is ALWAYS present — an empty array when every in-scope record parsed. It names every file that IS a `DECISION_RECORD` but failed to parse its required §1.2 fields, so a consumer can detect that the listing is incomplete and exactly which records are missing. Entries are sorted by `path` for deterministic output.
+
 **Error cases** (per §3.1.1 envelope):
 
 - `FILTER_INVALID` (`input_validation`) — `status` or `tier` is non-null and not a member of the admissible enum; `context.field` and `context.value` populated.
 - `WORKING_DIR_INVALID` (`io_failure`) — as in §3.2.
-- `RECORD_PARSE_FAILED` (`schema_violation`) — any record under `.hestai/decisions/**` fails to parse. Implementation choice: fail the whole call (recommended) rather than silently dropping the bad record; consumers MUST be able to detect that the list is incomplete.
+
+**Incompleteness handling**: a record under `.hestai/decisions/**` that IS a `DECISION_RECORD` but fails to parse does NOT fail the whole call. It is reported in the `skipped` array (above) — never silently dropped, and never blinding the rest of the index. This satisfies the hard requirement (consumers MUST be able to detect that the list is incomplete) while a single legacy or non-conforming record no longer makes the tool appear dead. (An earlier revision named whole-call `RECORD_PARSE_FAILED` as the recommended choice; the `skipped`-array form is the chosen implementation — detectability is preserved, resilience is improved. `lookup_decision` §3.2 still returns `RECORD_PARSE_FAILED` because a by-TOKEN read targets exactly one record.)
 
 ### 3.4 `trace_supersedure(working_dir, token)`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+---
+
+## [0.9.0] — 2026-06-17 — Real Cost Accounting & Truncation Resilience
+
 ### Added
 - `AIClientTruncationError` in the AIClient port taxonomy — models output-token budget exhaustion (provider `finish_reason="length"`) distinctly from a malformed response, carrying the real `consumed_tokens` (issue #96)
 - Config-sourced provider upstream-routing pin: `HESTAI_AI_PROVIDER_ORDER` (comma-separated upstream slugs, OpenRouter) and `HESTAI_AI_PROVIDER_ROUTING=off` to disable. Defaults to a preferred order with `allow_fallbacks` preserved (prefer, not require), so a preferred-upstream outage degrades gracefully (issue #96)
@@ -206,5 +210,6 @@ This milestone implements the full ADR-0013 Portable Session State specification
 
 ---
 
-[Unreleased]: https://github.com/elevanaltd/hestai-context-mcp/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/elevanaltd/hestai-context-mcp/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/elevanaltd/hestai-context-mcp/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/elevanaltd/hestai-context-mcp/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - `metrics.cost` and `metrics.tokens` now report the provider's **real** figures from the OpenRouter response (via `usage: {include: true}`) instead of local estimates. Previously `cost` overstated real spend by ~15× (flat $0.01/1k) and `tokens` were char-estimated. The flat-rate estimate is retained only for the pre-call cost-projection / abort guard, and as a clearly-labelled fallback when the provider reports no cost (issue #98)
+- `list_decisions` no longer fail-closes the entire index when one record is unparseable. It returns the parseable records plus an always-present `skipped` array naming each malformed `DECISION_RECORD` and why it failed. A single legacy/non-conforming file (e.g. a pre-schema ADR) can no longer make the whole tool appear dead. Detectability of an incomplete list — the ADR-RFC-ARCH-004 §3.3 hard requirement — is preserved via `skipped`; silent dropping remains forbidden. `lookup_decision` (by-TOKEN) still returns `RECORD_PARSE_FAILED`, since it targets exactly one record (ADR-RFC-ARCH-004 §3.3)
 
 ### Fixed
 - Stage-2 prose→OCTAVE (`submit_governance` prose mode) no longer fails non-deterministically when OpenRouter routes a reasoning model onto an upstream that truncates at the token cap: the pin reduces routing nondeterminism and `finish_reason="length"` is now surfaced as an actionable truncation error instead of an opaque protocol error (issue #96)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hestai-context-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "HestAI Context MCP Server - Session lifecycle, context synthesis, and review infrastructure"
 authors = [{name = "HestAI", email = "noreply@hestai.dev"}]
 readme = "README.md"

--- a/src/hestai_context_mcp/tools/list_decisions.py
+++ b/src/hestai_context_mcp/tools/list_decisions.py
@@ -2,8 +2,16 @@
 
 Pure read (PROD I5), structured return (PROD I4). Returns summary entries sorted
 by ``authored_at`` DESCENDING with optional scope/status/tier filters. Errors use
-the §3.1.1 envelope: FILTER_INVALID, WORKING_DIR_INVALID, RECORD_PARSE_FAILED
-(a single unparseable record fails the WHOLE call — no silent drop).
+the §3.1.1 envelope: FILTER_INVALID, WORKING_DIR_INVALID.
+
+§3.3 incompleteness handling: a file that IS a DECISION_RECORD but fails to
+parse its required §1.2 fields is NOT fatal. The parseable records are returned
+and each unparseable one is reported in an explicit ``skipped`` array (with its
+path and parse error). This satisfies the §3.3 invariant — consumers MUST be
+able to detect that the list is incomplete — without one legacy/malformed record
+fail-closing the entire index. Silent drop remains forbidden: a skip is always
+surfaced. (The contract names whole-call failure as a *recommended* option; the
+hard requirement is detectability, which the ``skipped`` array provides.)
 
 Reuses the shared ``tools.governance.agr_read`` primitives (enumeration via
 ``iter_record_paths``, structured parsing) — no rebuilt logic.
@@ -37,8 +45,12 @@ def list_decisions(
         tier: One of the TIER enum values, or ``None``.
 
     Returns:
-        On success: ``{"ok": True, "records": [...], "total": int}`` sorted by
-        ``authored_at`` DESC. On failure: the §3.1.1 error envelope.
+        On success: ``{"ok": True, "records": [...], "total": int,
+        "skipped": [{"path": str, "parse_error": str}, ...]}`` with ``records``
+        sorted by ``authored_at`` DESC. ``skipped`` is always present (empty when
+        every in-scope record parsed) and names every DECISION_RECORD that failed
+        to parse, so a consumer can detect an incomplete list (§3.3). On input
+        failure (bad filter / working_dir): the §3.1.1 error envelope.
     """
     working_path = agr_read.validate_working_dir(working_dir)
     if working_path is None:
@@ -57,6 +69,7 @@ def list_decisions(
         return _filter_invalid("tier", tier)
 
     records: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
     for path in agr_read.iter_record_paths(working_path):
         is_agr, parsed = agr_read.classify_file(path)
 
@@ -67,22 +80,20 @@ def list_decisions(
         if not is_agr:
             continue
 
-        # §3.3 PROTECTION (preserved): a file that IS a DECISION_RECORD but fails
-        # to parse its required §1.2 fields fails the WHOLE call — consumers MUST
-        # be able to detect that the list is incomplete; do not silently drop a
-        # genuinely-malformed AGR.
+        # §3.3 INCOMPLETENESS HANDLING: a file that IS a DECISION_RECORD but fails
+        # to parse its required §1.2 fields must not be SILENTLY dropped, and must
+        # not blind the whole index either. Record it in ``skipped`` — that
+        # surfaces the incompleteness (the §3.3 hard requirement) while the rest
+        # of the index remains usable. A single legacy/non-conforming record can
+        # no longer fail-close the entire call.
         if not agr_read.record_is_parseable(parsed):
-            return agr_read.error_envelope(
-                code="RECORD_PARSE_FAILED",
-                category="schema_violation",
-                message="A DECISION_RECORD under .hestai/decisions failed to parse.",
-                tool=_TOOL,
-                context={
+            skipped.append(
+                {
                     "path": agr_read.rel_path(working_path, path),
                     "parse_error": "missing OCTAVE envelope or required §1.2 field(s)",
-                },
-                contract_ref=_CONTRACT_REF,
+                }
             )
+            continue
 
         if status is not None and parsed["status"] != status:
             continue
@@ -104,8 +115,10 @@ def list_decisions(
 
     # §3.3: sorted by authored_at DESCENDING.
     records.sort(key=lambda r: r["authored_at"] or "", reverse=True)
+    # Stable, deterministic skip order for reproducible consumer diffs.
+    skipped.sort(key=lambda s: s["path"])
 
-    return {"ok": True, "records": records, "total": len(records)}
+    return {"ok": True, "records": records, "total": len(records), "skipped": skipped}
 
 
 def _filter_invalid(field: str, value: str) -> dict[str, Any]:

--- a/tests/unit/tools/governance/test_list_decisions.py
+++ b/tests/unit/tools/governance/test_list_decisions.py
@@ -12,8 +12,12 @@ Return::
     }
 
 sorted by authored_at DESCENDING. Optional scope/status/tier filters.
-FILTER_INVALID for a bad enum, WORKING_DIR_INVALID for a bad path,
-RECORD_PARSE_FAILED fails the WHOLE call (no silent drop) per §3.3.
+FILTER_INVALID for a bad enum, WORKING_DIR_INVALID for a bad path. A record
+that IS a DECISION_RECORD but fails to parse is NOT fatal: the parseable
+records are still returned and each unparseable one is reported in an explicit
+``skipped`` array (§3.3). This satisfies the §3.3 invariant — consumers MUST be
+able to detect that the list is incomplete — without one legacy/malformed file
+blinding the entire index. (Silent drop remains forbidden.)
 
 RED: ``tools.list_decisions`` does not exist yet — import raises
 ModuleNotFoundError.
@@ -195,17 +199,26 @@ class TestErrorEnvelope:
         self._assert_envelope(result, "WORKING_DIR_INVALID", "io_failure")
 
     @pytest.mark.unit
-    def test_record_parse_failed_fails_whole_call(self, tmp_path: Path) -> None:
-        """§3.3: a single unparseable record fails the WHOLE call, no silent drop.
+    def test_malformed_record_does_not_blind_the_index(self, tmp_path: Path) -> None:
+        """§3.3: a single unparseable record is reported in ``skipped`` — NOT fatal.
 
-        Consumers MUST be able to detect that the list is incomplete; the tool
-        therefore returns the error envelope rather than dropping the bad file.
+        The parseable record is still returned, and the malformed one surfaces in
+        the explicit ``skipped`` array so the consumer can detect the list is
+        incomplete. One legacy/non-conforming file must not blind the whole index.
         """
         list_decisions = _list_decisions()
         write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
         write_malformed_record(tmp_path)
         result = list_decisions(str(tmp_path))
-        self._assert_envelope(result, "RECORD_PARSE_FAILED", "schema_violation")
+        # Parseable record is still listed.
+        assert result["ok"] is True
+        assert [r["token"] for r in result["records"]] == [_T1]
+        assert result["total"] == 1
+        # The malformed AGR is surfaced, not silently dropped.
+        assert len(result["skipped"]) == 1
+        skipped = result["skipped"][0]
+        assert "MALFORMED" in skipped["path"]
+        assert isinstance(skipped["parse_error"], str) and skipped["parse_error"]
 
 
 class TestCoLocatedNonAgrFiles:
@@ -308,9 +321,10 @@ class TestCoLocatedNonAgrFiles:
         assert result["total"] == 0
 
     @pytest.mark.unit
-    def test_malformed_agr_still_errors_amid_non_agrs(self, tmp_path: Path) -> None:
-        """§3.3 protection intact: an is-an-AGR-but-broken record errors even when
-        co-located non-AGRs are present (the non-AGRs are not what trips it)."""
+    def test_malformed_agr_skipped_amid_non_agrs(self, tmp_path: Path) -> None:
+        """§3.3 distinction intact: a co-located non-AGR is excluded silently
+        (out of scope), while an is-an-AGR-but-broken record is reported in
+        ``skipped`` (in scope, but unparseable) — not conflated with the non-AGR."""
         list_decisions = _list_decisions()
         write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
         write_non_agr_record(
@@ -322,10 +336,55 @@ class TestCoLocatedNonAgrFiles:
         )
         write_malformed_record(tmp_path)  # declares DECISION_RECORD, missing fields
         result = list_decisions(str(tmp_path))
-        assert result["ok"] is False
-        assert result["error"]["code"] == "RECORD_PARSE_FAILED"
-        # The failing path is the broken AGR, not the legitimately-typed non-AGR.
-        assert "MALFORMED" in result["error"]["context"]["path"]
+        assert result["ok"] is True
+        assert [r["token"] for r in result["records"]] == [_T1]
+        # Exactly the broken AGR is skipped — the non-AGR is excluded entirely,
+        # not reported as a skip.
+        assert len(result["skipped"]) == 1
+        assert "MALFORMED" in result["skipped"][0]["path"]
+
+
+class TestGracefulDegradation:
+    """§3.3 graceful fallback: a clean store reports an empty ``skipped`` array;
+    unparseable records degrade the call to a partial result, never an error."""
+
+    @pytest.mark.unit
+    def test_clean_store_has_empty_skipped(self, tmp_path: Path) -> None:
+        """When every record parses, ``skipped`` is present and empty — so a
+        consumer can unconditionally read it as the incompleteness signal."""
+        list_decisions = _list_decisions()
+        _seed_three(tmp_path)
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        assert result["total"] == 3
+        assert result["skipped"] == []
+
+    @pytest.mark.unit
+    def test_multiple_malformed_all_reported(self, tmp_path: Path) -> None:
+        """Every unparseable record is surfaced; the count is not capped."""
+        list_decisions = _list_decisions()
+        write_record(tmp_path, token=_T1, authored_at="2026-01-01T00:00:00Z")
+        write_malformed_record(tmp_path)
+        # A second malformed AGR under a nested decisions subdir.
+        nested = tmp_path / ".hestai" / "decisions" / "rfc-arch"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "HO-CONTEXT-MCP-BROKEN-20260701.oct.md").write_text(
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            "  TOKEN::HO-CONTEXT-MCP-BROKEN-20260701\n"
+            "===END===\n",
+            encoding="utf-8",
+        )
+        result = list_decisions(str(tmp_path))
+        assert result["ok"] is True
+        assert [r["token"] for r in result["records"]] == [_T1]
+        assert len(result["skipped"]) == 2
+        # Each skip entry carries path + parse_error.
+        for entry in result["skipped"]:
+            assert entry["path"].endswith(".oct.md")
+            assert isinstance(entry["parse_error"], str) and entry["parse_error"]
 
 
 class TestPurity:

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "hestai-context-mcp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Promote Unreleased changelog section to v0.9.0 release
- Bump version in pyproject.toml to reflect real cost accounting and truncation resilience improvements
- Document all changes made since repository inception

## Changes
- **CHANGELOG.md**: Promote Unreleased to v0.9.0 with real cost accounting and truncation resilience features
- **pyproject.toml**: Update version from 0.8.x to 0.9.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.9.0 for `hestai-context-mcp`, promoting Unreleased to a tagged release and updating `pyproject.toml` and `uv.lock`. This captures real cost accounting, truncation resilience, and a safer `list_decisions` that returns parseable records plus an always-present `skipped` array for malformed records.

<sup>Written for commit d7525e23aab9d0abf5e477733e531d0b1b84d700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

