### PR TITLE
fix: bounded retry for transient malformed responses in OpenAI adapter

### DIFF
--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -26,9 +26,11 @@ Design notes:
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import TracebackType
 from typing import cast
@@ -52,6 +54,16 @@ __all__ = [
     "OpenAICompatAIClient",
     "build_default_ai_client",
 ]
+
+# Issue #1186: bounded retry for the transient malformed-response signature.
+# Some providers intermittently return a 200-OK body whose
+# ``choices[0].message.content`` is not a string (or whose ``choices`` shape is
+# otherwise malformed) for an input that compiles fine on the very next call.
+# A small bounded retry below the port turns that flake into a success without
+# changing any caller. Kept minimal (MIP): a sensible hardcoded default rather
+# than a new env knob — the values are constructor-overridable for tests.
+_DEFAULT_MAX_ATTEMPTS = 3
+_DEFAULT_RETRY_BACKOFF_SECONDS = 0.5
 
 
 @dataclass(frozen=True)
@@ -103,11 +115,22 @@ class OpenAICompatAIClient:
         timeout_seconds: float = 15.0,
         transport: httpx.AsyncBaseTransport | None = None,
         provider_payload: dict[str, object] | None = None,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+        retry_backoff_seconds: float = _DEFAULT_RETRY_BACKOFF_SECONDS,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._timeout_seconds = float(timeout_seconds)
+        # Issue #1186: bounded retry for the transient malformed-response
+        # signature. ``max_attempts`` is the TOTAL number of POSTs (clamped to a
+        # floor of 1 so a misconfiguration can never disable the request). The
+        # backoff between attempts and the sleep coroutine are injectable so the
+        # retry loop is deterministic and instant under test (no real seconds).
+        self._max_attempts = max(1, int(max_attempts))
+        self._retry_backoff_seconds = max(0.0, float(retry_backoff_seconds))
+        self._sleep: Callable[[float], Awaitable[None]] = sleep or asyncio.sleep
         # Issue #96: a generic, opaque payload merged into every outgoing
         # /chat/completions body (e.g. OpenRouter ``provider`` routing
         # preferences). The adapter is agnostic about its contents; the
@@ -150,12 +173,58 @@ class OpenAICompatAIClient:
             self._client = None
 
     async def complete_text(self, request: CompletionRequest) -> CompletionResult:
-        """Execute a chat completion call and return content + real usage/cost."""
+        """Execute a chat completion call and return content + real usage/cost.
+
+        Issue #1186: a single transient ``AIClientProtocolError`` (a 200-OK body
+        whose shape is malformed — e.g. ``content`` is not a string) is retried
+        up to ``max_attempts`` total POSTs with a small backoff. The retry is
+        deliberately NARROW: only ``AIClientProtocolError`` re-issues the call.
+        ``AIClientAuthError`` (permanent), ``AIClientTransportError`` (the port
+        contract says "do not retry within the request"), and
+        ``AIClientTruncationError`` (a re-issue would re-truncate and burn
+        budget) are distinct exception classes that propagate immediately on the
+        first occurrence. On exhaustion a clearer, actionable
+        ``AIClientProtocolError`` is raised, preserving the underlying detail on
+        the exception chain.
+        """
         if self._client is None:
-            # Guarded by the async-context-manager contract; defensive
-            # here so misuse fails predictably rather than with a
-            # ``NoneType`` attribute error.
+            # Guarded by the async-context-manager contract; defensive here so
+            # misuse fails predictably (and is NOT swallowed by the retry loop —
+            # this is a programming error, not a transient provider flake).
             raise AIClientProtocolError("OpenAICompatAIClient used outside an async-with block")
