### PR TITLE
chore(governance): ratify HO-INTAKE-MODEL-RESOLUTION-PER-REPO (#106)

### DIFF
--- a/.hestai/decisions/HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619.oct.md
+++ b/.hestai/decisions/HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619.oct.md
@@ -3,9 +3,11 @@ META:
   TYPE::DECISION_RECORD
   VERSION::"1.0"
   TOKEN::HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619
-  STATUS::PROPOSED
+  STATUS::RATIFIED
   TIER::STRATEGIC
   AUTHORED_AT::"2026-06-19T00:00:00Z"
+  RATIFIED_BY::"human:operator"
+  RATIFIED_AT::"2026-06-20T00:00:00Z"
   ISSUE_REF::"repo:hestai-context-mcp#106"
   HUMAN_ADR_REF::".hestai/decisions/rfc-arch/ADR-RFC-ARCH-004-agent-readable-governance-records.md"
   SCOPE::"hestai-context-mcp"


### PR DESCRIPTION
## Ratification

Operator-authorised ratification of the per-repo AI-model resolution decision (`HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619`, ISSUE_REF #106).

- `STATUS`: PROPOSED → **RATIFIED**
- `RATIFIED_BY::"human:operator"`, `RATIFIED_AT::2026-06-20T00:00:00Z`

Architecture independently concurred by HO, the SR standards review (PR #107), and an external operator-side assessment. Validated clean against Gate A (ADR-004 §4.1, incl. #12 ratification provenance).

**Unblocks #106** (implementation of per-repo model resolution).

### Tooling-gap note
There is no amendment-broker tool yet (`propose_decision_amendment` is out of scope per RFC-40 follow-ups), and `submit_governance` cannot transition an existing record (TOKEN-uniqueness rejects the re-author). This STATUS transition was authored as a minimal, structure-preserving field amendment. A first-class ratify/amend path is a candidate follow-up — and overlaps the AGR-format/process work being taken to debate under #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ratifies the per-repo model resolution decision and records provenance, unblocking #106. In `.hestai/decisions/HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619.oct.md`, set `STATUS` to `RATIFIED` and add `RATIFIED_BY` and `RATIFIED_AT`.

<sup>Written for commit 8ae36e2b4b1cf7a6dbfe9605d1649d34130feb59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

