### PR TITLE
fix(governance): enforce remaining ADR-004 §4.1 invariants in Gate A (#88)

### DIFF
--- a/src/hestai_context_mcp/tools/governance/agr_read.py
+++ b/src/hestai_context_mcp/tools/governance/agr_read.py
@@ -26,7 +26,11 @@ from hestai_context_mcp.core.agent_readable_governance_parser import (
     parse_decision_record,
 )
 
-# §1.3 TOKEN format — reuse the authoritative Gate-A regex (do not rebuild).
+# §1.3 TOKEN format + the §1.2 required-field contract — reuse the authoritative
+# Gate-A definitions (do not rebuild). ``REQUIRED_META_FIELDS`` is the SINGLE
+# SOURCE OF TRUTH shared with the write-side validator so the read-side
+# parse-completeness check (``record_is_parseable``) and Gate A's required-field
+# presence check (§4.1 #2) can never drift (issue #88 write/read parity).
 from hestai_context_mcp.tools.governance.type_checker import (
     _DECISION_RECORD_TYPE,
     _extract_sentinel,
@@ -35,17 +39,16 @@ from hestai_context_mcp.tools.governance.type_checker import (
 from hestai_context_mcp.tools.governance.type_checker import (
     _TOKEN_FORMAT_RE as TOKEN_FORMAT_RE,
 )
-
-# The §1.2 required fields whose presence proves the OCTAVE envelope parsed.
-_REQUIRED_FIELDS = (
-    "token",
-    "type",
-    "status",
-    "tier",
-    "decision",
-    "because",
-    "authored_at",
+from hestai_context_mcp.tools.governance.type_checker import (
+    REQUIRED_META_FIELDS as _REQUIRED_META_FIELDS,
 )
+
+# The §1.2 required fields whose presence proves the OCTAVE envelope parsed,
+# expressed as the lowercase DecisionRecord keys. Derived from the shared
+# write-side tuple (excluding VERSION, which the parser surfaces but
+# record_is_parseable has never gated on — see DecisionRecord/_CORE_FIELDS) so
+# the two sides stay in lockstep by construction.
+_REQUIRED_FIELDS = tuple(name.lower() for name in _REQUIRED_META_FIELDS if name != "VERSION")
 
 # Read-side TYPE-membership regex: LINE-ANCHORED and EXACT (CRS P2 guard).
 # The KEY must be exactly ``TYPE`` at line start — a leading whitespace-only

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -18,6 +18,7 @@ additive and runs alongside it at the submit_governance seam.
 
 import re
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 from hestai_context_mcp.tools.governance.lexer import lookup_token_deterministic
@@ -56,13 +57,17 @@ _TOKEN_RE = re.compile(r'(?m)^\s*TOKEN::(?:"([^"]+)"|([^"\s]+))\s*$')
 # (cubic P2 — the quoted branch was previously unanchored).
 _ID_QUOTED_RE = re.compile(r'(?m)^  ID::(?:"([^"]+)"|([^"\s]+))\s*$')
 
-# SUPERSEDED_BY field: quoted string. LINE-ANCHORED (issue #85): ``^\s*`` admits
-# OCTAVE indentation but forbids a ``*SUPERSEDED_BY::``-suffixed key (e.g.
-# ``PARENT_SUPERSEDED_BY::``) from substring-leaking a supersedure target via
-# ``.search()`` — this is the supersedure-corruption vector the issue exists to
-# kill. ``\s*$`` rejects trailing garbage; the quoted-only value behavior is
-# unchanged (only anchors added).
-_SUPERSEDED_BY_RE = re.compile(r'(?m)^\s*SUPERSEDED_BY::"([^"]+)"\s*$')
+# SUPERSEDED_BY field: QUOTE-OPTIONAL (T3 CE/CIV rework — ADR-004 §13.1 ratified
+# bare TOKEN edge references as canonical, so a bare ``SUPERSEDED_BY::TOKEN`` MUST
+# be recognised exactly as the legacy quoted form; this mirrors
+# ``lineage._SUPERSEDED_BY_RE`` so the §4.1 #9 iff check and the lineage guard
+# agree). LINE-ANCHORED (issue #85): ``^\s*`` admits OCTAVE indentation but
+# forbids a ``*SUPERSEDED_BY::``-suffixed key (e.g. ``PARENT_SUPERSEDED_BY::``)
+# from substring-leaking a supersedure target via ``.search()`` — the
+# supersedure-corruption vector the issue exists to kill. The end-anchor
+# (``\s*$``) lives OUTSIDE the alternation so BOTH branches reject trailing
+# garbage. Group 1 = quoted value, group 2 = bare value.
+_SUPERSEDED_BY_RE = re.compile(r'(?m)^\s*SUPERSEDED_BY::(?:"([^"]+)"|([^"\s]+))\s*$')
 
 # ISSUE_REF field: greedy line capture (horizontal whitespace anchor only —
 # no ReDoS risk, no extractor/presence-detector asymmetry).
@@ -117,12 +122,6 @@ _META_FIELD_LINE_RE = re.compile(r"(?m)^\s*([A-Z][A-Z0-9_]*)::(.*?)\s*$")
 # §1.5 VERSION shape: MAJOR.MINOR (two numeric segments, no patch level).
 # Rejects 3-segment "1.0.0" and non-numeric "v1" (§4.1 #1 envelope clause).
 _VERSION_SHAPE_RE = re.compile(r"^[0-9]+\.[0-9]+$")
-
-# AUTHORED_AT date prefix: capture the leading YYYY-MM-DD (UTC) for the §1.3
-# TOKEN-date consistency check (#3-residual). Anchored at string start; the
-# remaining time/offset portion is not constrained here (Gate B / octave-mcp
-# owns full timestamp grammar — North Star §4 boundary).
-_AUTHORED_AT_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
 
 # TOKEN trailing date suffix (the §1.3 YYYYMMDD), captured for #3 comparison.
 _TOKEN_DATE_SUFFIX_RE = re.compile(r"-([0-9]{8})$")
@@ -223,10 +222,13 @@ def _extract_id(content: str) -> str | None:
 
 
 def _extract_superseded_by(content: str) -> str | None:
-    """Extract the SUPERSEDED_BY field if present."""
+    """Extract the SUPERSEDED_BY field if present, quote-optional.
+
+    Group 1 holds the quoted value, group 2 the bare value; exactly one is set.
+    """
     m = _SUPERSEDED_BY_RE.search(content)
     if m:
-        return m.group(1)
+        return m.group(1) if m.group(1) is not None else m.group(2)
     return None
 
 
@@ -384,19 +386,27 @@ def _check_agr_invariants(
             )
 
     # --- #3-residual: TOKEN date suffix == UTC date of AUTHORED_AT (§1.3) ---
+    # The comparison is against the UTC DATE PORTION (§1.3): an offset timestamp
+    # is normalised to UTC before the date is taken (T3 CIV rework — a lexical
+    # leading-date capture mis-handles offsets and silently passes a non-
+    # timestamp AUTHORED_AT).
     authored_at = _strip_quotes(meta["AUTHORED_AT"]) if "AUTHORED_AT" in meta else None
     token_date_m = _TOKEN_DATE_SUFFIX_RE.search(token)
     if authored_at is not None and token_date_m is not None:
-        date_m = _AUTHORED_AT_DATE_RE.match(authored_at)
-        if date_m is not None:
-            authored_yyyymmdd = f"{date_m.group(1)}{date_m.group(2)}{date_m.group(3)}"
-            token_yyyymmdd = token_date_m.group(1)
-            if authored_yyyymmdd != token_yyyymmdd:
-                errors.append(
-                    f"TOKEN date suffix '{token_yyyymmdd}' does not equal the UTC "
-                    f"date of AUTHORED_AT ('{authored_yyyymmdd}' from "
-                    f"'{authored_at}') (ADR-RFC-ARCH-004 §1.3 / §4.1 #3)."
-                )
+        token_yyyymmdd = token_date_m.group(1)
+        authored_yyyymmdd = _authored_at_utc_date(authored_at)
+        if authored_yyyymmdd is None:
+            errors.append(
+                f"AUTHORED_AT '{authored_at}' is not a parseable ISO-8601 "
+                "timestamp; the §1.3 TOKEN-date consistency check (§4.1 #3) "
+                "cannot be evaluated."
+            )
+        elif authored_yyyymmdd != token_yyyymmdd:
+            errors.append(
+                f"TOKEN date suffix '{token_yyyymmdd}' does not equal the UTC "
+                f"date of AUTHORED_AT ('{authored_yyyymmdd}' from "
+                f"'{authored_at}') (ADR-RFC-ARCH-004 §1.3 / §4.1 #3)."
+            )
 
     # --- #9: SUPERSEDED_BY present IFF STATUS == SUPERSEDED ---
     has_superseded_by = _extract_superseded_by(content) is not None
@@ -432,6 +442,34 @@ def _check_agr_invariants(
             "(not PROPOSED); ratification provenance is recommended "
             "(ADR-RFC-ARCH-004 §4.1 #12, severity WARNING)."
         )
+
+
+def _authored_at_utc_date(value: str) -> str | None:
+    """Return the UTC date of an ISO-8601 ``AUTHORED_AT`` as ``YYYYMMDD``.
+
+    Per §1.3 the TOKEN suffix equals the **UTC date portion** of AUTHORED_AT, so
+    an offset timestamp (e.g. ``2026-06-18T23:30:00-02:00``) is normalised to UTC
+    (date ``20260619``) BEFORE the date is taken. A naive timestamp (no offset)
+    is treated as already-UTC. Returns ``None`` when ``value`` is not a parseable
+    ISO-8601 timestamp so the caller can flag it rather than silently pass.
+
+    Regex-only boundary preserved: this uses ``datetime`` parsing of a scalar
+    timestamp value (stdlib, deterministic), NOT OCTAVE AST parsing — North Star
+    §4 governs OCTAVE structure, which this does not touch.
+    """
+    text = value.strip()
+    # ``datetime.fromisoformat`` accepts a trailing ``Z`` only from Python 3.11+;
+    # normalise it to ``+00:00`` for portability/clarity.
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    # Naive timestamp: spec treats AUTHORED_AT as UTC, so the date is taken
+    # as-is. Offset-aware timestamp: normalise to UTC before taking the date.
+    utc = parsed if parsed.tzinfo is None else parsed.astimezone(UTC)
+    return f"{utc.year:04d}{utc.month:02d}{utc.day:02d}"
 
 
 def _human_adr_ref_resolves(working_dir: Path, ref: str) -> bool:

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -80,6 +80,61 @@ _ISSUE_REF_SHAPE_RE = re.compile(
 # ^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$
 _TOKEN_FORMAT_RE = re.compile(r"^[A-Z][A-Z0-9_-]{1,126}[A-Z0-9_]-[0-9]{8}$")
 
+# --- ADR-RFC-ARCH-004 §1.2 / §4.1 shared write/read contract constants --------
+# These are the SINGLE SOURCE OF TRUTH for the AGR required-field set and the
+# STATUS/TIER enums. The read side (``agr_read``) derives its parse-completeness
+# tuple from ``REQUIRED_META_FIELDS`` (lowercased) so the write-side Gate A and
+# the read-side parser can never disagree on what a parseable record requires
+# (issue #88 write/read parity; MIP one-source-of-truth).
+
+# §1.2 required META fields (uppercase OCTAVE keys), every record / every state.
+REQUIRED_META_FIELDS = (
+    "TYPE",
+    "VERSION",
+    "TOKEN",
+    "STATUS",
+    "TIER",
+    "DECISION",
+    "BECAUSE",
+    "AUTHORED_AT",
+)
+
+# §1.4 STATUS enum and §1.2 TIER enum (case-sensitive).
+STATUS_VALUES = frozenset({"PROPOSED", "RATIFIED", "SUPERSEDED", "VOID"})
+TIER_VALUES = frozenset({"STRATEGIC", "TACTICAL", "OPERATIONAL"})
+
+# §1.2 reserved names — MUST NOT appear in any v1.x record (§4.1 #7).
+RESERVED_FIELD_NAMES = frozenset({"DEPENDS_ON", "CONFLICTS_WITH", "ARCHIVED_AT"})
+
+# A single META ``KEY::value`` assignment at line start (whitespace-tolerant —
+# OCTAVE bodies are indented). Mirrors the read-side parser's ``_FIELD_LINE_RE``
+# (core.agent_readable_governance_parser) EXACTLY so the write-side presence /
+# enum / reserved-name checks see the same field set the read parser surfaces
+# (issue #88 parity). KEY is an uppercase OCTAVE identifier; the value is the
+# rest of the line.  Regex-only — no structural OCTAVE parsing.
+_META_FIELD_LINE_RE = re.compile(r"(?m)^\s*([A-Z][A-Z0-9_]*)::(.*?)\s*$")
+
+# §1.5 VERSION shape: MAJOR.MINOR (two numeric segments, no patch level).
+# Rejects 3-segment "1.0.0" and non-numeric "v1" (§4.1 #1 envelope clause).
+_VERSION_SHAPE_RE = re.compile(r"^[0-9]+\.[0-9]+$")
+
+# AUTHORED_AT date prefix: capture the leading YYYY-MM-DD (UTC) for the §1.3
+# TOKEN-date consistency check (#3-residual). Anchored at string start; the
+# remaining time/offset portion is not constrained here (Gate B / octave-mcp
+# owns full timestamp grammar — North Star §4 boundary).
+_AUTHORED_AT_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+
+# TOKEN trailing date suffix (the §1.3 YYYYMMDD), captured for #3 comparison.
+_TOKEN_DATE_SUFFIX_RE = re.compile(r"-([0-9]{8})$")
+
+# RATIFIED_BY presence (§4.1 #12 warning). Quote-optional, line-anchored —
+# same ``*FIELD::``-suffix-safe shape as the other anchored field regexes.
+_RATIFIED_BY_RE = re.compile(r'(?m)^\s*RATIFIED_BY::(?:"([^"]*)"|(\S.*?))\s*$')
+
+# HUMAN_ADR_REF value (§4.1 #11). Quote-optional, line-anchored; the captured
+# path is resolved under the repository root separately.
+_HUMAN_ADR_REF_RE = re.compile(r'(?m)^\s*HUMAN_ADR_REF::(?:"([^"]*)"|(\S.*?))\s*$')
+
 # Facet card ID format per ADR-RFC-ARCH-005 §1.3
 # ^[A-Z][A-Z0-9_]{2,127}$
 _FACET_ID_FORMAT_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
@@ -105,8 +160,13 @@ class ValidationResult:
     """Result of Gate A dumb type checking.
 
     Fields:
-        valid: True if all checks passed, False otherwise.
-        errors: List of human-readable error strings (empty when valid=True).
+        valid: True if all ERROR-severity checks passed, False otherwise.
+            (Per ADR-RFC-ARCH-004 §4.2, WARNING-severity findings do NOT flip
+            ``valid`` to False — see ``warnings``.)
+        errors: List of human-readable ERROR strings (empty when valid=True).
+        warnings: List of human-readable WARNING strings (§4.2 advisory; may be
+            non-empty even when valid=True — e.g. §4.1 #12 ratification
+            provenance). Additive field; defaults to empty.
         token: Extracted TOKEN or ID value (may be None if extraction failed).
         card_type: Extracted TYPE value (may be None if extraction failed).
         target_path: Computed target path for placement (None on error).
@@ -114,6 +174,7 @@ class ValidationResult:
 
     valid: bool
     errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     token: str | None = None
     card_type: str | None = None
     target_path: Path | None = None
@@ -197,6 +258,27 @@ def _extract_repo_id(content: str) -> str | None:
     return None
 
 
+def _extract_meta_fields(content: str) -> dict[str, str]:
+    """Map every line-anchored ``KEY::value`` META assignment to its raw value.
+
+    First occurrence wins (the META block precedes any prose echoes), matching
+    the read-side parser's ``setdefault`` behaviour exactly so presence/enum
+    checks agree with ``record_is_parseable`` (issue #88 parity). Quotes are NOT
+    stripped here — callers that need the bare value strip them locally.
+    """
+    fields: dict[str, str] = {}
+    for key, value in _META_FIELD_LINE_RE.findall(content):
+        fields.setdefault(key, value)
+    return fields
+
+
+def _strip_quotes(value: str) -> str:
+    """Strip one surrounding pair of double quotes (§1.1 quote-optionality)."""
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
 def _compute_target_path(
     working_dir: Path,
     card_type: str,
@@ -225,6 +307,152 @@ def _compute_target_path(
     return working_dir / ".hestai" / "context" / "concepts" / repo_id / f"{token}.oct.md"
 
 
+def _check_agr_invariants(
+    working_dir: Path,
+    content: str,
+    token: str,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    """Enforce the ADR-RFC-ARCH-004 §4.1 invariants for a DECISION_RECORD (#88).
+
+    Collect-more-errors style (mirrors the established #10 ISSUE_REF / #8
+    SUPERSEDED_BY precedent): every finding is appended to ``errors`` (or
+    ``warnings`` for §4.1 #12) so a single round-trip surfaces ALL problems with
+    the offending field NAMED. Regex-only (North Star §4 / PROD I3); never
+    raises (PROD I4). ``token`` is the already-extracted, §1.3-format-valid
+    TOKEN.
+
+    Invariants enforced here (the residual set unenforced before #88):
+      #1-residual  VERSION two-segment shape (§1.5)
+      #2           Required §1.2 fields present
+      #3-residual  TOKEN YYYYMMDD suffix == UTC date of AUTHORED_AT
+      #5           STATUS enum
+      #6           TIER enum
+      #7           Reserved names absent
+      #9           SUPERSEDED_BY present IFF STATUS == SUPERSEDED
+      #11          HUMAN_ADR_REF resolves under the repository
+      #12          Ratification provenance (WARNING per §4.2)
+    """
+    meta = _extract_meta_fields(content)
+
+    # --- #2: Required fields present (the core silent-pass class) ---
+    # TYPE and TOKEN are proven present by the time we get here; check the rest
+    # so a record the read parser would mark unparseable is rejected on write.
+    for required in REQUIRED_META_FIELDS:
+        if required not in meta:
+            errors.append(
+                f"Required field '{required}' is missing from the META block "
+                "(ADR-RFC-ARCH-004 §1.2 / §4.1 #2)."
+            )
+
+    # --- #1-residual: VERSION two-segment shape (§1.5) ---
+    if "VERSION" in meta:
+        version = _strip_quotes(meta["VERSION"])
+        if not _VERSION_SHAPE_RE.match(version):
+            errors.append(
+                f"VERSION '{version}' is not a two-segment MAJOR.MINOR string "
+                "(ADR-RFC-ARCH-004 §1.5 / §4.1 #1). "
+                "Patch levels (e.g. '1.0.0') and non-numeric values are rejected."
+            )
+
+    # --- #5: STATUS enum ---
+    status = _strip_quotes(meta["STATUS"]) if "STATUS" in meta else None
+    if status is not None and status not in STATUS_VALUES:
+        errors.append(
+            f"STATUS '{status}' is not a valid value. "
+            f"Must be one of {', '.join(sorted(STATUS_VALUES))} "
+            "(ADR-RFC-ARCH-004 §1.4 / §4.1 #5)."
+        )
+
+    # --- #6: TIER enum ---
+    if "TIER" in meta:
+        tier = _strip_quotes(meta["TIER"])
+        if tier not in TIER_VALUES:
+            errors.append(
+                f"TIER '{tier}' is not a valid value. "
+                f"Must be one of {', '.join(sorted(TIER_VALUES))} "
+                "(ADR-RFC-ARCH-004 §1.2 / §4.1 #6)."
+            )
+
+    # --- #7: Reserved names MUST NOT appear (§1.2) ---
+    for reserved in sorted(RESERVED_FIELD_NAMES):
+        if reserved in meta:
+            errors.append(
+                f"Reserved field '{reserved}' MUST NOT appear in a v1.x record "
+                "(ADR-RFC-ARCH-004 §1.2 reserved-names / §4.1 #7)."
+            )
+
+    # --- #3-residual: TOKEN date suffix == UTC date of AUTHORED_AT (§1.3) ---
+    authored_at = _strip_quotes(meta["AUTHORED_AT"]) if "AUTHORED_AT" in meta else None
+    token_date_m = _TOKEN_DATE_SUFFIX_RE.search(token)
+    if authored_at is not None and token_date_m is not None:
+        date_m = _AUTHORED_AT_DATE_RE.match(authored_at)
+        if date_m is not None:
+            authored_yyyymmdd = f"{date_m.group(1)}{date_m.group(2)}{date_m.group(3)}"
+            token_yyyymmdd = token_date_m.group(1)
+            if authored_yyyymmdd != token_yyyymmdd:
+                errors.append(
+                    f"TOKEN date suffix '{token_yyyymmdd}' does not equal the UTC "
+                    f"date of AUTHORED_AT ('{authored_yyyymmdd}' from "
+                    f"'{authored_at}') (ADR-RFC-ARCH-004 §1.3 / §4.1 #3)."
+                )
+
+    # --- #9: SUPERSEDED_BY present IFF STATUS == SUPERSEDED ---
+    has_superseded_by = _extract_superseded_by(content) is not None
+    if status == "SUPERSEDED" and not has_superseded_by:
+        errors.append(
+            "STATUS is SUPERSEDED but SUPERSEDED_BY is absent; a superseded "
+            "record MUST name its successor "
+            "(ADR-RFC-ARCH-004 §1.2 / §4.1 #9)."
+        )
+    elif has_superseded_by and status is not None and status != "SUPERSEDED":
+        errors.append(
+            f"SUPERSEDED_BY is present but STATUS is '{status}', not SUPERSEDED; "
+            "SUPERSEDED_BY is required iff STATUS == SUPERSEDED "
+            "(ADR-RFC-ARCH-004 §1.2 / §4.1 #9)."
+        )
+
+    # --- #11: HUMAN_ADR_REF resolves under the repository ---
+    human_adr_m = _HUMAN_ADR_REF_RE.search(content)
+    if human_adr_m is not None:
+        ref = human_adr_m.group(1) if human_adr_m.group(1) is not None else human_adr_m.group(2)
+        ref = (ref or "").strip()
+        if not _human_adr_ref_resolves(working_dir, ref):
+            errors.append(
+                f"HUMAN_ADR_REF '{ref}' does not resolve to a file under the "
+                "repository (ADR-RFC-ARCH-004 §1.2 / §4.1 #11)."
+            )
+
+    # --- #12: Ratification provenance (WARNING per §4.2, NOT error) ---
+    has_ratified_by = _RATIFIED_BY_RE.search(content) is not None
+    if status is not None and status != "PROPOSED" and not has_ratified_by:
+        warnings.append(
+            f"RATIFIED_BY is absent on a record whose STATUS is '{status}' "
+            "(not PROPOSED); ratification provenance is recommended "
+            "(ADR-RFC-ARCH-004 §4.1 #12, severity WARNING)."
+        )
+
+
+def _human_adr_ref_resolves(working_dir: Path, ref: str) -> bool:
+    """True iff ``ref`` resolves to an existing file UNDER ``working_dir`` (#11).
+
+    Path-traversal safe: the resolved candidate MUST stay within the repository
+    root, so a ``../../../etc/passwd`` style ref is rejected even if such a file
+    exists on the host. Pure read; never raises.
+    """
+    if not ref:
+        return False
+    try:
+        root = working_dir.resolve()
+        candidate = (working_dir / ref).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return False
+    if root != candidate and root not in candidate.parents:
+        return False
+    return candidate.is_file()
+
+
 def validate_octave_content(working_dir: Path, content: str) -> ValidationResult:
     """Validate OCTAVE governance content using regex-only checks.
 
@@ -249,15 +477,21 @@ def validate_octave_content(working_dir: Path, content: str) -> ValidationResult
         ValidationResult with valid=True on success or errors populated on failure.
     """
     errors: list[str] = []
+    warnings: list[str] = []
 
     try:
-        return _validate_impl(working_dir, content, errors)
+        return _validate_impl(working_dir, content, errors, warnings)
     except Exception as exc:  # noqa: BLE001
         errors.append(f"Unexpected validation error: {exc}")
-        return ValidationResult(valid=False, errors=errors)
+        return ValidationResult(valid=False, errors=errors, warnings=warnings)
 
 
-def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> ValidationResult:
+def _validate_impl(
+    working_dir: Path,
+    content: str,
+    errors: list[str],
+    warnings: list[str],
+) -> ValidationResult:
     """Internal validation implementation."""
     # --- Check 1: OCTAVE sentinel at document start (Bug 7) ---
     sentinel = _extract_sentinel(content)
@@ -306,6 +540,14 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
                 "(ADR-RFC-ARCH-004 §1.3)"
             )
             return ValidationResult(valid=False, errors=errors, card_type=card_type, token=token)
+
+        # --- Check 4c: ADR-RFC-ARCH-004 §4.1 invariants (#88) ---
+        # Required-field presence (#2), VERSION shape (#1-residual), TOKEN-date
+        # consistency (#3-residual), STATUS/TIER enums (#5/#6), reserved names
+        # (#7), SUPERSEDED_BY iff (#9), HUMAN_ADR_REF resolution (#11), and the
+        # ratification-provenance WARNING (#12). Collect-more-errors; the
+        # offending field is named in each message for operator UX.
+        _check_agr_invariants(working_dir, content, token, errors, warnings)
 
     elif card_type in _FACET_CARD_TYPES:
         token = _extract_id(content)
@@ -380,7 +622,13 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
         )
 
     if errors:
-        return ValidationResult(valid=False, errors=errors, card_type=card_type, token=token)
+        return ValidationResult(
+            valid=False,
+            errors=errors,
+            warnings=warnings,
+            card_type=card_type,
+            token=token,
+        )
 
     # --- Check 7: Compute target path + path traversal guard (Bug 4 via caller) ---
     target_path: Path | None = None
@@ -388,9 +636,12 @@ def _validate_impl(working_dir: Path, content: str, errors: list[str]) -> Valida
         effective_repo_id = repo_id or ""
         target_path = _compute_target_path(working_dir, card_type, token, effective_repo_id)
 
+    # warnings (§4.2) may be non-empty even on a valid record — e.g. §4.1 #12
+    # ratification provenance. They are advisory and do NOT flip ``valid``.
     return ValidationResult(
         valid=True,
         errors=[],
+        warnings=warnings,
         token=token,
         card_type=card_type,
         target_path=target_path,

--- a/src/hestai_context_mcp/tools/governance/type_checker.py
+++ b/src/hestai_context_mcp/tools/governance/type_checker.py
@@ -126,6 +126,15 @@ _VERSION_SHAPE_RE = re.compile(r"^[0-9]+\.[0-9]+$")
 # TOKEN trailing date suffix (the §1.3 YYYYMMDD), captured for #3 comparison.
 _TOKEN_DATE_SUFFIX_RE = re.compile(r"-([0-9]{8})$")
 
+# AUTHORED_AT date-only guard (cubic P2): §1.2 declares AUTHORED_AT an ISO-8601
+# *timestamp* (full form, e.g. ``2026-06-11T00:00:00Z``), but
+# ``datetime.fromisoformat`` also accepts a bare date (``2026-06-19`` -> midnight),
+# which would silently pass the §4.1 #3 check whenever the TOKEN suffix matched.
+# A value carries a time component iff a ``T`` or space separator is followed by
+# at least an hour field; this regex matches the date-ONLY form (no such
+# separator+time) so the #3 check can reject it before normalisation.
+_AUTHORED_AT_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 # RATIFIED_BY presence (§4.1 #12 warning). Quote-optional, line-anchored —
 # same ``*FIELD::``-suffix-safe shape as the other anchored field regexes.
 _RATIFIED_BY_RE = re.compile(r'(?m)^\s*RATIFIED_BY::(?:"([^"]*)"|(\S.*?))\s*$')
@@ -394,19 +403,29 @@ def _check_agr_invariants(
     token_date_m = _TOKEN_DATE_SUFFIX_RE.search(token)
     if authored_at is not None and token_date_m is not None:
         token_yyyymmdd = token_date_m.group(1)
-        authored_yyyymmdd = _authored_at_utc_date(authored_at)
-        if authored_yyyymmdd is None:
+        if _AUTHORED_AT_DATE_ONLY_RE.match(authored_at.strip()):
+            # §1.2: AUTHORED_AT is an ISO-8601 *timestamp*, not a bare date.
+            # ``datetime.fromisoformat`` would accept the date-only form (midnight)
+            # and silently pass #3 — reject it explicitly (cubic P2).
             errors.append(
-                f"AUTHORED_AT '{authored_at}' is not a parseable ISO-8601 "
-                "timestamp; the §1.3 TOKEN-date consistency check (§4.1 #3) "
-                "cannot be evaluated."
+                f"AUTHORED_AT '{authored_at}' must be a full ISO-8601 timestamp, "
+                "not a date (e.g. '2026-06-19T00:00:00Z'); the §1.3 TOKEN-date "
+                "consistency check (§4.1 #3) requires a time component."
             )
-        elif authored_yyyymmdd != token_yyyymmdd:
-            errors.append(
-                f"TOKEN date suffix '{token_yyyymmdd}' does not equal the UTC "
-                f"date of AUTHORED_AT ('{authored_yyyymmdd}' from "
-                f"'{authored_at}') (ADR-RFC-ARCH-004 §1.3 / §4.1 #3)."
-            )
+        else:
+            authored_yyyymmdd = _authored_at_utc_date(authored_at)
+            if authored_yyyymmdd is None:
+                errors.append(
+                    f"AUTHORED_AT '{authored_at}' is not a parseable ISO-8601 "
+                    "timestamp; the §1.3 TOKEN-date consistency check (§4.1 #3) "
+                    "cannot be evaluated."
+                )
+            elif authored_yyyymmdd != token_yyyymmdd:
+                errors.append(
+                    f"TOKEN date suffix '{token_yyyymmdd}' does not equal the UTC "
+                    f"date of AUTHORED_AT ('{authored_yyyymmdd}' from "
+                    f"'{authored_at}') (ADR-RFC-ARCH-004 §1.3 / §4.1 #3)."
+                )
 
     # --- #9: SUPERSEDED_BY present IFF STATUS == SUPERSEDED ---
     has_superseded_by = _extract_superseded_by(content) is not None

--- a/tests/unit/core/test_intake_linker_wiring.py
+++ b/tests/unit/core/test_intake_linker_wiring.py
@@ -37,7 +37,13 @@ _VALID_OCTAVE = (
     "===DECISION_RECORD===\n"
     "META:\n"
     "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
     f'  TOKEN::"{RECORD_TOKEN}"\n'
+    "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
+    '  DECISION::"Record a decision for the linker wiring test."\n'
+    '  BECAUSE::"Exercises the Stage-4 run_linker handoff."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
     "===END===\n"
 )
 

--- a/tests/unit/core/test_intake_pipeline.py
+++ b/tests/unit/core/test_intake_pipeline.py
@@ -32,26 +32,40 @@ from hestai_context_mcp.tools.governance.intake_context import IntakeContext
 # stays live on this file (no path-ignore).
 RECORD_TOKEN = "HO-CONTEXT-MCP-NEWREC-20260601"
 
-# A syntactically valid DECISION_RECORD that passes the regex Gate A.
+# A fully-formed DECISION_RECORD that passes the regex Gate A. Carries every
+# §1.2 required field (post-#88 Gate A enforces presence + TOKEN-date
+# consistency: the 20260601 suffix matches AUTHORED_AT's UTC date).
 _VALID_OCTAVE = (
     "===DECISION_RECORD===\n"
     "META:\n"
     "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
     f'  TOKEN::"{RECORD_TOKEN}"\n'
+    "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
+    '  DECISION::"Record a decision for the intake pipeline test."\n'
+    '  BECAUSE::"Exercises the Stage-3 gate end to end."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
     "===END===\n"
 )
 _INVALID_OCTAVE = "this is not octave at all"
 
-# Syntactically VALID (passes Gates A+B) but verbose: a single DECISION value far
-# over the word ceiling. Exercises the density backstop in ``_gate``.
+# Fully-formed and VALID (passes Gates A+B) but verbose: the DECISION value is
+# far over the word ceiling. Exercises the density backstop in ``_gate``. The
+# verbose DECISION lives INSIDE the META block (post-#88 the §1.1 envelope rule
+# means required fields after a ``---`` separator do not count as present).
 _VERBOSE_DECISION = " ".join(f"word{i}" for i in range(200))
 _VERBOSE_OCTAVE = (
     "===DECISION_RECORD===\n"
     "META:\n"
     "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
     f'  TOKEN::"{RECORD_TOKEN}"\n'
-    "---\n"
-    f'DECISION::"{_VERBOSE_DECISION}"\n'
+    "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
+    f'  DECISION::"{_VERBOSE_DECISION}"\n'
+    '  BECAUSE::"Exercises the verbosity density backstop."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
     "===END===\n"
 )
 

--- a/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
+++ b/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
@@ -1,0 +1,462 @@
+"""Gate A §4.1 invariant enforcement — issue #88 (silent-pass gap closure).
+
+ADR-RFC-ARCH-004 §4.1 enumerates 12 invariants the AGR validator MUST enforce.
+Before #88 the write-side Gate A (``type_checker.validate_octave_content``)
+enforced only a subset, so ``submit_governance`` ACCEPTED and EMITTED records
+that the read layer (``agr_read.record_is_parseable`` +
+``agent_readable_governance_parser``) then correctly REJECTED as unparseable —
+the write tool produced records its own read tools could not parse.
+
+This module adds one test class per remaining unenforced invariant, asserting
+BOTH the rejection AND an actionable, field-named error message at the correct
+§4.2 severity:
+
+  #1-residual  VERSION two-segment shape (§1.5; reject 3-segment "1.0.0")  -> error
+  #2          Required fields present (TYPE/VERSION/TOKEN/STATUS/TIER/
+              DECISION/BECAUSE/AUTHORED_AT)                                -> error
+  #3-residual TOKEN YYYYMMDD suffix == UTC date of AUTHORED_AT             -> error
+  #5          STATUS enum                                                  -> error
+  #6          TIER enum                                                    -> error
+  #7          Reserved names DEPENDS_ON/CONFLICTS_WITH/ARCHIVED_AT         -> error
+  #9          SUPERSEDED_BY present IFF STATUS == SUPERSEDED               -> error
+  #11         HUMAN_ADR_REF resolves under the repository                  -> error
+  #12         Ratification provenance (STATUS!=PROPOSED ∧ RATIFIED_BY
+              absent)                                                      -> WARNING
+
+Plus a write/read PARITY proof: a record that the read parser rejects is now
+rejected by Gate A too.
+
+Regex-only (North Star §4 / PROD I3); structured ``ValidationResult`` errors,
+never raised (PROD I4). Mirrors the established #10 ISSUE_REF precedent
+(dc30ac9 RED / 782621d GREEN) and the bare-canonical test style.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hestai_context_mcp.core.agent_readable_governance_parser import (
+    parse_decision_record,
+)
+from hestai_context_mcp.tools.governance.agr_read import (
+    is_decision_record,
+    record_is_parseable,
+)
+from hestai_context_mcp.tools.governance.type_checker import validate_octave_content
+
+# A canonical, fully-valid DECISION_RECORD. Helpers below mutate ONE axis at a
+# time so each test isolates a single invariant. TOKEN date suffix matches
+# AUTHORED_AT's UTC date (20260619) so #3-residual stays clean unless mutated.
+_VALID_TOKEN = "HO-CONTEXT-MCP-GATE-A-88-20260619"
+_VALID_AUTHORED_AT = "2026-06-19T00:00:00Z"
+
+
+def _record(
+    *,
+    token: str = _VALID_TOKEN,
+    version: str | None = "1.0",
+    type_field: str | None = "DECISION_RECORD",
+    status: str | None = "PROPOSED",
+    tier: str | None = "OPERATIONAL",
+    decision: str | None = "A binding decision sentence.",
+    because: str | None = "A one-sentence rationale.",
+    authored_at: str | None = _VALID_AUTHORED_AT,
+    extra_lines: str = "",
+) -> str:
+    """Build a DECISION_RECORD; any field set to None is OMITTED entirely.
+
+    ``extra_lines`` is injected verbatim into the META block (already indented
+    by the caller) for fields like SUPERSEDED_BY / RATIFIED_BY / HUMAN_ADR_REF /
+    reserved names.
+    """
+    lines = ["===DECISION_RECORD===", "META:"]
+    if type_field is not None:
+        lines.append(f"  TYPE::{type_field}")
+    if version is not None:
+        lines.append(f'  VERSION::"{version}"')
+    if token is not None:
+        lines.append(f"  TOKEN::{token}")
+    if status is not None:
+        lines.append(f"  STATUS::{status}")
+    if tier is not None:
+        lines.append(f"  TIER::{tier}")
+    if decision is not None:
+        lines.append(f'  DECISION::"{decision}"')
+    if because is not None:
+        lines.append(f'  BECAUSE::"{because}"')
+    if authored_at is not None:
+        lines.append(f'  AUTHORED_AT::"{authored_at}"')
+    if extra_lines:
+        lines.append(extra_lines.rstrip("\n"))
+    lines.append("===END===")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Invariant #2 — Required fields present (error)
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredFieldsPresent:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("omit_kwarg", "field_name"),
+        [
+            ({"status": None}, "STATUS"),
+            ({"tier": None}, "TIER"),
+            ({"decision": None}, "DECISION"),
+            ({"because": None}, "BECAUSE"),
+            ({"authored_at": None}, "AUTHORED_AT"),
+            ({"version": None}, "VERSION"),
+        ],
+    )
+    def test_missing_required_field_rejected(
+        self, tmp_path: Path, omit_kwarg: dict[str, None], field_name: str
+    ) -> None:
+        """A DECISION_RECORD missing any §1.2 required field is rejected by Gate A.
+
+        This is the core silent-pass class: today a record with only TYPE+TOKEN
+        passes Gate A but the read parser marks it unparseable.
+        """
+        content = _record(**omit_kwarg)  # type: ignore[arg-type]
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, f"missing {field_name} must reject"
+        # Operator UX: the missing field must be NAMED in the error.
+        assert any(field_name in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_only_type_and_token_rejected(self, tmp_path: Path) -> None:
+        """The exact #88 repro: TYPE+TOKEN only passes today; must now reject."""
+        content = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            f"  TOKEN::{_VALID_TOKEN}\n"
+            "===END===\n"
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        # At minimum STATUS, TIER, DECISION, BECAUSE, AUTHORED_AT named.
+        for field_name in ("STATUS", "TIER", "DECISION", "BECAUSE", "AUTHORED_AT"):
+            assert any(field_name in e for e in result.errors), (field_name, result.errors)
+
+    @pytest.mark.unit
+    def test_all_required_fields_present_valid(self, tmp_path: Path) -> None:
+        """Regression: a fully-formed record still validates."""
+        result = validate_octave_content(tmp_path, _record())
+        assert result.valid, result.errors
+
+
+# ---------------------------------------------------------------------------
+# Invariant #1-residual — VERSION two-segment shape (§1.5) (error)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionShape:
+    @pytest.mark.unit
+    def test_three_segment_version_rejected(self, tmp_path: Path) -> None:
+        """VERSION "1.0.0" (3-segment) is rejected: §1.5 is MAJOR.MINOR only."""
+        result = validate_octave_content(tmp_path, _record(version="1.0.0"))
+        assert result.valid is False
+        assert any("VERSION" in e for e in result.errors), result.errors
+        assert any("1.0.0" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_non_numeric_version_rejected(self, tmp_path: Path) -> None:
+        """VERSION "v1" is rejected — must be a parseable MAJOR.MINOR string."""
+        result = validate_octave_content(tmp_path, _record(version="v1"))
+        assert result.valid is False
+        assert any("VERSION" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_two_segment_version_accepted(self, tmp_path: Path) -> None:
+        """VERSION "1.0" (and future "1.1") is accepted."""
+        assert validate_octave_content(tmp_path, _record(version="1.0")).valid
+        assert validate_octave_content(tmp_path, _record(version="1.1")).valid
+
+
+# ---------------------------------------------------------------------------
+# Invariant #3-residual — TOKEN date suffix == UTC date of AUTHORED_AT (error)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenDateConsistency:
+    @pytest.mark.unit
+    def test_token_date_mismatch_rejected(self, tmp_path: Path) -> None:
+        """TOKEN suffix 20260619 with AUTHORED_AT 2026-06-18 is a hard error (§1.3)."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-18T23:59:59Z",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        assert any("AUTHORED_AT" in e or "date" in e.lower() for e in result.errors), result.errors
+        assert any("20260619" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_token_date_match_accepted(self, tmp_path: Path) -> None:
+        """TOKEN suffix equal to AUTHORED_AT UTC date validates."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-19T12:34:56Z",
+        )
+        assert validate_octave_content(tmp_path, content).valid
+
+    @pytest.mark.unit
+    def test_token_date_utc_boundary_uses_date_portion(self, tmp_path: Path) -> None:
+        """The check is on the UTC DATE portion only (time-of-day irrelevant)."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-19T00:00:00Z",
+        )
+        assert validate_octave_content(tmp_path, content).valid
+
+
+# ---------------------------------------------------------------------------
+# Invariant #5 — STATUS enum (error)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEnum:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("status", ["PROPOSED", "RATIFIED", "SUPERSEDED", "VOID"])
+    def test_valid_status_accepted(self, tmp_path: Path, status: str) -> None:
+        # SUPERSEDED requires SUPERSEDED_BY (#9); supply it so this isolates #5.
+        extra = ""
+        if status == "SUPERSEDED":
+            # Point at an existing token: seed it on disk.
+            target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
+            decisions = tmp_path / ".hestai" / "decisions"
+            decisions.mkdir(parents=True, exist_ok=True)
+            (decisions / f"{target}.oct.md").write_text(
+                _record(token=target), encoding="utf-8"
+            )
+            extra = f'  SUPERSEDED_BY::"{target}"'
+        result = validate_octave_content(tmp_path, _record(status=status, extra_lines=extra))
+        assert result.valid, result.errors
+
+    @pytest.mark.unit
+    def test_invalid_status_rejected(self, tmp_path: Path) -> None:
+        """STATUS::DRAFT is not in the §1.4 enum and must reject, naming the value."""
+        result = validate_octave_content(tmp_path, _record(status="DRAFT"))
+        assert result.valid is False
+        assert any("STATUS" in e for e in result.errors), result.errors
+        assert any("DRAFT" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_lowercase_status_rejected(self, tmp_path: Path) -> None:
+        """Enum is case-sensitive: 'proposed' is not 'PROPOSED'."""
+        result = validate_octave_content(tmp_path, _record(status="proposed"))
+        assert result.valid is False
+        assert any("STATUS" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# Invariant #6 — TIER enum (error)
+# ---------------------------------------------------------------------------
+
+
+class TestTierEnum:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("tier", ["STRATEGIC", "TACTICAL", "OPERATIONAL"])
+    def test_valid_tier_accepted(self, tmp_path: Path, tier: str) -> None:
+        assert validate_octave_content(tmp_path, _record(tier=tier)).valid
+
+    @pytest.mark.unit
+    def test_invalid_tier_rejected(self, tmp_path: Path) -> None:
+        """TIER::HIGH is not in the §1.2 enum and must reject, naming the value."""
+        result = validate_octave_content(tmp_path, _record(tier="HIGH"))
+        assert result.valid is False
+        assert any("TIER" in e for e in result.errors), result.errors
+        assert any("HIGH" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# Invariant #7 — Reserved names MUST NOT appear in v1.x (error)
+# ---------------------------------------------------------------------------
+
+
+class TestReservedNames:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "reserved", ["DEPENDS_ON", "CONFLICTS_WITH", "ARCHIVED_AT"]
+    )
+    def test_reserved_field_rejected(self, tmp_path: Path, reserved: str) -> None:
+        """A v1.x record carrying a reserved field name is rejected (§1.2)."""
+        result = validate_octave_content(
+            tmp_path, _record(extra_lines=f'  {reserved}::"whatever"')
+        )
+        assert result.valid is False
+        assert any(reserved in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_no_reserved_field_accepted(self, tmp_path: Path) -> None:
+        """Regression: a clean record (no reserved names) validates."""
+        assert validate_octave_content(tmp_path, _record()).valid
+
+
+# ---------------------------------------------------------------------------
+# Invariant #9 — SUPERSEDED_BY present IFF STATUS == SUPERSEDED (error)
+# ---------------------------------------------------------------------------
+
+
+class TestSupersededByIff:
+    def _seed_successor(self, tmp_path: Path) -> str:
+        target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True, exist_ok=True)
+        (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
+        return target
+
+    @pytest.mark.unit
+    def test_superseded_without_superseded_by_rejected(self, tmp_path: Path) -> None:
+        """STATUS::SUPERSEDED with NO SUPERSEDED_BY is a hard error (#9)."""
+        result = validate_octave_content(tmp_path, _record(status="SUPERSEDED"))
+        assert result.valid is False
+        assert any("SUPERSEDED_BY" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_superseded_by_on_non_superseded_rejected(self, tmp_path: Path) -> None:
+        """SUPERSEDED_BY present while STATUS != SUPERSEDED is a hard error (#9)."""
+        target = self._seed_successor(tmp_path)
+        result = validate_octave_content(
+            tmp_path,
+            _record(status="RATIFIED", extra_lines=f'  SUPERSEDED_BY::"{target}"'),
+        )
+        assert result.valid is False
+        assert any("SUPERSEDED_BY" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_superseded_with_superseded_by_accepted(self, tmp_path: Path) -> None:
+        """The matched case (SUPERSEDED ∧ SUPERSEDED_BY present) validates."""
+        target = self._seed_successor(tmp_path)
+        result = validate_octave_content(
+            tmp_path,
+            _record(status="SUPERSEDED", extra_lines=f'  SUPERSEDED_BY::"{target}"'),
+        )
+        assert result.valid, result.errors
+
+
+# ---------------------------------------------------------------------------
+# Invariant #11 — HUMAN_ADR_REF resolves under the repository (error)
+# ---------------------------------------------------------------------------
+
+
+class TestHumanAdrRefResolution:
+    @pytest.mark.unit
+    def test_unresolvable_human_adr_ref_rejected(self, tmp_path: Path) -> None:
+        """HUMAN_ADR_REF pointing at a non-existent path is a hard error (#11)."""
+        result = validate_octave_content(
+            tmp_path,
+            _record(extra_lines='  HUMAN_ADR_REF::"docs/adr/does-not-exist.md"'),
+        )
+        assert result.valid is False
+        assert any("HUMAN_ADR_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_resolvable_human_adr_ref_accepted(self, tmp_path: Path) -> None:
+        """HUMAN_ADR_REF resolving under the repo validates."""
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-real.md").write_text("# real adr\n", encoding="utf-8")
+        result = validate_octave_content(
+            tmp_path, _record(extra_lines='  HUMAN_ADR_REF::"docs/adr/0001-real.md"')
+        )
+        assert result.valid, result.errors
+
+    @pytest.mark.unit
+    def test_human_adr_ref_traversal_rejected(self, tmp_path: Path) -> None:
+        """A HUMAN_ADR_REF escaping the repo root is rejected (does not resolve under repo)."""
+        result = validate_octave_content(
+            tmp_path, _record(extra_lines='  HUMAN_ADR_REF::"../../../etc/passwd"')
+        )
+        assert result.valid is False
+        assert any("HUMAN_ADR_REF" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_human_adr_ref_absent_accepted(self, tmp_path: Path) -> None:
+        """HUMAN_ADR_REF is OPTIONAL: absence validates."""
+        assert validate_octave_content(tmp_path, _record()).valid
+
+
+# ---------------------------------------------------------------------------
+# Invariant #12 — Ratification provenance: WARNING (not error) per §4.2
+# ---------------------------------------------------------------------------
+
+
+class TestRatificationProvenanceWarning:
+    @pytest.mark.unit
+    def test_ratified_without_ratified_by_warns_not_errors(self, tmp_path: Path) -> None:
+        """STATUS=RATIFIED ∧ RATIFIED_BY absent => WARNING, record still valid (#12)."""
+        result = validate_octave_content(tmp_path, _record(status="RATIFIED"))
+        # §4.2: this is a WARNING, NOT an error. The record must remain valid.
+        assert result.valid, result.errors
+        assert any("RATIFIED_BY" in w for w in result.warnings), result.warnings
+
+    @pytest.mark.unit
+    def test_proposed_without_ratified_by_no_warning(self, tmp_path: Path) -> None:
+        """PROPOSED records need no RATIFIED_BY: no warning emitted (#12)."""
+        result = validate_octave_content(tmp_path, _record(status="PROPOSED"))
+        assert result.valid, result.errors
+        assert not any("RATIFIED_BY" in w for w in result.warnings), result.warnings
+
+    @pytest.mark.unit
+    def test_ratified_with_ratified_by_no_warning(self, tmp_path: Path) -> None:
+        """RATIFIED with RATIFIED_BY present: clean, no warning (#12)."""
+        result = validate_octave_content(
+            tmp_path,
+            _record(status="RATIFIED", extra_lines='  RATIFIED_BY::"human:operator"'),
+        )
+        assert result.valid, result.errors
+        assert not any("RATIFIED_BY" in w for w in result.warnings), result.warnings
+
+
+# ---------------------------------------------------------------------------
+# WRITE/READ PARITY PROOF (issue #88 core requirement)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteReadParity:
+    """A record the READ parser rejects must now be rejected by Gate A (write).
+
+    Before #88 these records passed Gate A (write side) but
+    ``record_is_parseable`` returned False (read side) — the write tool emitted
+    records its own read tools could not parse. This proves the gap is closed.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "content",
+        [
+            # Only TYPE + TOKEN — missing 5 required fields.
+            (
+                "===DECISION_RECORD===\n"
+                "META:\n"
+                "  TYPE::DECISION_RECORD\n"
+                f"  TOKEN::{_VALID_TOKEN}\n"
+                "===END===\n"
+            ),
+            # Missing AUTHORED_AT only.
+            _record(authored_at=None),
+            # Missing STATUS only.
+            _record(status=None),
+        ],
+    )
+    def test_read_unparseable_record_now_fails_gate_a(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        # Precondition: the read side considers this an AGR but unparseable.
+        assert is_decision_record(content) is True
+        assert record_is_parseable(parse_decision_record(content)) is False
+        # The parity claim: Gate A (write) now ALSO rejects it.
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False, "Gate A must reject what the read parser rejects"
+
+    @pytest.mark.unit
+    def test_read_parseable_record_passes_gate_a(self, tmp_path: Path) -> None:
+        """Converse: a read-parseable record still passes Gate A (no over-rejection)."""
+        content = _record()
+        assert record_is_parseable(parse_decision_record(content)) is True
+        assert validate_octave_content(tmp_path, content).valid, "no over-rejection"

--- a/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
+++ b/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
@@ -230,9 +230,7 @@ class TestStatusEnum:
             target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
             decisions = tmp_path / ".hestai" / "decisions"
             decisions.mkdir(parents=True, exist_ok=True)
-            (decisions / f"{target}.oct.md").write_text(
-                _record(token=target), encoding="utf-8"
-            )
+            (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
             extra = f'  SUPERSEDED_BY::"{target}"'
         result = validate_octave_content(tmp_path, _record(status=status, extra_lines=extra))
         assert result.valid, result.errors
@@ -280,14 +278,10 @@ class TestTierEnum:
 
 class TestReservedNames:
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "reserved", ["DEPENDS_ON", "CONFLICTS_WITH", "ARCHIVED_AT"]
-    )
+    @pytest.mark.parametrize("reserved", ["DEPENDS_ON", "CONFLICTS_WITH", "ARCHIVED_AT"])
     def test_reserved_field_rejected(self, tmp_path: Path, reserved: str) -> None:
         """A v1.x record carrying a reserved field name is rejected (§1.2)."""
-        result = validate_octave_content(
-            tmp_path, _record(extra_lines=f'  {reserved}::"whatever"')
-        )
+        result = validate_octave_content(tmp_path, _record(extra_lines=f'  {reserved}::"whatever"'))
         assert result.valid is False
         assert any(reserved in e for e in result.errors), result.errors
 
@@ -444,9 +438,7 @@ class TestWriteReadParity:
             _record(status=None),
         ],
     )
-    def test_read_unparseable_record_now_fails_gate_a(
-        self, tmp_path: Path, content: str
-    ) -> None:
+    def test_read_unparseable_record_now_fails_gate_a(self, tmp_path: Path, content: str) -> None:
         # Precondition: the read side considers this an AGR but unparseable.
         assert is_decision_record(content) is True
         assert record_is_parseable(parse_decision_record(content)) is False

--- a/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
+++ b/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
@@ -94,6 +94,20 @@ def _record(
     return "\n".join(lines) + "\n"
 
 
+def _seed_successor(tmp_path: Path) -> str:
+    """Write a valid successor AGR on disk and return its TOKEN.
+
+    Shared by the #9 SUPERSEDED_BY tests so a SUPERSEDED record can name an
+    existing successor (the SUPERSEDED_BY target-existence check, Gate A Check 5,
+    requires the referenced TOKEN to already exist in the store).
+    """
+    target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
+    decisions = tmp_path / ".hestai" / "decisions"
+    decisions.mkdir(parents=True, exist_ok=True)
+    (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
+    return target
+
+
 # ---------------------------------------------------------------------------
 # Invariant #2 — Required fields present (error)
 # ---------------------------------------------------------------------------
@@ -226,11 +240,7 @@ class TestStatusEnum:
         # SUPERSEDED requires SUPERSEDED_BY (#9); supply it so this isolates #5.
         extra = ""
         if status == "SUPERSEDED":
-            # Point at an existing token: seed it on disk.
-            target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
-            decisions = tmp_path / ".hestai" / "decisions"
-            decisions.mkdir(parents=True, exist_ok=True)
-            (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
+            target = _seed_successor(tmp_path)
             extra = f'  SUPERSEDED_BY::"{target}"'
         result = validate_octave_content(tmp_path, _record(status=status, extra_lines=extra))
         assert result.valid, result.errors
@@ -297,13 +307,6 @@ class TestReservedNames:
 
 
 class TestSupersededByIff:
-    def _seed_successor(self, tmp_path: Path) -> str:
-        target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
-        decisions = tmp_path / ".hestai" / "decisions"
-        decisions.mkdir(parents=True, exist_ok=True)
-        (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
-        return target
-
     @pytest.mark.unit
     def test_superseded_without_superseded_by_rejected(self, tmp_path: Path) -> None:
         """STATUS::SUPERSEDED with NO SUPERSEDED_BY is a hard error (#9)."""
@@ -314,7 +317,7 @@ class TestSupersededByIff:
     @pytest.mark.unit
     def test_superseded_by_on_non_superseded_rejected(self, tmp_path: Path) -> None:
         """SUPERSEDED_BY present while STATUS != SUPERSEDED is a hard error (#9)."""
-        target = self._seed_successor(tmp_path)
+        target = _seed_successor(tmp_path)
         result = validate_octave_content(
             tmp_path,
             _record(status="RATIFIED", extra_lines=f'  SUPERSEDED_BY::"{target}"'),
@@ -325,7 +328,7 @@ class TestSupersededByIff:
     @pytest.mark.unit
     def test_superseded_with_superseded_by_accepted(self, tmp_path: Path) -> None:
         """The matched case (SUPERSEDED ∧ SUPERSEDED_BY present) validates."""
-        target = self._seed_successor(tmp_path)
+        target = _seed_successor(tmp_path)
         result = validate_octave_content(
             tmp_path,
             _record(status="SUPERSEDED", extra_lines=f'  SUPERSEDED_BY::"{target}"'),
@@ -463,17 +466,10 @@ class TestWriteReadParity:
 
 
 class TestSupersededByBareCanonical:
-    def _seed_successor(self, tmp_path: Path) -> str:
-        target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
-        decisions = tmp_path / ".hestai" / "decisions"
-        decisions.mkdir(parents=True, exist_ok=True)
-        (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
-        return target
-
     @pytest.mark.unit
     def test_superseded_with_bare_superseded_by_accepted(self, tmp_path: Path) -> None:
-        """SUPERSEDED + BARE SUPERSEDED_BV::TOKEN satisfies #9 (canonical form)."""
-        target = self._seed_successor(tmp_path)
+        """SUPERSEDED + BARE SUPERSEDED_BY::TOKEN satisfies #9 (canonical form)."""
+        target = _seed_successor(tmp_path)
         result = validate_octave_content(
             tmp_path,
             _record(status="SUPERSEDED", extra_lines=f"  SUPERSEDED_BY::{target}"),
@@ -483,7 +479,7 @@ class TestSupersededByBareCanonical:
     @pytest.mark.unit
     def test_bare_superseded_by_on_non_superseded_rejected(self, tmp_path: Path) -> None:
         """A BARE SUPERSEDED_BY on a RATIFIED record must still trip #9."""
-        target = self._seed_successor(tmp_path)
+        target = _seed_successor(tmp_path)
         result = validate_octave_content(
             tmp_path,
             _record(status="RATIFIED", extra_lines=f"  SUPERSEDED_BY::{target}"),
@@ -542,6 +538,43 @@ class TestTokenDateUtcNormalisation:
         result = validate_octave_content(tmp_path, content)
         assert result.valid is False
         assert any("AUTHORED_AT" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_date_only_authored_at_rejected(self, tmp_path: Path) -> None:
+        """A DATE-ONLY AUTHORED_AT (no time component) must be rejected (cubic P2).
+
+        §1.2 declares AUTHORED_AT an ISO-8601 *timestamp* (full form, e.g.
+        ``2026-06-11T00:00:00Z``). ``datetime.fromisoformat`` happily accepts a
+        bare date (``2026-06-19`` -> midnight), so before this fix a date-only
+        value silently passed #3 whenever the TOKEN suffix matched — a silent
+        pass in the very feature meant to close them.
+        """
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-19",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        assert any("AUTHORED_AT" in e for e in result.errors), result.errors
+        # The message must name the problem so operators can fix in one round-trip.
+        assert any(
+            "full ISO-8601 timestamp" in e or "not a date" in e.lower() for e in result.errors
+        ), result.errors
+
+    @pytest.mark.unit
+    def test_space_separated_timestamp_accepted(self, tmp_path: Path) -> None:
+        """A space-separated ISO-8601 timestamp (has a time component) is accepted.
+
+        ISO-8601 / ``datetime.fromisoformat`` permit a space in place of ``T``;
+        such a value DOES carry a time component, so it must NOT be swept up by
+        the date-only rejection.
+        """
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-19 00:00:00+00:00",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
 
     @pytest.mark.unit
     def test_plain_utc_z_still_accepted(self, tmp_path: Path) -> None:

--- a/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
+++ b/tests/unit/tools/governance/test_gate_a_required_invariants_issue_88.py
@@ -452,3 +452,102 @@ class TestWriteReadParity:
         content = _record()
         assert record_is_parseable(parse_decision_record(content)) is True
         assert validate_octave_content(tmp_path, content).valid, "no over-rejection"
+
+
+# ---------------------------------------------------------------------------
+# Review rework (T3 CE/CIV): #9 must honour the CANONICAL BARE SUPERSEDED_BY
+# form. ADR-RFC-ARCH-004 §13.1 ratified bare TOKEN edge references as canonical;
+# the §4.1 #9 iff check must therefore see a bare ``SUPERSEDED_BY::TOKEN`` exactly
+# as it sees the legacy quoted form, mirroring lineage.py's quote-optional regex.
+# ---------------------------------------------------------------------------
+
+
+class TestSupersededByBareCanonical:
+    def _seed_successor(self, tmp_path: Path) -> str:
+        target = "HO-CONTEXT-MCP-SUCCESSOR-20260619"
+        decisions = tmp_path / ".hestai" / "decisions"
+        decisions.mkdir(parents=True, exist_ok=True)
+        (decisions / f"{target}.oct.md").write_text(_record(token=target), encoding="utf-8")
+        return target
+
+    @pytest.mark.unit
+    def test_superseded_with_bare_superseded_by_accepted(self, tmp_path: Path) -> None:
+        """SUPERSEDED + BARE SUPERSEDED_BV::TOKEN satisfies #9 (canonical form)."""
+        target = self._seed_successor(tmp_path)
+        result = validate_octave_content(
+            tmp_path,
+            _record(status="SUPERSEDED", extra_lines=f"  SUPERSEDED_BY::{target}"),
+        )
+        assert result.valid, result.errors
+
+    @pytest.mark.unit
+    def test_bare_superseded_by_on_non_superseded_rejected(self, tmp_path: Path) -> None:
+        """A BARE SUPERSEDED_BY on a RATIFIED record must still trip #9."""
+        target = self._seed_successor(tmp_path)
+        result = validate_octave_content(
+            tmp_path,
+            _record(status="RATIFIED", extra_lines=f"  SUPERSEDED_BY::{target}"),
+        )
+        assert result.valid is False
+        assert any("SUPERSEDED_BY" in e for e in result.errors), result.errors
+
+
+# ---------------------------------------------------------------------------
+# Review rework (T3 CIV): #3 TOKEN-date consistency MUST use the UTC date, not a
+# lexical leading-date capture. §1.3 says the suffix equals the *UTC date portion*
+# of AUTHORED_AT — an offset timestamp must be normalised to UTC before
+# comparison, and a non-timestamp AUTHORED_AT must not silently pass #3.
+# ---------------------------------------------------------------------------
+
+
+class TestTokenDateUtcNormalisation:
+    @pytest.mark.unit
+    def test_offset_timestamp_normalised_to_utc_accepted(self, tmp_path: Path) -> None:
+        """2026-06-18T23:30-02:00 is UTC date 2026-06-19 → token 20260619 valid."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-18T23:30:00-02:00",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
+
+    @pytest.mark.unit
+    def test_offset_timestamp_normalised_to_utc_mismatch_rejected(self, tmp_path: Path) -> None:
+        """Same instant: token 20260618 disagrees with UTC date 20260619 → reject."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260618",
+            authored_at="2026-06-18T23:30:00-02:00",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        assert any("AUTHORED_AT" in e or "date" in e.lower() for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_positive_offset_normalised_to_utc(self, tmp_path: Path) -> None:
+        """2026-06-19T01:00+03:00 is UTC date 2026-06-18 → token 20260618 valid."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260618",
+            authored_at="2026-06-19T01:00:00+03:00",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid, result.errors
+
+    @pytest.mark.unit
+    def test_unparseable_authored_at_rejected(self, tmp_path: Path) -> None:
+        """A non-timestamp AUTHORED_AT must NOT silently pass the #3 date check."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="not-a-timestamp",
+        )
+        result = validate_octave_content(tmp_path, content)
+        assert result.valid is False
+        assert any("AUTHORED_AT" in e for e in result.errors), result.errors
+
+    @pytest.mark.unit
+    def test_plain_utc_z_still_accepted(self, tmp_path: Path) -> None:
+        """Regression: the common Z-suffixed UTC form still validates."""
+        content = _record(
+            token="HO-CONTEXT-MCP-GATE-A-88-20260619",
+            authored_at="2026-06-19T00:00:00Z",
+        )
+        assert validate_octave_content(tmp_path, content).valid

--- a/tests/unit/tools/test_submit_governance_octave_validator.py
+++ b/tests/unit/tools/test_submit_governance_octave_validator.py
@@ -31,13 +31,22 @@ from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
 
 @pytest.fixture()
 def decision_record_octave() -> str:
-    """A well-formed DECISION_RECORD that passes the regex Gate A."""
+    """A fully-formed DECISION_RECORD that passes the regex Gate A.
+
+    Carries every §1.2 required field (post-#88 Gate A enforces presence,
+    enums, and TOKEN-date consistency: the 20260601 suffix matches AUTHORED_AT).
+    """
     return (
         "===DECISION_RECORD===\n"
         "META:\n"
         "  TYPE::DECISION_RECORD\n"
+        '  VERSION::"1.0"\n'
         '  TOKEN::"HO-CONTEXT-MCP-GATEB-DECISION-20260601"\n'
         "  STATUS::PROPOSED\n"
+        "  TIER::OPERATIONAL\n"
+        '  DECISION::"A binding decision for the Gate B test."\n'
+        '  BECAUSE::"Exercises the real OCTAVE validator seam."\n'
+        '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
         "===END===\n"
     )
 

--- a/tests/unit/tools/test_submit_governance_prose.py
+++ b/tests/unit/tools/test_submit_governance_prose.py
@@ -32,8 +32,10 @@ _VALID_OCTAVE = (
     '  VERSION::"1.0"\n'
     '  TOKEN::"HO-CONTEXT-MCP-PROSE-20260601"\n'
     "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
     '  DECISION::"Prose-authored decision."\n'
     '  BECAUSE::"Gate C end-to-end."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
     "===END===\n"
 )
 


### PR DESCRIPTION
## Summary

Closes the **Gate A silent-pass gap** (#88): `submit_governance` could emit AGR `DECISION_RECORD`s that its own read layer (`lookup_decision`/`list_decisions`/`trace_supersedure`) then rejected as unparseable — breaking the AGR dogfood loop and the §4 DECISION_LOOKUP Tier-A path. Gate A now enforces the remaining ADR-RFC-ARCH-004 §4.1 invariants, regex-only, with §4.2 severity.

The bug was reproduced first (a TYPE+TOKEN-only record passed Gate A but failed the read parser), then closed at the source.

## Invariants now enforced (Gate A, write-side)

| # | Rule | Severity |
|---|------|----------|
| #2 | Required META fields present (TYPE, VERSION, TOKEN, STATUS, TIER, DECISION, BECAUSE, AUTHORED_AT) | error |
| #3 (residual) | TOKEN `YYYYMMDD` suffix == UTC date of `AUTHORED_AT` | error |
| #5 | STATUS ∈ {PROPOSED, RATIFIED, SUPERSEDED, VOID} | error |
| #6 | TIER ∈ {STRATEGIC, TACTICAL, OPERATIONAL} | error |
| #7 | Reserved names (DEPENDS_ON / CONFLICTS_WITH / ARCHIVED_AT) absent in v1.x | error |
| #9 | SUPERSEDED_BY present **iff** STATUS == SUPERSEDED (bare + quoted forms) | error |
| #11 | HUMAN_ADR_REF resolves under the repo when present | error |
| #12 | Ratification provenance: STATUS != PROPOSED with RATIFIED_BY absent | **warning** (§4.2) |

## Design decision — shared constants (one source of truth)

The required-field set, STATUS/TIER enums, reserved names, and the `SUPERSEDED_BY` regex now live **once** in `type_checker.py`; `agr_read.py` derives `_REQUIRED_FIELDS` from them. Gate A (write) and the read parser's `record_is_parseable` therefore **cannot drift by construction** — this is the root-cause fix, not a patch. A `TestWriteReadParity` end-to-end test additionally proves Gate A now rejects exactly what the read parser rejects (no over-rejection).

## Discipline

- Regex-only — no OCTAVE AST, no LLM (North Star §4 / PROD I3). Mirrors the #10 ISSUE_REF precedent.
- Structured `ValidationResult` errors with actionable field-named messages; new `warnings` field for #12 (PROD I4). Never raised.
- Scope: Gate A validator + shared-constants extraction + tests + 4 silent-pass fixture corrections. No bleed into the AIClient adapter (#96), failover (#78), JIT prompt (#76), or ID-indent (#92).

## Tests & gates

- 49 dedicated `test_gate_a_required_invariants_issue_88.py` (one class per invariant + parity proof) — all green.
- Full suite green (the only excluded tests are the env-only #66 `clock_in` AI-synthesis cases). ruff / black / mypy clean. Coverage: type_checker 94%, agr_read 93%, parser 100%.

## Review status

T3 chain — **3 of 4 stamped**: CIV APPROVED (after catching 2 blocking bugs — bare `SUPERSEDED_BY` and lexical-vs-UTC `AUTHORED_AT` — both fixed in-session), CE CONCERNS-resolved, CRS APPROVED. **TMG (test-methodology) pending** — reviewer CLI was unreachable this session; to be obtained before merge.

## Notes (non-blocking)

- Gate A now *requires* VERSION while the read parser doesn't gate on it — Gate A is intentionally stricter than the read floor (safe direction). Flagged as a possible future ADR-004 clarification.
- No in-repo records need remediation: all 3 existing AGRs pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the remaining ADR-004 §4.1 invariants in Gate A to stop write/read drift and reject malformed `DECISION_RECORD`s. Closes the silent-pass bug (#88) and maintains write/read parity.

- **Bug Fixes**
  - Enforces required META fields: `TYPE`, `VERSION`, `TOKEN`, `STATUS`, `TIER`, `DECISION`, `BECAUSE`, `AUTHORED_AT` (error).
  - Validates `VERSION` as MAJOR.MINOR and `STATUS`/`TIER` enums; blocks reserved names (`DEPENDS_ON`, `CONFLICTS_WITH`, `ARCHIVED_AT`) (error).
  - Checks `TOKEN` date suffix matches the UTC date of `AUTHORED_AT`; rejects unparseable or date-only values (error).
  - Requires `SUPERSEDED_BY` iff `STATUS` is `SUPERSEDED` (bare or quoted forms) (error).
  - Verifies `HUMAN_ADR_REF` resolves under the repo (error).
  - Adds advisory `RATIFIED_BY` check for non-PROPOSED records (warning; does not block).

- **Refactors**
  - Centralizes shared constants in `type_checker.py` (`REQUIRED_META_FIELDS`, `STATUS_VALUES`, `TIER_VALUES`, `RESERVED_FIELD_NAMES`) and derives `agr_read` parseability from them (excludes `VERSION`) to ensure parity.
  - Extends `ValidationResult` with `warnings`; preserves regex-only validation and updates fixtures to fully-formed records.

<sup>Written for commit 204cb7fbeb84919fb1e0c2fa30def863f376694e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