+        last_protocol_error: AIClientProtocolError | None = None
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                return await self._attempt_completion(request)
+            except AIClientProtocolError as exc:
+                # Transient malformed 200-OK body: retry the whole call until the
+                # budget is exhausted. Auth/transport/truncation are NOT caught
+                # here (distinct classes) so they propagate without retry.
+                last_protocol_error = exc
+                if attempt < self._max_attempts:
+                    logger.warning(
+                        "provider returned a malformed response (attempt %d/%d): %s; retrying",
+                        attempt,
+                        self._max_attempts,
+                        exc,
+                    )
+                    await self._sleep(self._retry_backoff_seconds)
+        # Exhausted every attempt on the malformed-response signature. Surface a
+        # clearer, actionable error while preserving the low-level cause.
+        raise AIClientProtocolError(
+            f"provider returned an unparseable response after {self._max_attempts} attempts; "
+            "retry later or resubmit in octave_content mode"
+        ) from last_protocol_error
+
+    async def _attempt_completion(self, request: CompletionRequest) -> CompletionResult:
+        """Single POST + response interpretation (one attempt of the retry loop).
+
+        ``complete_text`` has already verified the async-context-manager contract
+        (``self._client`` is open) before entering the retry loop, so the guard
+        below is purely a type-narrowing assertion for mypy — it is never the
+        live failure path.
+        """
+        assert self._client is not None  # narrowed by complete_text's guard
         payload: dict[str, object] = {}
         if self._provider_payload:
             # Merge the opaque config-sourced payload first so the reserved

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -66,6 +66,24 @@ _DEFAULT_MAX_ATTEMPTS = 3
 _DEFAULT_RETRY_BACKOFF_SECONDS = 0.5
 
 
+class _MalformedBodyError(AIClientProtocolError):
+    """Adapter-private marker: a 200-OK response whose BODY shape is malformed.
+
+    Issue #1186: this is the *transient* protocol failure worth retrying — the
+    provider returned HTTP 200 but the JSON envelope was unparseable or shaped
+    wrong (non-JSON body, missing/empty ``choices``, non-object ``choices[0]`` /
+    ``message``, or non-string ``content``). The SAME input typically compiles on
+    the next attempt, so the retry loop re-issues ONLY this subclass.
+
+    Deliberately a *subclass* of :class:`AIClientProtocolError` so callers and
+    the port contract are unchanged (it still surfaces as a protocol error). A
+    *deterministic* protocol surprise — an unexpected non-200 status such as 400
+    / 404 / 422 — keeps raising the plain ``AIClientProtocolError`` base, which
+    the retry loop does NOT catch: re-issuing a 4xx would burn latency/budget for
+    a guaranteed-identical failure (critical-engineer review, #1186).
+    """
+
+
 @dataclass(frozen=True)
 class _Usage:
     """Adapter-internal parsed view of a provider ``usage`` block.
@@ -175,31 +193,35 @@ class OpenAICompatAIClient:
     async def complete_text(self, request: CompletionRequest) -> CompletionResult:
         """Execute a chat completion call and return content + real usage/cost.
 
-        Issue #1186: a single transient ``AIClientProtocolError`` (a 200-OK body
-        whose shape is malformed — e.g. ``content`` is not a string) is retried
-        up to ``max_attempts`` total POSTs with a small backoff. The retry is
-        deliberately NARROW: only ``AIClientProtocolError`` re-issues the call.
-        ``AIClientAuthError`` (permanent), ``AIClientTransportError`` (the port
-        contract says "do not retry within the request"), and
+        Issue #1186: a transient malformed 200-OK body (``_MalformedBodyError``
+        — e.g. non-JSON body, missing/empty ``choices``, or ``content`` not a
+        string) is retried up to ``max_attempts`` total POSTs with a small
+        backoff. The retry is deliberately NARROW: only ``_MalformedBodyError``
+        (the malformed-200-body subclass of ``AIClientProtocolError``) re-issues
+        the call. ``AIClientAuthError`` (permanent), ``AIClientTransportError``
+        (the port contract says "do not retry within the request"),
         ``AIClientTruncationError`` (a re-issue would re-truncate and burn
-        budget) are distinct exception classes that propagate immediately on the
-        first occurrence. On exhaustion a clearer, actionable
-        ``AIClientProtocolError`` is raised, preserving the underlying detail on
-        the exception chain.
+        budget), AND a deterministic non-200 protocol surprise (the plain
+        ``AIClientProtocolError`` base, e.g. 400/404/422 — fails identically
+        every time) all propagate immediately on the first occurrence. On
+        exhaustion a clearer, actionable ``AIClientProtocolError`` is raised,
+        preserving the underlying detail on the exception chain.
         """
         if self._client is None:
             # Guarded by the async-context-manager contract; defensive here so
             # misuse fails predictably (and is NOT swallowed by the retry loop —
             # this is a programming error, not a transient provider flake).
             raise AIClientProtocolError("OpenAICompatAIClient used outside an async-with block")
-        last_protocol_error: AIClientProtocolError | None = None
+        last_protocol_error: _MalformedBodyError | None = None
         for attempt in range(1, self._max_attempts + 1):
             try:
                 return await self._attempt_completion(request)
-            except AIClientProtocolError as exc:
+            except _MalformedBodyError as exc:
                 # Transient malformed 200-OK body: retry the whole call until the
-                # budget is exhausted. Auth/transport/truncation are NOT caught
-                # here (distinct classes) so they propagate without retry.
+                # budget is exhausted. Auth, transport, truncation, AND a
+                # deterministic non-200 protocol surprise (plain
+                # AIClientProtocolError, e.g. 400/404/422) are NOT caught here, so
+                # they propagate immediately without a pointless re-issue.
                 last_protocol_error = exc
                 if attempt < self._max_attempts:
                     logger.warning(
@@ -274,21 +296,30 @@ class OpenAICompatAIClient:
         if status in (408, 429) or 500 <= status < 600:
             raise AIClientTransportError(f"provider returned HTTP {status}")
         if status != 200:
-            # Unknown non-2xx: treat as protocol-level surprise.
+            # Unknown non-2xx (e.g. 400/404/422): a DETERMINISTIC protocol
+            # surprise, NOT the transient malformed-body signature. Raise the
+            # plain base so the #1186 retry loop does NOT re-issue it — a 4xx will
+            # fail identically on every attempt (critical-engineer review).
             raise AIClientProtocolError(f"unexpected HTTP status from provider: {status}")
+        # --- Everything below is a 200-OK whose BODY shape is malformed: the
+        # transient signature the #1186 retry loop re-issues (_MalformedBodyError).
         try:
             body = response.json()
         except (json.JSONDecodeError, ValueError) as exc:
-            raise AIClientProtocolError(f"provider returned non-JSON body: {exc}") from exc
+            raise _MalformedBodyError(f"provider returned non-JSON body: {exc}") from exc
         choices = body.get("choices") if isinstance(body, dict) else None
-        if not choices:
-            raise AIClientProtocolError("provider response missing or empty 'choices' array")
+        # Validate the CONTAINER type before indexing: a truthy non-list value
+        # (e.g. a dict or scalar) would otherwise raise a raw KeyError/TypeError
+        # that escapes the port exception taxonomy and bypasses both this retry
+        # loop and every caller's ``except AIClientError`` fallback (CRS, #1186).
+        if not isinstance(choices, list) or not choices:
+            raise _MalformedBodyError("provider response missing or empty 'choices' array")
         first = choices[0]
         if not isinstance(first, dict):
-            raise AIClientProtocolError("provider response 'choices[0]' is not an object")
+            raise _MalformedBodyError("provider response 'choices[0]' is not an object")
         message = first.get("message")
         if not isinstance(message, dict):
-            raise AIClientProtocolError("provider response 'choices[0].message' is not an object")
+            raise _MalformedBodyError("provider response 'choices[0].message' is not an object")
         # Issue #96: inspect the stop condition BEFORE the content type-check.
         # ``finish_reason == "length"`` means the generation hit the output-token
         # cap (budget exhaustion) — a well-formed envelope whose body is
@@ -309,7 +340,7 @@ class OpenAICompatAIClient:
             )
         content = message.get("content")
         if not isinstance(content, str):
-            raise AIClientProtocolError(
+            raise _MalformedBodyError(
                 "provider response 'choices[0].message.content' is not a string"
             )
         # Issue #98: return the provider's real usage + cost alongside content so

--- a/tests/unit/adapters/test_openai_compat_ai_client_retry.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client_retry.py
@@ -1,0 +1,328 @@
+"""Bounded-retry tests for ``OpenAICompatAIClient.complete_text`` (issue #1186).
+
+A real provider intermittently returns a 200-OK body whose
+``choices[0].message.content`` is not a string (a transient malformed-response
+signature). The SAME prose input that fails on one call compiles on the next, so
+the adapter must retry the *narrow* transient-malformed-response case a bounded
+number of times before surfacing a clearer, actionable error.
+
+PLACEMENT (operator-ratified): the retry lives in the adapter (``complete_text``),
+below the ``AIClient`` port — honouring the port invariant that "retries ... live
+below this port, in the adapter/config layer" (``ports/ai_client.py``). Callers
+(``core/intake_compiler``) stay unchanged.
+
+SCOPE GUARDRAILS asserted here:
+    * RETRY only on ``AIClientProtocolError`` from a malformed 200-OK body.
+    * NO retry on ``AIClientAuthError`` (permanent), ``AIClientTransportError``
+      (port says "do not retry within the request"), or
+      ``AIClientTruncationError`` (re-issue would re-truncate and burn budget).
+    * Backoff is injected so tests never block on real wall-clock seconds.
+    * No spend leakage: a malformed body carries no usage, so a successful retry
+      reports only the *winning* response's usage.
+
+Transport is injected via ``httpx.MockTransport`` (first-party; no network).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+
+def _build_client_with_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    api_key: str = "test-key",
+    base_url: str = "https://openrouter.ai/api/v1",
+    model: str = "google/gemini-2.0-flash-lite",
+    timeout: float = 5.0,
+    provider_payload: dict | None = None,
+    **adapter_kwargs: object,
+):
+    """Create the adapter with an injected ``httpx.MockTransport``.
+
+    ``adapter_kwargs`` forwards retry-tuning knobs (``max_attempts``,
+    ``retry_backoff_seconds``, ``sleep``) so tests stay deterministic and fast.
+    """
+    from hestai_context_mcp.adapters.openai_compat_ai_client import (
+        OpenAICompatAIClient,
+    )
+
+    transport = httpx.MockTransport(handler)
+    return OpenAICompatAIClient(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        timeout_seconds=timeout,
+        transport=transport,
+        provider_payload=provider_payload,
+        **adapter_kwargs,
+    )
+
+
+def _malformed_response() -> httpx.Response:
+    """A 200-OK body whose ``content`` is not a string (the #1186 signature)."""
+    return httpx.Response(
+        200,
+        json={
+            "choices": [
+                {"message": {"content": None}, "index": 0, "finish_reason": "stop"},
+            ],
+        },
+    )
+
+
+def _ok_response(text: str, **usage: int) -> httpx.Response:
+    body: dict[str, object] = {
+        "choices": [
+            {"message": {"content": text}, "index": 0, "finish_reason": "stop"},
+        ],
+    }
+    if usage:
+        body["usage"] = usage
+    return httpx.Response(200, json=body)
+
+
+class _SleepSpy:
+    """Records backoff durations without sleeping for real."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+class TestRetrySucceedsAfterTransientMalformed:
+    @pytest.mark.asyncio
+    async def test_malformed_twice_then_valid_returns_content(self):
+        """Two malformed 200-OK bodies then a valid one → ultimately SUCCEEDS."""
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        responses = [
+            _malformed_response(),
+            _malformed_response(),
+            _ok_response("recovered-octave", prompt_tokens=5, completion_tokens=7, total_tokens=12),
+        ]
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return responses[len(calls) - 1]
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.01, sleep=sleep
+        )
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        # Retry proved: three transport calls, final valid content returned.
+        assert out.content == "recovered-octave"
+        assert len(calls) == 3
+        # No spend leakage: usage reflects only the WINNING response.
+        assert out.total_tokens == 12
+        assert out.prompt_tokens == 5
+        assert out.completion_tokens == 7
+        # Backoff was applied between attempts (two gaps), never after success.
+        assert sleep.calls == [0.01, 0.01]
+
+    @pytest.mark.asyncio
+    async def test_malformed_once_then_valid_retries_exactly_once(self):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        responses = [_malformed_response(), _ok_response("ok")]
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return responses[len(calls) - 1]
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert out.content == "ok"
+        assert len(calls) == 2
+        assert len(sleep.calls) == 1
+
+
+class TestRetryExhaustion:
+    @pytest.mark.asyncio
+    async def test_all_malformed_raises_clearer_error_after_exhaustion(self):
+        """Every attempt malformed → AIClientProtocolError with an ACTIONABLE msg."""
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return _malformed_response()
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientProtocolError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        # Exhausted all attempts.
+        assert len(calls) == 3
+        msg = str(excinfo.value)
+        # The clearer message must be actionable, mention the attempt count, and
+        # NOT be the raw low-level "is not a string" string.
+        assert "3 attempt" in msg
+        assert "octave_content" in msg
+        assert "is not a string" not in msg
+        # Underlying detail is preserved on the exception chain.
+        assert excinfo.value.__cause__ is not None
+        assert "is not a string" in str(excinfo.value.__cause__)
+        # Slept once per inter-attempt gap (2 gaps for 3 attempts).
+        assert len(sleep.calls) == 2
+
+
+class TestNoRetryOnPermanentOrDistinctErrors:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_auth_error_is_not_retried(self, status: int):
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientAuthError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return httpx.Response(status, json={"error": "bad key"})
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientAuthError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1  # immediate, no retry
+        assert sleep.calls == []
+
+    @pytest.mark.asyncio
+    async def test_truncation_error_is_not_retried(self):
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTruncationError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": None}, "index": 0, "finish_reason": "length"},
+                    ],
+                    "usage": {"prompt_tokens": 200, "completion_tokens": 8000, "total_tokens": 8200},
+                },
+            )
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientTruncationError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1  # re-issue would re-truncate and burn budget
+        assert sleep.calls == []
+        # Real tokens preserved through the (unretried) error.
+        assert excinfo.value.consumed_tokens == 8200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [429, 500, 503])
+    async def test_transport_error_is_not_retried_within_request(self, status: int):
+        """Port contract: transport failures are not retried within the request."""
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTransportError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return httpx.Response(status, json={"error": "boom"})
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientTransportError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1
+        assert sleep.calls == []
+
+    @pytest.mark.asyncio
+    async def test_network_exception_is_not_retried_within_request(self):
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientTransportError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            raise httpx.ConnectError("refused", request=req)
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientTransportError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1
+        assert sleep.calls == []
+
+
+class TestRetryDefaultsAndBackCompat:
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt_never_sleeps(self):
+        """The happy path is unchanged: one call, no backoff."""
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return _ok_response("first-try")
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(handler, sleep=sleep)
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert out.content == "first-try"
+        assert len(calls) == 1
+        assert sleep.calls == []
+
+    def test_default_max_attempts_is_bounded_and_small(self):
+        """A sensible bounded default exists (MIP): >1 to retry, but small."""
+        client = _build_client_with_transport(lambda req: _ok_response("x"))
+        assert 2 <= client._max_attempts <= 3

--- a/tests/unit/adapters/test_openai_compat_ai_client_retry.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client_retry.py
@@ -304,6 +304,148 @@ class TestNoRetryOnPermanentOrDistinctErrors:
         assert len(calls) == 1
         assert sleep.calls == []
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 404, 422])
+    async def test_deterministic_non_200_status_is_not_retried(self, status: int):
+        """Critical-engineer (#1186): a 4xx 'protocol surprise' is NOT the flaky
+        malformed-body signature — it fails identically on every attempt, so the
+        retry loop must NOT re-issue it. It raises the plain AIClientProtocolError
+        base (not the retryable _MalformedBodyError subclass) and propagates on
+        the first response.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return httpx.Response(status, json={"error": "client error"})
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        with pytest.raises(AIClientProtocolError) as excinfo:
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        # Exactly one POST — no pointless re-issue of a deterministic failure.
+        assert len(calls) == 1
+        assert sleep.calls == []
+        # Surfaces the unexpected-status message, not the generic exhaustion text.
+        assert "unexpected HTTP status" in str(excinfo.value)
+        assert "after" not in str(excinfo.value)  # not the exhaustion message
+
+
+class TestAllMalformed200ShapesAreRetried:
+    """Every malformed-200 BODY shape is the transient signature → retried.
+
+    Pins the retry-eligible set precisely: non-JSON body, missing/empty
+    ``choices``, non-object ``choices[0]``, non-object ``message``, and non-string
+    ``content``. Each malformed-then-valid sequence must SUCCEED on the retry.
+    """
+
+    @staticmethod
+    def _malformed_then_ok(first: httpx.Response):
+        responses = [first, _ok_response("recovered")]
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return responses[len(calls) - 1]
+
+        return handler, calls
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "first_response",
+        [
+            httpx.Response(200, text="not-json-at-all"),
+            httpx.Response(200, json={"no_choices": "here"}),
+            httpx.Response(200, json={"choices": []}),
+            httpx.Response(200, json={"choices": ["not-an-object"]}),
+            httpx.Response(200, json={"choices": [{"message": "not-an-object"}]}),
+            httpx.Response(200, json={"choices": [{"message": None}]}),
+            # CRS (#1186): a truthy NON-LIST ``choices`` (dict/scalar) must NOT
+            # leak a raw KeyError/TypeError past the port taxonomy — it is a
+            # malformed body and must surface as the retryable _MalformedBodyError.
+            httpx.Response(200, json={"choices": {"message": {"content": "x"}}}),
+            httpx.Response(200, json={"choices": 1}),
+            httpx.Response(200, json={"choices": True}),
+            httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": None}, "finish_reason": "stop"}]},
+            ),
+        ],
+        ids=[
+            "non_json_body",
+            "missing_choices",
+            "empty_choices",
+            "choices0_not_object",
+            "message_not_object",
+            "message_null",
+            "choices_dict_not_list",
+            "choices_scalar_int",
+            "choices_scalar_bool",
+            "content_not_string",
+        ],
+    )
+    async def test_malformed_200_shape_is_retried_then_succeeds(
+        self, first_response: httpx.Response
+    ):
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        handler, calls = self._malformed_then_ok(first_response)
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=3, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert out.content == "recovered"
+        assert len(calls) == 2  # retried exactly once, then succeeded
+        assert len(sleep.calls) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "choices_value",
+        [{"message": {"content": "x"}}, 1, True, "a-string"],
+        ids=["dict", "int", "bool", "str"],
+    )
+    async def test_truthy_non_list_choices_surfaces_as_port_protocol_error(
+        self, choices_value: object
+    ):
+        """CRS (#1186): a truthy non-list ``choices`` must surface through the port
+        exception taxonomy (AIClientProtocolError), never as a raw KeyError /
+        TypeError that bypasses every caller's ``except AIClientError`` fallback.
+        With all attempts malformed it must raise the clearer exhaustion error.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return httpx.Response(200, json={"choices": choices_value})
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(
+            handler, max_attempts=2, retry_backoff_seconds=0.0, sleep=sleep
+        )
+        # Must be a port-taxonomy error, NOT a raw KeyError/TypeError.
+        with pytest.raises(AIClientProtocolError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+        # And it is the retryable signature: both attempts were issued.
+        assert len(calls) == 2
+
 
 class TestRetryDefaultsAndBackCompat:
     @pytest.mark.asyncio
@@ -326,7 +468,106 @@ class TestRetryDefaultsAndBackCompat:
         assert len(calls) == 1
         assert sleep.calls == []
 
-    def test_default_max_attempts_is_bounded_and_small(self):
-        """A sensible bounded default exists (MIP): >1 to retry, but small."""
-        client = _build_client_with_transport(lambda req: _ok_response("x"))
-        assert 2 <= client._max_attempts <= 3
+    @pytest.mark.asyncio
+    async def test_default_budget_tolerates_one_transient_malformed(self):
+        """Behavioural proof the DEFAULT budget retries (MIP: >1 attempt).
+
+        With no retry knobs supplied, a single malformed-then-valid sequence must
+        still recover — pinning that the shipped default is >1 attempt without
+        reaching into the private ``_max_attempts`` attribute.
+        """
+        from hestai_context_mcp.ports.ai_client import CompletionRequest
+
+        responses = [_malformed_response(), _ok_response("default-recovered")]
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return responses[len(calls) - 1]
+
+        # Inject only the sleep spy so no real backoff elapses; attempts/backoff
+        # use the shipped defaults.
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(handler, sleep=sleep)
+        async with client as c:
+            out = await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert out.content == "default-recovered"
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_one_disables_retry(self):
+        """``max_attempts=1`` makes exactly one POST and never retries/sleeps."""
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return _malformed_response()
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(handler, max_attempts=1, sleep=sleep)
+        with pytest.raises(AIClientProtocolError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1
+        assert sleep.calls == []
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_zero_is_clamped_to_one_call(self):
+        """A misconfigured ``max_attempts=0`` clamps to 1 — the request still fires.
+
+        The clamp guarantees a bad config can never silently disable the call.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return _malformed_response()
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(handler, max_attempts=0, sleep=sleep)
+        with pytest.raises(AIClientProtocolError):
+            async with client as c:
+                await c.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert len(calls) == 1
+        assert sleep.calls == []
+
+
+class TestMisuseGuardIsNotRetried:
+    @pytest.mark.asyncio
+    async def test_complete_text_outside_async_with_raises_immediately(self):
+        """Calling ``complete_text`` without entering ``async with`` is a misuse
+        (programming error, not a transient flake) and must raise immediately —
+        it must NOT be swallowed and re-issued by the retry loop.
+        """
+        from hestai_context_mcp.ports.ai_client import (
+            AIClientProtocolError,
+            CompletionRequest,
+        )
+
+        calls: list[httpx.Request] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls.append(req)
+            return _ok_response("never-reached")
+
+        sleep = _SleepSpy()
+        client = _build_client_with_transport(handler, sleep=sleep)
+        # NOTE: deliberately NOT using ``async with`` — the client is never opened.
+        with pytest.raises(AIClientProtocolError, match="async-with"):
+            await client.complete_text(CompletionRequest(system_prompt="s", user_prompt="u"))
+
+        assert calls == []  # no POST ever issued
+        assert sleep.calls == []  # not retried

--- a/tests/unit/adapters/test_openai_compat_ai_client_retry.py
+++ b/tests/unit/adapters/test_openai_compat_ai_client_retry.py
@@ -233,7 +233,11 @@ class TestNoRetryOnPermanentOrDistinctErrors:
                     "choices": [
                         {"message": {"content": None}, "index": 0, "finish_reason": "length"},
                     ],
-                    "usage": {"prompt_tokens": 200, "completion_tokens": 8000, "total_tokens": 8200},
+                    "usage": {
+                        "prompt_tokens": 200,
+                        "completion_tokens": 8000,
+                        "total_tokens": 8200,
+                    },
                 },
             )
 


### PR DESCRIPTION
## Summary
- Added bounded retry logic to `openai_compat_ai_client` adapter to gracefully handle transient malformed responses from providers
- Prevents infinite retry loops while allowing recovery from temporary provider issues
- Hardened retry scope based on T3 review feedback

## Changes
- **openai_compat_ai_client.py**: Implemented bounded retry mechanism with configurable limits for malformed provider responses, ensuring transient failures don't cascade
- **test_openai_compat_ai_client_retry.py**: Added comprehensive test suite (573 lines) covering retry behavior for various malformed response scenarios, validating both success recovery and failure boundaries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded retry to `openai_compat_ai_client` that recovers from transient 200‑OK but malformed provider bodies, reducing flakiness without changing callers. Addresses #1186 with a narrow scope and clearer errors on exhaustion.

- **Bug Fixes**
  - Retries only `_MalformedBodyError` (malformed 200‑OK body) with a default of 3 attempts and small backoff; `max_attempts` and `retry_backoff_seconds` are configurable, and `sleep` is injectable for tests.
  - No retry for `AIClientAuthError`, `AIClientTransportError`, `AIClientTruncationError`, or non‑200 protocol surprises (e.g., 400/404/422); these propagate immediately.
  - Hardened response parsing (validate `choices` as a non‑empty list, etc.) and raise `_MalformedBodyError` for all malformed shapes; on exhaustion, raise an actionable `AIClientProtocolError` with the original cause chained.

<sup>Written for commit 9b9a0963827561f8dc88eee7ca2b43f8b05cb956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

