### PR TITLE
feat(ci): host review-gate Governance Socket in hestai-context

### DIFF
--- a/.github/workflows/review-gate-caller.yml.template
+++ b/.github/workflows/review-gate-caller.yml.template
@@ -1,0 +1,46 @@
+# Review Gate - Governance Socket
+# Copy this file to .github/workflows/review-gate.yml in your repo.
+# Source: https://github.com/elevanaltd/hestai-context-mcp
+#
+# This delegates PR review-gate enforcement to the reusable workflow
+# hosted in hestai-context-mcp. The reusable workflow will:
+#   - Checkout your repo and the review-gate tooling
+#   - Determine review tier based on changed files
+#   - Check for required approval comments on the PR
+#   - Post a status comment on the PR
+name: Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  check-review:
+    # Only invoke for PR events, or PR comments containing review verdicts.
+    # Filters out irrelevant comments (discussion, bot noise) that can't change gate outcome.
+    # Keywords match review_formats.py: APPROVED, REVIEWED (covers SELF-REVIEWED), GO.
+    # Also matches markdown-bold variants (**APPROVED**, **GO**) since review_formats.py
+    # strips bold markers before pattern matching.
+    # IMPORTANT: Exclude bot comments to prevent self-triggering — the gate's own status
+    # comment contains 'APPROVED'/'REVIEWED' in guidance text which would re-trigger the gate.
+    if: >-
+      github.event_name == 'pull_request'
+      || (github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && (contains(github.event.comment.body, 'APPROVED')
+              || contains(github.event.comment.body, 'REVIEWED')
+              || contains(github.event.comment.body, ' GO')
+              || contains(github.event.comment.body, ' GO:')
+              || contains(github.event.comment.body, '**GO**')))
+    uses: elevanaltd/hestai-context-mcp/.github/workflows/review-gate.yml@main
+    # Caller must declare permissions explicitly - the reusable workflow
+    # cannot elevate beyond what the caller allows. Without these, orgs
+    # with restrictive default permissions will block PR commenting.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    with:
+      pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -401,7 +401,9 @@ jobs:
                 per_page: 100
               });
 
-              const botComment = comments.find(c =>
+              // Reverse to update the NEWEST marker comment, matching the
+              // extract step above; avoids leaving stale marker/cache comments.
+              const botComment = comments.reverse().find(c =>
                 c.user.type === 'Bot' && c.body.includes(marker)
               );
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,482 @@
+# HestAI Review Gate v3.0.0 - Governance Socket
+# Source: https://github.com/elevanaltd/HestAI-MCP
+# Last updated: 2026-02-10 (Governance Socket: reusable workflow_call support)
+#
+# This workflow runs review validation for PRs. It supports two modes:
+#   1. LOCAL:  Triggered directly by HestAI-MCP's own PRs (pull_request / issue_comment)
+#   2. REMOTE: Called by other repos via workflow_call (Governance Socket pattern)
+#
+# For consuming repos, copy review-gate-caller.yml.template to your
+# .github/workflows/review-gate.yml - see that file for details.
+
+name: Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created, edited]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number from the calling workflow'
+        required: true
+        type: string
+
+jobs:
+  check-review:
+    runs-on: ubuntu-latest
+    # Only run on PR events, workflow_call, or PR comments containing review verdicts.
+    # Filters out irrelevant comments (discussion, bot noise) that can't change gate outcome.
+    # Keywords match review_formats.py: APPROVED, REVIEWED (covers SELF-REVIEWED), GO.
+    # Also matches markdown-bold variants (**APPROVED**, **GO**) since review_formats.py
+    # strips bold markers before pattern matching.
+    # IMPORTANT: Exclude bot comments to prevent self-triggering — the gate's own ❌ status
+    # comment contains 'APPROVED'/'REVIEWED' in guidance text which would re-trigger the gate.
+    if: >-
+      github.event_name == 'pull_request'
+      || github.event_name == 'workflow_call'
+      || github.event_name == 'pull_request_review'
+      || (github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && (contains(github.event.comment.body, 'APPROVED')
+              || contains(github.event.comment.body, 'REVIEWED')
+              || contains(github.event.comment.body, ' GO')
+              || contains(github.event.comment.body, ' GO:')
+              || contains(github.event.comment.body, '**GO**')))
+
+    # Required for PR commenting and commit status updates
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
+
+    steps:
+      # --- Determine execution context ---
+      - name: Detect execution context
+        id: context
+        run: |
+          if [ "${{ github.repository }}" = "elevanaltd/hestai-context-mcp" ]; then
+            echo "mode=local" >> $GITHUB_OUTPUT
+            echo "script_path=scripts/validate_review.py" >> $GITHUB_OUTPUT
+          else
+            echo "mode=remote" >> $GITHUB_OUTPUT
+            echo "script_path=.review-gate-tools/scripts/validate_review.py" >> $GITHUB_OUTPUT
+          fi
+
+      # --- Checkout the target repo (caller or self) ---
+      # NOTE: This MUST come before the tools checkout below, because
+      # actions/checkout with clean:true (default) runs git clean -ffdx
+      # which would delete any previously checked-out untracked directories.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # --- Cross-repo: fetch review-gate tooling from HestAI-MCP ---
+      # Checked out into a subdirectory of the already-checked-out repo.
+      # Must come AFTER the target repo checkout to survive git clean.
+      - name: Checkout review-gate tooling
+        if: steps.context.outputs.mode == 'remote'
+        uses: actions/checkout@v4
+        with:
+          repository: elevanaltd/hestai-context-mcp
+          path: .review-gate-tools
+          sparse-checkout: |
+            scripts/validate_review.py
+            src/hestai_context_mcp/tools/shared/review_formats.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Get PR Number
+        id: pr
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            # For issue_comment events on PRs
+            PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -oE '[0-9]+$')
+            echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          fi
+
+      # --- Comment-event fast path ---
+      # On issue_comment events, the diff hasn't changed — only approvals may have.
+      # Parse the existing status comment for cached tier/reviewers/SHA to avoid
+      # re-running file classification. If the cached SHA matches the PR head,
+      # pass the cached data to validate_review.py via CACHED_GATE_DATA.
+      - name: Extract cached gate data (comment and review events)
+        id: cached_gate
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100
+              });
+
+              const marker = '<!-- review-gate-status -->';
+              // Use reverse search to find the newest marker comment in case
+              // multiple exist (e.g. from workflow re-runs before update logic).
+              const botComment = comments.reverse().find(c =>
+                c.user.type === 'Bot' && c.body.includes(marker)
+              );
+
+              if (botComment) {
+                const dataMatch = botComment.body.match(/<!-- review-gate-data:(.*?) -->/);
+                if (dataMatch) {
+                  const cached = JSON.parse(dataMatch[1]);
+                  // Get current PR data to compare against cached SHAs
+                  const { data: pr } = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber
+                  });
+                  const headSha = pr.head.sha;
+                  const baseSha = pr.base.sha;
+
+                  if (cached.sha && cached.sha !== 'unknown' && cached.sha === headSha) {
+                    // Head SHA matches — now check base branch tip SHA to detect base movement.
+                    // If base_sha is missing from cached data (old format), treat as cache miss.
+                    if (!cached.base_sha) {
+                      console.log('Cache miss: cached data missing base_sha (old format)');
+                      core.setOutput('cache_hit', 'false');
+                    } else if (cached.base_sha !== baseSha) {
+                      console.log(`Cache miss: base branch moved (cached base=${cached.base_sha.substring(0, 7)}, current=${baseSha.substring(0, 7)})`);
+                      core.setOutput('cache_hit', 'false');
+                    } else {
+                      console.log(`Fast path: cached SHA ${cached.sha.substring(0, 7)} matches PR head, base ${baseSha.substring(0, 7)} matches`);
+                      core.setOutput('cache_hit', 'true');
+                      core.setOutput('cached_data', JSON.stringify(cached));
+                    }
+                  } else {
+                    console.log(`Cache miss: cached SHA=${cached.sha || 'none'}, head SHA=${headSha}`);
+                    core.setOutput('cache_hit', 'false');
+                  }
+                } else {
+                  console.log('No cached gate data found in status comment');
+                  core.setOutput('cache_hit', 'false');
+                }
+              } else {
+                console.log('No review-gate status comment found');
+                core.setOutput('cache_hit', 'false');
+              }
+            } catch (error) {
+              console.warn('Failed to extract cached gate data:', error.message);
+              core.setOutput('cache_hit', 'false');
+            }
+
+      - name: Check Review Requirements
+        id: review_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CI: true
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CACHED_GATE_DATA: ${{ steps.cached_gate.outputs.cached_data || '' }}
+        run: |
+          # Universal PR checkout - works for both same-repo and fork PRs
+
+          # Get base ref for comparison
+          if [ "$EVENT_NAME" = "pull_request" ] || [ -n "$PR_BASE_REF" ]; then
+            BASE_REF="$PR_BASE_REF"
+          else
+            # For issue_comment or workflow_call events, fetch PR details via API
+            PR_DATA=$(gh pr view "$PR_NUMBER" --json baseRefName)
+            BASE_REF=$(echo "$PR_DATA" | jq -r '.baseRefName')
+          fi
+
+          echo "PR Number: $PR_NUMBER"
+          echo "Base ref: $BASE_REF"
+
+          # Fetch base branch
+          git fetch origin "$BASE_REF"
+          export GITHUB_BASE_REF="origin/$BASE_REF"
+
+          # Fetch and checkout PR using GitHub's universal PR ref
+          # This works for all PRs (same-repo and forks)
+          git fetch origin "refs/pull/$PR_NUMBER/head:pr-$PR_NUMBER"
+          git checkout "pr-$PR_NUMBER"
+
+          # Run validation using context-appropriate script path
+          SCRIPT_PATH="${{ steps.context.outputs.script_path }}"
+          echo "Running: python3 $SCRIPT_PATH"
+
+          set +e  # Don't exit on error
+          OUTPUT=$(python3 "$SCRIPT_PATH" 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          # Save output for next step
+          echo "$OUTPUT"
+          echo "$OUTPUT" > /tmp/review_output.txt
+
+          # Set output for next step
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+
+          exit $EXIT_CODE
+
+      - name: Update PR Status
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          REVIEW_EXIT_CODE: ${{ steps.review_check.outputs.exit_code }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = process.env.PR_NUMBER;
+            const exitCode = process.env.REVIEW_EXIT_CODE;
+            const success = exitCode === '0';
+
+            // Read validation output if available
+            let validationOutput = '';
+            try {
+              validationOutput = fs.readFileSync('/tmp/review_output.txt', 'utf8');
+            } catch (e) {
+              validationOutput = 'Unable to read validation output';
+            }
+
+            // Parse key information from output.
+            // Strategy: Try structured JSON first (emitted by validate_review.py v2.1+),
+            // fall back to regex parsing for backward compatibility with older versions
+            // that cross-repo callers might still reference.
+            let gateData = null;
+            const jsonMatch = validationOutput.match(/<!-- REVIEW_GATE_JSON:(.*?) -->/);
+            if (jsonMatch) {
+              try {
+                gateData = JSON.parse(jsonMatch[1]);
+                console.log('Parsed structured JSON from validate_review.py');
+              } catch (e) {
+                console.warn('Failed to parse REVIEW_GATE_JSON, falling back to regex:', e.message);
+              }
+            }
+
+            // Extract tier, reason, roles, and provenance — prefer JSON, fall back to regex
+            let tier, reason, roles, provenance;
+            if (gateData) {
+              tier = gateData.tier || 'UNKNOWN';
+              reason = gateData.reason || '';
+              roles = (gateData.reviewers || []).sort();
+              // Per-role provenance map (issue #412): { ROLE: [DIFF|HEAD|BASE|PR_BODY] }.
+              provenance = (gateData.provenance && typeof gateData.provenance === 'object')
+                ? gateData.provenance
+                : {};
+            } else {
+              // Regex fallback for backward compatibility
+              const tierMatch = validationOutput.match(/📋 Review Tier: (\S+)/);
+              const reasonMatch = validationOutput.match(/Reason: (.+)/);
+              const rolesMatch = validationOutput.match(/Reviewers: \[([^\]]+)\]/);
+              tier = tierMatch ? tierMatch[1] : 'UNKNOWN';
+              reason = reasonMatch ? reasonMatch[1] : '';
+              roles = rolesMatch ? rolesMatch[1].split(', ').sort() : [];
+              provenance = {};
+            }
+
+            // Render the per-role provenance table (issue #412 §4). Source labels
+            // map to human-readable origins. A role contributed ONLY by BASE
+            // (present in the base blob, removed in head) shows `BASE` alone — the
+            // visible audit trail of an attempted downgrade that set-union refused.
+            // Returns '' when no escalation provenance is present (pure diff-shape).
+            function renderProvenance(roleList, prov) {
+              // Only render when at least one role was escalated by a declaration
+              // (i.e. a non-DIFF source contributed). Pure diff-shape PRs stay quiet.
+              const escalated = roleList.some(r => {
+                const s = prov[r];
+                return Array.isArray(s) && s.some(x => x !== 'DIFF');
+              });
+              if (!escalated) return '';
+              // Sources: DIFF=facets, HEAD/BASE=blob declaration, PR_BODY=declared in PR body.
+              // BASE-only = role was present in base but removed in head (ratchet retained it).
+              let table = '**Required reviewers** (sources: DIFF=facets, HEAD/BASE=blob, PR\\_BODY=PR body):\n';
+              table += '```\n';
+              for (const role of roleList) {
+                const srcs = Array.isArray(prov[role]) ? prov[role] : [];
+                // Pad role to 5 chars for column alignment (e.g. "TMG  — ...").
+                const padded = (role + '     ').slice(0, 5);
+                table += `${padded}— ${srcs.join(', ') || 'DIFF'}\n`;
+              }
+              table += '```\n';
+              return table;
+            }
+            const provenanceTable = renderProvenance(roles, provenance);
+
+            // Build status message
+            const status = success ? '✅' : '❌';
+            let message = '';
+
+            if (success) {
+              message = '**Review requirements satisfied**\n\n';
+              message += `**Tier**: ${tier}\n`;
+              message += validationOutput.includes('TIER_0_EXEMPT')
+                ? '✓ Exempt from review (docs/tests only)\n'
+                : '✓ Required approvals found\n';
+              if (provenanceTable) {
+                message += '\n' + provenanceTable;
+              }
+            } else {
+              message = '**Review requirements not met**\n\n';
+              message += `**Tier**: ${tier}\n`;
+
+              if (reason) {
+                message += `**Reason**: ${reason}\n\n`;
+              }
+
+              if (provenanceTable) {
+                message += provenanceTable + '\n';
+              }
+
+              // Extract required reviewers dynamically from validation output.
+              // The validator prints lines like "   - 'CE APPROVED: [assessment]' (or CE GO:)"
+              // for each required role. Parse these to build the guidance block.
+              if (tier === 'TIER_1_SELF') {
+                message += '**Required**: Self-review or HO supervisory review:\n';
+                message += '```\n{your-role} SELF-REVIEWED: [your rationale]\n-- or --\nHO REVIEWED: [rationale after delegated work]\n```\nAny role or name accepted (e.g., IL, skills-expert, Shaun).\n';
+              } else {
+                if (roles.length > 0) {
+                  message += `**Required**: ${roles.join(' + ')} approval:\n`;
+                  message += '```\n';
+                  for (const role of roles) {
+                    message += `${role} APPROVED: [assessment] (or ${role} GO:)\n`;
+                  }
+                  message += '```\n';
+                } else {
+                  message += '**Required**: See validation output for details\n';
+                }
+              }
+
+              message += '\n<details><summary>📋 Full Validation Output</summary>\n\n';
+              message += '```\n' + validationOutput + '\n```\n';
+              message += '</details>\n';
+            }
+
+            // Embed structured gate data as HTML comment for comment-event fast path.
+            // On issue_comment events, the gate can parse this cached data instead of
+            // re-running full file classification (the diff hasn't changed).
+            // Include both head SHA and base branch SHA to detect base branch movement.
+            const sha = gateData ? (gateData.sha || 'unknown') : 'unknown';
+            let base_sha = 'unknown';
+            try {
+              const { data: prData } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              base_sha = prData.base.sha || 'unknown';
+            } catch (e) {
+              console.warn('Failed to fetch PR base SHA for caching:', e.message);
+            }
+            // Persist provenance in the cached payload so the comment-event fast
+            // path (which skips re-classification) can re-render the audit trail
+            // without re-reading the base/head blobs.
+            const cachedData = JSON.stringify({ tier, reason, roles, sha, base_sha, provenance });
+            const dataComment = `<!-- review-gate-data:${cachedData} -->`;
+
+            // Add or update status comment
+            const marker = '<!-- review-gate-status -->';
+            const body = `${marker}\n${dataComment}\n## Review Gate Status: ${status}\n\n${message}\n\n<sub>Evaluated at commit ${sha.substring(0, 7)}</sub>`;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100
+              });
+
+              const botComment = comments.find(c =>
+                c.user.type === 'Bot' && c.body.includes(marker)
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body
+                });
+                console.log('Updated existing review status comment');
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body
+                });
+                console.log('Created new review status comment');
+              }
+            } catch (error) {
+              console.error('Failed to update PR comment:', error);
+              core.setFailed(`Failed to update PR status: ${error.message}`);
+            }
+
+      # --- Set commit status on PR head SHA ---
+      # GitHub Actions creates check runs on the default branch for issue_comment
+      # triggers, NOT on the PR's head SHA. This means the PR's check status badge
+      # doesn't update when approvals are posted via comments. To fix this, we
+      # explicitly set a commit status on the PR's head SHA using the Statuses API.
+      # This runs for both pull_request and issue_comment events so the "Review Gate"
+      # status is always consistent. Skipped for workflow_call (remote repos handle
+      # their own status).
+      - name: Set commit status on PR head
+        if: always() && steps.context.outputs.mode == 'local'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REVIEW_EXIT_CODE: ${{ steps.review_check.outputs.exit_code }}
+        run: |
+          # Get the PR's head SHA
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # For issue_comment events, fetch from API
+            PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
+          fi
+
+          if [ -z "$PR_HEAD_SHA" ]; then
+            echo "::warning::Could not determine PR head SHA, skipping commit status"
+            exit 0
+          fi
+
+          # Determine pass/fail from exit code
+          if [ "$REVIEW_EXIT_CODE" = "0" ]; then
+            STATE="success"
+            DESC="All required approvals found"
+          else
+            STATE="failure"
+            DESC="Review requirements not met"
+          fi
+
+          echo "Setting commit status: state=$STATE on SHA=$PR_HEAD_SHA"
+
+          # Set commit status on PR head SHA
+          gh api "repos/${{ github.repository }}/statuses/$PR_HEAD_SHA" \
+            -f state="$STATE" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f description="$DESC" \
+            -f context="Review Gate"
+
+      # AI code review bots (all advisory, non-blocking):
+      # - Cubic Dev AI: auto-reviews on PR activity (no configuration available)
+      # - GitHub Copilot: auto-reviews on PR activity
+      #
+      # The CRS/CE chain (via submit-review tool) remains the structural gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ markers = [
     "behavior: executable behavior tests",
     "contract: interaction/contract tests",
     "integration: full integration tests",
+    "security: security-focused tests (spoofing, injection, bypass)",
 ]
 addopts = [
     "--cov=hestai_context_mcp",

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -847,7 +847,7 @@ def check_pr_comments(
         # contains "APPROVED", "GO", etc. which would falsely clear the gate.
         def _is_bot_comment(comment: dict[str, Any]) -> bool:
             """Check if a comment or review is from a bot author."""
-            login = comment.get("author", {}).get("login", "")
+            login = (comment.get("author") or {}).get("login", "")
             if login in _BOT_LOGIN_SET:
                 return True
             # Catch any other [bot]-suffixed accounts (GitHub convention)
@@ -865,7 +865,7 @@ def check_pr_comments(
         skipped_bots: list[str] = []
         for c in pr_data.get("comments", []):
             if _is_bot_comment(c):
-                bot_login = c.get("author", {}).get("login", "unknown")
+                bot_login = (c.get("author") or {}).get("login", "unknown")
                 skipped_bots.append(bot_login)
             else:
                 searchable_texts.append(c.get("body", ""))
@@ -881,7 +881,7 @@ def check_pr_comments(
             if r.get("state") not in active_review_states:
                 continue
             if _is_bot_comment(r):
-                bot_login = r.get("author", {}).get("login", "unknown")
+                bot_login = (r.get("author") or {}).get("login", "unknown")
                 skipped_bots.append(bot_login)
             else:
                 review_body = r.get("body", "")

--- a/scripts/validate_review.py
+++ b/scripts/validate_review.py
@@ -1,0 +1,1406 @@
+#!/usr/bin/env python3
+"""
+Review validation script - enforces review requirements based on PR changes.
+Called by pre-commit hooks and CI pipeline.
+
+Version: 2.0.0 (SECURITY: Fail-closed error handling)
+Source: https://github.com/elevanaltd/HestAI-MCP
+Last updated: 2026-01-19
+Breaking Change: Now exits non-zero on CI failures (was: fail-open)
+"""
+
+# Critical-Engineer: consulted for Review-gate fail-closed validation
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# --- Advisory bot accounts ---
+# Bot comments are ADVISORY ONLY: they provide context for reviewers but NEVER
+# satisfy or block review gates.  The canonical list uses GitHub's [bot] suffix
+# convention; _BOT_LOGIN_SET is derived for comment filtering.
+ADVISORY_BOTS: list[str] = [
+    "cubic-dev-ai[bot]",
+    "github-copilot[bot]",
+]
+
+# --- Known bot account logins whose comments must be excluded from approval matching ---
+# Derived from ADVISORY_BOTS (strip "[bot]" suffix) plus legacy login variants
+# that GitHub may use for the same accounts.
+# NOTE: This set has a DIFFERENT lifecycle from ADVISORY_BOTS.  A bot removed
+# from ADVISORY_BOTS (e.g., Qodo) must STAY here so its comments can never
+# satisfy an approval gate — even if we no longer surface it in advisory output.
+_BOT_LOGIN_SET: frozenset[str] = frozenset(
+    {name.removesuffix("[bot]") for name in ADVISORY_BOTS}
+    | {
+        "github-actions",
+        "copilot",  # Legacy login variant for github-copilot[bot]
+        "Copilot",  # GitHub API returns capital-C variant
+        "cubic-bot",
+        "qodo-code-review",  # Removed from ADVISORY_BOTS but kept for gate exclusion
+        "qodo-merge-pro",
+        "qodo-merge-pro-for-open-source",
+    }
+)
+
+
+def get_changed_files() -> list[dict[str, Any]]:
+    """Get list of changed files with line counts and file status.
+
+    Each returned dict includes:
+      - path: new file path (or current path for non-renamed files)
+      - added: lines added
+      - deleted: lines deleted
+      - total_changed: added + deleted
+      - status: git status letter (A=added, M=modified, D=deleted, R=renamed)
+      - previous_path: (renames only) the old file path before the rename
+
+    For renamed files, ``previous_path`` is populated so that callers can
+    fetch the BASE blob using the old path (issue #417).
+    """
+    try:
+        # In CI, compare against base branch; locally use cached
+        if "CI" in os.environ:
+            # Get the base branch (usually main)
+            base_ref = os.environ.get("GITHUB_BASE_REF", "origin/main")
+            numstat_cmd = ["git", "diff", f"{base_ref}...HEAD", "--numstat"]
+            status_cmd = ["git", "diff", f"{base_ref}...HEAD", "--name-status"]
+        else:
+            # Local: check staged files
+            numstat_cmd = ["git", "diff", "--cached", "--numstat"]
+            status_cmd = ["git", "diff", "--cached", "--name-status"]
+
+        # Build rename map from --name-status first: old_path -> new_path.
+        # For renames git emits: "R<score>\t<old_path>\t<new_path>"
+        # We key by new_path to match against numstat entries, and store old_path
+        # as previous_path.
+        status_result = subprocess.run(status_cmd, capture_output=True, text=True, check=True)
+        status_map: dict[str, str] = {}  # new_path -> status letter
+        rename_map: dict[str, str] = {}  # new_path -> old_path
+        for line in status_result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                # Status is first char of first field (e.g., "M", "A", "R100")
+                status_letter = parts[0][0]
+                if status_letter == "R" and len(parts) >= 3:
+                    # Rename: parts[1]=old_path, parts[2]=new_path
+                    old_path = parts[1]
+                    new_path = parts[2]
+                    status_map[new_path] = "R"
+                    rename_map[new_path] = old_path
+                else:
+                    filename = parts[-1]  # Last field is the path
+                    status_map[filename] = status_letter
+
+        # Get diff stats (line counts).
+        # --numstat for renamed files emits either:
+        #   <added>\t<deleted>\t<old_path>\t<new_path>  (4 fields, with -M)
+        # or the brace-notation form:
+        #   <added>\t<deleted>\t{old => new}  (3 fields)
+        # We normalise both: for the 4-field form use new_path (parts[3]); for
+        # the 3-field form use rename_map to resolve the correct new_path key.
+        result = subprocess.run(numstat_cmd, capture_output=True, text=True, check=True)
+
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) == 4:
+                # 4-field rename line: added, deleted, old_path, new_path
+                added, deleted, _old, new_path = parts
+                files.append(
+                    {
+                        "path": new_path,
+                        "added": int(added) if added != "-" else 0,
+                        "deleted": int(deleted) if deleted != "-" else 0,
+                        "total_changed": (int(added) if added != "-" else 0)
+                        + (int(deleted) if deleted != "-" else 0),
+                    }
+                )
+            elif len(parts) == 3:
+                added, deleted, filename = parts
+                # Resolve arrow/brace rename notation that real git --numstat emits.
+                # Three forms exist (all 3-field, ' => ' inside the filename field):
+                #   Plain:     "old/path.md => new/path.md"
+                #   Same-dir:  "dir/{old.md => new.md}"
+                #   Cross-dir: "{old/dir => new/dir}/file.md"
+                if " => " in filename:
+                    brace_match = re.search(r"\{([^}]*) => ([^}]*)\}", filename)
+                    if brace_match:
+                        # Replace the entire {old => new} fragment with just the new side.
+                        filename = (
+                            filename[: brace_match.start()]
+                            + brace_match.group(2)
+                            + filename[brace_match.end() :]
+                        )
+                    else:
+                        # Plain "old_path => new_path" — take the new (right) side.
+                        filename = filename.split(" => ", 1)[1]
+                files.append(
+                    {
+                        "path": filename,
+                        "added": int(added) if added != "-" else 0,
+                        "deleted": int(deleted) if deleted != "-" else 0,
+                        "total_changed": (int(added) if added != "-" else 0)
+                        + (int(deleted) if deleted != "-" else 0),
+                    }
+                )
+
+        # Merge status (and previous_path for renames) into file dicts.
+        for f in files:
+            path = f["path"]
+            f["status"] = status_map.get(path, "M")  # Default to M if unknown
+            if path in rename_map:
+                f["previous_path"] = rename_map[path]
+
+        return files
+    except subprocess.CalledProcessError as e:
+        # SECURITY FIX: Fail closed in CI, permissive locally
+        if "CI" in os.environ:
+            print(f"❌ Git command failed in CI: {e}", file=sys.stderr)
+            sys.exit(1)
+        return []
+
+
+def _is_generated_json(path: str) -> bool:
+    """Check if a JSON file is a generated/lock file (exempt) vs hand-edited (not exempt).
+
+    Per governance rule ``**/*.json[when:generated_file]``, JSON is exempt ONLY
+    when it is a generated file. Hand-edited config files (package.json,
+    tsconfig.json, .eslintrc.json, pyrightconfig.json, .vscode/*.json) are NOT
+    exempt because humans maintain them and changes can introduce bugs.
+
+    Only truly auto-generated JSON (lock files, coverage reports) qualifies.
+    """
+    generated_patterns = [
+        r"(^|/)package-lock\.json$",
+        r"(^|/)coverage/.*\.json$",
+    ]
+    return any(re.search(pattern, path) for pattern in generated_patterns)
+
+
+# --- Facet → Required Reviewers mapping ---
+FACET_ROLE_MAP: dict[str, set[str]] = {
+    "META_CONTROL_PLANE": {"CIV", "CE", "CRS", "SR", "TMG"},  # PE excluded: T4 is manual-only
+    "EXECUTABLE_SPEC": {"CE", "CRS", "SR"},
+    "GOVERNANCE": {"SR"},
+    "SECURITY": {"CIV", "CE", "CRS", "TMG"},
+    "ROUTINE_CODE": {"CE", "CRS", "TMG"},
+}
+
+# Hardcoded paths that always trigger META_CONTROL_PLANE
+_META_CONTROL_PLANE_PATHS = {
+    "scripts/validate_review.py",
+    ".github/workflows/review-gate.yml",
+}
+
+# Security path patterns
+_SECURITY_PATTERNS = [
+    r"(^|/)auth/",
+    r"(^|/)session/",
+    r"(^|/)config/env",
+    r"(^|/)path_utils",
+]
+
+# OCTAVE types that classify as EXECUTABLE_SPEC
+_EXECUTABLE_SPEC_TYPES = {"AGENT_DEFINITION", "SKILL"}
+
+
+def _sniff_octave_type(path: str) -> str:
+    """Read META.TYPE from an OCTAVE file. Max 50 lines, fail-safe.
+
+    Args:
+        path: File path to read.
+
+    Returns:
+        The TYPE value string (e.g., 'AGENT_DEFINITION', 'RULE') or empty string.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            for _ in range(50):
+                line = f.readline()
+                if not line:
+                    break
+                if "TYPE::" in line:
+                    parts = line.split("::", 1)
+                    if len(parts) == 2:
+                        return parts[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return ""
+
+
+def _classify_file_facet(path: str) -> str | None:
+    """Classify a single file path into a content facet.
+
+    Returns:
+        Facet name string, or None if the file is exempt.
+    """
+    # Bundled hub skill/pattern files (.md but NOT exempt — governance artifacts)
+    # These define agent behavior and must be classified before exempt check
+    if "/library/skills/" in path and path.endswith("/SKILL.md"):
+        return "EXECUTABLE_SPEC"
+    if "/library/patterns/" in path and path.endswith(".md"):
+        return "EXECUTABLE_SPEC"
+
+    # Exempt patterns
+    exempt_patterns = [
+        r".*(?<!\.oct)\.md$",  # Markdown exempt, but NOT .oct.md
+        r"^tests/.*$",
+        r".*\.lock$",
+    ]
+
+    # Check standard exempt patterns
+    if any(re.match(pattern, path) for pattern in exempt_patterns):
+        return None
+
+    # JSON: only generated ones are exempt
+    if path.endswith(".json"):
+        if _is_generated_json(path):
+            return None
+        # Non-generated JSON is ROUTINE_CODE
+        return "ROUTINE_CODE"
+
+    # META_CONTROL_PLANE: hardcoded paths
+    if path in _META_CONTROL_PLANE_PATHS:
+        return "META_CONTROL_PLANE"
+    # Also match review-requirements.oct.md
+    if "review-requirements.oct.md" in path:
+        return "META_CONTROL_PLANE"
+
+    # .oct.md files: classify by path or sniff TYPE
+    if path.endswith(".oct.md"):
+        # Agent/skill .oct.md files are always EXECUTABLE_SPEC by path
+        # (even if deleted and can't be sniffed for TYPE)
+        if "/library/agents/" in path or "/library/skills/" in path:
+            return "EXECUTABLE_SPEC"
+        # For other .oct.md files, sniff TYPE to distinguish
+        octave_type = _sniff_octave_type(path)
+        if octave_type in _EXECUTABLE_SPEC_TYPES:
+            return "EXECUTABLE_SPEC"
+        # All other .oct.md (RULE, STANDARD, NORTH_STAR_SUMMARY, unknown) -> GOVERNANCE
+        return "GOVERNANCE"
+
+    # Security paths
+    if any(re.search(pattern, path) for pattern in _SECURITY_PATTERNS):
+        return "SECURITY"
+
+    # Architecture/infrastructure paths (base classes, shared modules, hooks, tools, MCP)
+    architecture_patterns = [
+        r"(^|/)base\.py$",
+        r"/shared/",
+        r"(^|/)abstract/",
+        r"(^|/)hooks/",
+        r"(^|/)modules/tools/",
+        r"(^|/)mcp/tools/",
+        r"^clink/agents/",
+    ]
+    if any(re.search(pattern, path) for pattern in architecture_patterns):
+        return "SECURITY"  # Architecture changes require same elevated review as security
+
+    # SQL files -> SECURITY (high-impact data changes)
+    if path.endswith(".sql"):
+        return "SECURITY"
+
+    # Code files (.py, .ts, .js, etc.) -> ROUTINE_CODE
+    code_extensions = {".py", ".ts", ".js", ".tsx", ".jsx", ".sh"}
+    if any(path.endswith(ext) for ext in code_extensions):
+        return "ROUTINE_CODE"
+
+    # YAML, TOML, config files -> ROUTINE_CODE
+    if any(path.endswith(ext) for ext in (".yml", ".yaml", ".toml", ".cfg", ".ini")):
+        return "ROUTINE_CODE"
+
+    # Default: treat as ROUTINE_CODE (fail-safe: gets reviewed)
+    return "ROUTINE_CODE"
+
+
+def classify_pr_facets(
+    files: list[dict[str, Any]],
+    declared_roles: set[str] | None = None,
+) -> tuple[set[str], set[str], str, str]:
+    """Classify PR files into content facets and compute required reviewers.
+
+    Each file is assigned a facet based on its path and content type.
+    Required reviewers = union of all facets' role requirements UNION any
+    ``declared_roles`` (content-aware escalation, issue #412).
+    Tier label is backward-computed from the reviewer set.
+
+    Escalation-only semantics (issue #412): ``declared_roles`` can only ADD
+    required reviewers, never remove them. A non-empty ``declared_roles`` set
+    suppresses BOTH the ``TIER_0_EXEMPT`` (all-exempt) and ``TIER_1_SELF``
+    (small single-file) short-circuits, so a docs-only PR carrying a
+    declaration still escalates to the declared chain. ``declared_roles`` is
+    expected to be pre-filtered through ``ALLOWED_ESCALATION_ROLES`` by
+    :func:`_collect_bitemporal_declarations`.
+
+    Args:
+        files: List of changed file dicts with 'path' and 'total_changed' keys.
+        declared_roles: Optional set of escalation roles unioned in BEFORE the
+            early returns. Must already be whitelist-filtered. Defaults to None
+            (no declaration -> unchanged diff-shape behaviour).
+
+    Returns:
+        Tuple of (facets, required_roles, tier_label, reason):
+        - facets: Set of content facets found (e.g., {'ROUTINE_CODE', 'GOVERNANCE'})
+        - required_roles: Set of reviewer roles needed (e.g., {'CE', 'CRS', 'TMG', 'SR'})
+        - tier_label: Backward-computed display tier (TIER_0_EXEMPT .. TIER_4_STRATEGIC)
+        - reason: Human-readable explanation
+    """
+    declared: set[str] = set(declared_roles) if declared_roles else set()
+
+    facets: set[str] = set()
+    non_exempt_files = []
+
+    for f in files:
+        facet = _classify_file_facet(f["path"])
+        if facet is not None:
+            facets.add(facet)
+            non_exempt_files.append(f)
+
+    # CRITICAL ORDERING (issue #412, comment 4569387061): the declaration union
+    # MUST run BEFORE both early returns. A non-empty declared set suppresses
+    # the TIER_0_EXEMPT (all-exempt) and TIER_1_SELF short-circuits so that a
+    # docs-only / small-single-file PR carrying a declaration still escalates.
+    # If all files are exempt AND nothing was declared, no review needed.
+    if not facets and not declared:
+        return set(), set(), "TIER_0_EXEMPT", "No review required - only exempt files changed"
+
+    # Compute required roles from facets, then union the escalation declaration.
+    required_roles: set[str] = set()
+    for facet in facets:
+        required_roles |= FACET_ROLE_MAP.get(facet, set())
+
+    # Line count escalation: >500 lines adds CIV for elevated review
+    total_lines = sum(f["total_changed"] for f in non_exempt_files)
+    if total_lines > 500 and "CIV" not in required_roles:
+        required_roles.add("CIV")
+
+    # Escalation-only union: declarations can only ADD roles (set-union).
+    required_roles |= declared
+
+    # Check for T1 self-review eligibility. A declaration suppresses self-review.
+    has_new_test_files = any(
+        f.get("status") == "A" and f["path"].startswith("tests/") for f in files
+    )
+
+    if (
+        not declared
+        and total_lines < 10
+        and len(non_exempt_files) == 1
+        and not has_new_test_files
+        and "SECURITY" not in facets
+        and "META_CONTROL_PLANE" not in facets
+        and "EXECUTABLE_SPEC" not in facets
+    ):
+        return (
+            facets,
+            set(),  # No external reviewers needed for T1
+            "TIER_1_SELF",
+            f"Self-review sufficient - {total_lines} lines in single file",
+        )
+
+    # Compute tier label from role set
+    if "PE" in required_roles:
+        tier_label = "TIER_4_STRATEGIC"
+    elif "CIV" in required_roles:
+        tier_label = "TIER_3_CRITICAL"
+    else:
+        tier_label = "TIER_2_STANDARD"
+
+    facet_names = ", ".join(sorted(facets)) if facets else "(none — escalated by declaration)"
+    role_names = ", ".join(sorted(required_roles))
+    reason = f"Facets: [{facet_names}] -> Reviewers: [{role_names}]"
+    if declared:
+        reason += f" (escalated: [{', '.join(sorted(declared))}])"
+    return facets, required_roles, tier_label, reason
+
+
+def determine_review_tier(files: list[dict[str, Any]]) -> tuple[str, str]:
+    """Determine required review tier based on changed files.
+
+    Backward-compatible wrapper around classify_pr_facets(). Returns
+    (tier_label, reason) for callers that only need the tier string.
+    """
+    _, _, tier_label, reason = classify_pr_facets(files)
+    return tier_label, reason
+
+
+# Import shared review format utilities (single source of truth).
+# In CI, the package may not be installed, so we use importlib to load
+# the module file directly without triggering the package's __init__.py.
+try:
+    from hestai_context_mcp.tools.shared.review_formats import (
+        VALID_ROLES as _VALID_ROLES,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_ce_approval as _has_ce_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_civ_approval as _has_civ_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_crs_approval as _has_crs_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_crs_model_approval as _has_crs_model_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_gr_approval as _has_gr_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_ho_review as _has_ho_review,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_pe_approval as _has_pe_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_self_review as _has_self_review,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_sr_approval as _has_sr_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        has_tmg_approval as _has_tmg_approval,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        matches_approval_pattern as _matches_approval_pattern,
+    )
+    from hestai_context_mcp.tools.shared.review_formats import (
+        parse_review_metadata as _parse_review_metadata,
+    )
+except (ImportError, ModuleNotFoundError):
+    # CI fallback: load the module file directly via importlib
+    import importlib.util
+
+    _module_path = (
+        Path(__file__).resolve().parent.parent
+        / "src"
+        / "hestai_context_mcp"
+        / "tools"
+        / "shared"
+        / "review_formats.py"
+    )
+    if not _module_path.exists():
+        raise FileNotFoundError(
+            f"review_formats.py not found at {_module_path}. "
+            "Expected relative to scripts/ directory."
+        ) from None
+    _spec = importlib.util.spec_from_file_location("review_formats", _module_path)
+    if _spec is None or _spec.loader is None:
+        raise FileNotFoundError(
+            f"review_formats.py not found at {_module_path}. "
+            "Expected relative to scripts/ directory."
+        ) from None
+    _review_formats = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_review_formats)
+    _matches_approval_pattern = _review_formats.matches_approval_pattern
+    _has_crs_approval = _review_formats.has_crs_approval
+    _has_crs_model_approval = _review_formats.has_crs_model_approval
+    _has_ce_approval = _review_formats.has_ce_approval
+    _has_ho_review = _review_formats.has_ho_review
+    _has_tmg_approval = _review_formats.has_tmg_approval
+    _has_civ_approval = _review_formats.has_civ_approval
+    _has_pe_approval = _review_formats.has_pe_approval
+    _has_self_review = _review_formats.has_self_review
+    _has_sr_approval = _review_formats.has_sr_approval
+    _has_gr_approval = _review_formats.has_gr_approval
+    _parse_review_metadata = _review_formats.parse_review_metadata
+    _VALID_ROLES = _review_formats.VALID_ROLES
+
+
+# ---------------------------------------------------------------------------
+# Content-aware review-depth escalation (issue #412)
+# ---------------------------------------------------------------------------
+# Escalation-declarable whitelist. Derived from the single source of truth
+# (review_formats.VALID_ROLES) MINUS the self-review roles {IL, HO}: IL and HO
+# review their OWN work and therefore cannot be REQUIRED reviewers via an
+# escalation declaration. Declared tokens are intersected with this set;
+# out-of-set tokens (typos, [GOD_MODE]) are dropped non-fatally and logged.
+ALLOWED_ESCALATION_ROLES: frozenset[str] = frozenset(_VALID_ROLES) - {"IL", "HO"}
+
+# The gate's own rules-schema doc. Its REQUIRED_REVIEWERS:: facet lines and §8
+# marker examples are DESCRIPTIVE config, not a PR-level declaration, so this
+# file is excluded from the declaration scan (matched by basename to cover both
+# the bundled-hub source and the .hestai-sys runtime copy).
+_RULES_SCHEMA_BASENAME = "review-requirements.oct.md"
+
+# Tier -> role table for the `<!-- review-tier: TIER_X -->` marker. Mirrors the
+# backward-computed tier labels in classify_pr_facets (CIV => T3, PE => T4).
+_ESCALATION_TIER_ROLE_MAP: dict[str, set[str]] = {
+    "TIER_2_STANDARD": {"TMG", "CRS", "CE"},
+    "TIER_3_CRITICAL": {"TMG", "CRS", "CE", "CIV"},
+    "TIER_3_STRICT": {"TMG", "CRS", "CE", "CIV"},  # legacy alias
+    "TIER_4_STRATEGIC": {"TMG", "CRS", "CE", "CIV", "PE"},
+}
+
+# Markers (LOCKED schema, issue #412):
+#   <!-- review-requirements: [TMG, CRS, CE, CIV, SR] -->
+#   <!-- review-tier: TIER_3_CRITICAL: reason -->
+_REVIEW_REQUIREMENTS_COMMENT_RE = re.compile(
+    r"<!--\s*review-requirements:\s*\[([^\]]*)\]\s*-->", re.IGNORECASE
+)
+_REVIEW_TIER_COMMENT_RE = re.compile(
+    # Reason is non-greedy and anchored on the comment terminator (\s*-->), so an
+    # embedded '>' in the reason is preserved without over-capturing past `-->`.
+    r"<!--\s*review-tier:\s*(TIER_[0-9A-Z_]+)\s*(?::\s*(.*?))?\s*-->",
+    re.IGNORECASE,
+)
+# OCTAVE block field: REQUIRED_REVIEWERS::"{CE, CRS, SR}" (braces optional).
+_OCTAVE_REQUIRED_REVIEWERS_RE = re.compile(
+    r"^\s*REQUIRED_REVIEWERS\s*::\s*\"?\{?([^}\"\n]*)\}?\"?\s*$", re.MULTILINE
+)
+# YAML frontmatter: review-requirements: [CE, CRS] inside a leading --- block.
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|$)", re.DOTALL)
+_FRONTMATTER_REVIEWERS_RE = re.compile(
+    r"^\s*review-requirements:\s*\[([^\]]*)\]\s*$", re.MULTILINE | re.IGNORECASE
+)
+
+
+def _split_role_tokens(raw: str) -> set[str]:
+    """Split a comma/whitespace-separated role list into upper-cased tokens.
+
+    Tolerant of empty entries and stray whitespace (malformed declarations must
+    not crash — they degrade to whatever parsed cleanly).
+    """
+    tokens: set[str] = set()
+    for piece in re.split(r"[,\s]+", raw.strip()):
+        piece = piece.strip().upper()
+        if piece:
+            tokens.add(piece)
+    return tokens
+
+
+def _parse_review_declaration(text: str) -> dict[str, Any]:
+    """Single extractor for review-escalation declarations (issue #412).
+
+    Handles three declaration surfaces with ONE function (no per-surface
+    duplication):
+      1. OCTAVE block field ``REQUIRED_REVIEWERS::"{CE, CRS, SR}"``
+      2. HTML-comment markers ``<!-- review-requirements: [...] -->`` and
+         ``<!-- review-tier: TIER_X: reason -->``
+      3. YAML frontmatter ``review-requirements: [...]``
+
+    Roles from all matched surfaces are unioned. The ``review-tier`` marker is
+    mapped through the tier->role table. Tokens are NOT whitelist-filtered here
+    (that happens in :func:`_collect_bitemporal_declarations`) so the raw author
+    intent is visible to callers/tests.
+
+    Malformed input never raises: it degrades to an empty/partial result.
+
+    Args:
+        text: Arbitrary document or PR-body text to scan.
+
+    Returns:
+        Dict with optional keys: ``roles`` (set[str]), ``tier`` (str),
+        ``reason`` (str), and ``source`` (str label).
+    """
+    result: dict[str, Any] = {}
+    if not text:
+        return result
+
+    roles: set[str] = set()
+    sources: list[str] = []
+
+    try:
+        # 1. OCTAVE block field
+        for m in _OCTAVE_REQUIRED_REVIEWERS_RE.finditer(text):
+            parsed = _split_role_tokens(m.group(1))
+            if parsed:
+                roles |= parsed
+                sources.append("octave")
+
+        # 2a. HTML-comment review-requirements
+        for m in _REVIEW_REQUIREMENTS_COMMENT_RE.finditer(text):
+            parsed = _split_role_tokens(m.group(1))
+            if parsed:
+                roles |= parsed
+                sources.append("html_requirements")
+
+        # 2b. HTML-comment review-tier
+        tier_match = _REVIEW_TIER_COMMENT_RE.search(text)
+        if tier_match:
+            tier = tier_match.group(1).upper()
+            result["tier"] = tier
+            reason = (tier_match.group(2) or "").strip()
+            if reason:
+                result["reason"] = reason
+            mapped = _ESCALATION_TIER_ROLE_MAP.get(tier)
+            if mapped:
+                roles |= mapped
+                sources.append("html_tier")
+            else:
+                # Unrecognized/misspelled tier (e.g. TIER_0_EXEMPT, a typo like
+                # TIER_3_CRITCAL): contributes no roles. Warn non-fatally so the
+                # author gets a signal instead of a silent no-op. Never raise.
+                print(
+                    f"⚠️  Ignored unrecognized review-tier '{tier}' "
+                    f"(non-fatal): not in the tier->role table "
+                    f"{sorted(_ESCALATION_TIER_ROLE_MAP)}; no roles contributed.",
+                    file=sys.stderr,
+                )
+
+        # 3. YAML frontmatter
+        fm = _FRONTMATTER_RE.match(text)
+        if fm:
+            fm_match = _FRONTMATTER_REVIEWERS_RE.search(fm.group(1))
+            if fm_match:
+                parsed = _split_role_tokens(fm_match.group(1))
+                if parsed:
+                    roles |= parsed
+                    sources.append("frontmatter")
+    except Exception:
+        # Malformed declaration: never crash the gate. Keep whatever parsed.
+        pass
+
+    if roles:
+        result["roles"] = roles
+    if sources:
+        result["source"] = ",".join(sources)
+    return result
+
+
+def _git_show_file(sha: str, path: str) -> str | None:
+    """Return the contents of ``path`` at commit ``sha`` via ``git show``.
+
+    Returns None when the blob does not exist (e.g. a new file has no BASE
+    blob, or a deleted file has no HEAD blob). Never raises: any git failure
+    degrades to None so the bitemporal read is safe on missing blobs.
+    """
+    if not sha:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{sha}:{path}"],
+            capture_output=True,
+            text=True,
+            # A PR may change binary files (png, jpg, …). `git show` emits the
+            # raw blob bytes, which need not be valid UTF-8. Decode with
+            # errors="replace" so a binary blob degrades to a (garbage but
+            # declaration-free) string instead of raising UnicodeDecodeError
+            # and crashing the org-wide gate (I2). check=False keeps a missing
+            # blob (new/deleted file) returning a non-zero rc, handled below.
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        # Missing blob (new/deleted file) or bad ref — treat as absent.
+        return None
+    return result.stdout
+
+
+def _collect_bitemporal_declarations(
+    files: list[dict[str, Any]],
+    pr_body: str = "",
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+) -> tuple[set[str], dict[str, set[str]]]:
+    """Collect escalation declarations across the bitemporal source set.
+
+    Runs the single extractor against FOUR sources and unions them
+    (issue #412)::
+
+        Required_Roles = Base_Roles ∪ Head_Roles ∪ PR_Body_Roles  (∪ Diff later)
+
+    Per the debate contribution, set-union makes escalation-only an *emergent*
+    property: an author cannot relax the gate by deleting a declaration in a
+    later commit because the BASE blob still contributes the role. The result is
+    intersected with :data:`ALLOWED_ESCALATION_ROLES`; out-of-set tokens are
+    dropped non-fatally and logged. Missing base/head blobs (new/deleted files)
+    are handled gracefully — :func:`_git_show_file` returns None and that source
+    contributes nothing.
+
+    Args:
+        files: Changed-file dicts (need a 'path' key).
+        pr_body: The PR description text.
+        base_sha: Base commit SHA (``pr.base.sha``) for BASE blob reads.
+        head_sha: Head commit SHA (``pr.head.sha``) for HEAD blob reads.
+
+    Returns:
+        Tuple ``(declared_roles, provenance)`` where:
+        - declared_roles: whitelist-filtered union of all declared roles.
+        - provenance: maps each surviving role -> set of contributing source
+          labels drawn from {"HEAD", "BASE", "PR_BODY"}.
+    """
+    provenance: dict[str, set[str]] = {}
+    dropped: set[str] = set()
+
+    def _ingest(text: str | None, source_label: str) -> None:
+        if not text:
+            return
+        decl = _parse_review_declaration(text)
+        declared = decl.get("roles")
+        if not declared:
+            return
+        for role in declared:
+            if role in ALLOWED_ESCALATION_ROLES:
+                provenance.setdefault(role, set()).add(source_label)
+            else:
+                dropped.add(role)
+
+    # PR body
+    _ingest(pr_body, "PR_BODY")
+
+    # Per-file BASE and HEAD blobs
+    for f in files:
+        path = f.get("path")
+        if not path:
+            continue
+        # Exclude the gate's OWN rules-schema doc from the declaration scan.
+        # review-requirements.oct.md uses REQUIRED_REVIEWERS:: DESCRIPTIVELY to
+        # define per-facet reviewers (and §8 quotes the marker examples); those
+        # are the gate's config, NOT a PR-level declaration. Match by basename
+        # so BOTH the bundled-hub source and the .hestai-sys runtime copy are
+        # skipped as declaration SOURCES. The file still routes via its facet
+        # (META_CONTROL_PLANE) and the PR-body marker path is unaffected.
+        if os.path.basename(path) == _RULES_SCHEMA_BASENAME:
+            continue
+        if base_sha:
+            # For renamed files, the BASE blob lives at the OLD path (previous_path).
+            # Using the new path for the BASE lookup silently misses the declaration
+            # when the file was renamed — breaking the escalation-only ratchet
+            # (issue #417). Fall back to path when previous_path is absent (new/
+            # modified files where old path == new path).
+            base_path = f.get("previous_path", path)
+            _ingest(_git_show_file(base_sha, base_path), "BASE")
+        if head_sha:
+            _ingest(_git_show_file(head_sha, path), "HEAD")
+
+    if dropped:
+        print(
+            f"⚠️  Dropped {len(dropped)} declared role(s) outside "
+            f"ALLOWED_ESCALATION_ROLES (non-fatal): {', '.join(sorted(dropped))}",
+            file=sys.stderr,
+        )
+
+    declared_roles = set(provenance.keys())
+    return declared_roles, provenance
+
+
+def _has_approval(texts: list[str], prefix: str, keyword: str) -> bool:
+    """Check if any text in the list matches the approval pattern."""
+    return any(_matches_approval_pattern(t, prefix, keyword) for t in texts)
+
+
+def check_pr_comments(
+    _tier_or_roles: set[str] | str | None = None,
+    *,
+    required_roles: set[str] | None = None,
+    tier: str = "",
+) -> tuple[bool, str, list[str]]:
+    """Check if required review comments and PR body contain approval patterns.
+
+    Supports two calling conventions for backward compatibility:
+    - New: check_pr_comments(required_roles={'CE', 'CRS'}, tier='TIER_2_STANDARD')
+    - Old: check_pr_comments('TIER_2_STANDARD')  (string -> uses tier->roles mapping)
+
+    For TIER_1_SELF with empty required_roles, falls back to self-review logic.
+    For all other tiers, validates that ALL required_roles have posted approvals.
+
+    Returns:
+        Tuple of (approved, message, missing_roles):
+        - approved: True if all required approvals are present
+        - message: Human-readable status message
+        - missing_roles: List of role names that have NOT yet approved.
+          Empty list when approved=True or in non-CI/error contexts.
+    """
+    # Handle backward compat: positional string arg is the tier (old API)
+    if isinstance(_tier_or_roles, str):
+        tier = _tier_or_roles
+    elif isinstance(_tier_or_roles, set):
+        required_roles = _tier_or_roles
+
+    # In pre-commit context, we can't check PR comments
+    # This would be called from CI with PR number
+    if "CI" not in os.environ:
+        return True, "Skipping comment check in local context", []
+
+    pr_number = os.environ.get("PR_NUMBER")
+    if not pr_number:
+        return False, "❌ PR_NUMBER not set in environment", []
+
+    print(f"   Checking PR #{pr_number} for review comments...")
+
+    # Use gh CLI to get comments, PR body, and PR reviews
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "comments,body,reviews"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pr_data = json.loads(result.stdout)
+
+        # Collect all searchable text: PR body + comment bodies + review bodies
+        # Exclude ALL bot comments/reviews to prevent false positive approval matches.
+        # Bot review prose (Copilot, Cubic, github-actions) often
+        # contains "APPROVED", "GO", etc. which would falsely clear the gate.
+        def _is_bot_comment(comment: dict[str, Any]) -> bool:
+            """Check if a comment or review is from a bot author."""
+            login = comment.get("author", {}).get("login", "")
+            if login in _BOT_LOGIN_SET:
+                return True
+            # Catch any other [bot]-suffixed accounts (GitHub convention)
+            if login.endswith("[bot]"):
+                return True
+            # Legacy marker check for review-gate status comments
+            return "<!-- review-gate-status -->" in comment.get("body", "")
+
+        searchable_texts: list[str] = []
+        pr_body = pr_data.get("body")
+        if pr_body:
+            searchable_texts.append(pr_body)
+
+        # Filter comments, logging any bot comments that are skipped
+        skipped_bots: list[str] = []
+        for c in pr_data.get("comments", []):
+            if _is_bot_comment(c):
+                bot_login = c.get("author", {}).get("login", "unknown")
+                skipped_bots.append(bot_login)
+            else:
+                searchable_texts.append(c.get("body", ""))
+
+        # Include PR review bodies — GitHub PR Reviews (submitted via the Review
+        # button, pulls/{n}/reviews API) are a separate resource from issue-level
+        # comments.  Reviewers who self-review must use state=COMMENTED (GitHub
+        # forbids self-approve).  DISMISSED reviews are excluded: the reviewer
+        # retracted their assessment, so it must not satisfy the gate.
+        # PENDING reviews have not been submitted yet and are also excluded.
+        active_review_states: frozenset[str] = frozenset({"APPROVED", "COMMENTED"})
+        for r in pr_data.get("reviews", []):
+            if r.get("state") not in active_review_states:
+                continue
+            if _is_bot_comment(r):
+                bot_login = r.get("author", {}).get("login", "unknown")
+                skipped_bots.append(bot_login)
+            else:
+                review_body = r.get("body", "")
+                if review_body:
+                    searchable_texts.append(review_body)
+
+        if skipped_bots:
+            print(
+                f"   Skipped {len(skipped_bots)} bot comment(s) "
+                f"(ADVISORY only, not counted for gate): "
+                f"{', '.join(sorted(set(skipped_bots)))}"
+            )
+
+        # --- Metadata extraction and cross-validation ---
+        # Extract structured metadata from all texts for machine-readable checks.
+        # When metadata IS present, also run regex on the same comment.
+        # If regex-extracted verdict contradicts metadata verdict, FAIL
+        # (prevents spoofing: visible "BLOCKED" with hidden metadata "APPROVED").
+        metadata_entries: list[dict[str, str | None]] = []
+        for text in searchable_texts:
+            meta = _parse_review_metadata(text)
+            if meta is not None:
+                metadata_entries.append(meta)
+                # CROSS-VALIDATION: If metadata says a role gave an approval
+                # verdict, the visible text in the same comment MUST also
+                # match that approval via regex. Otherwise reject.
+                meta_role = meta.get("role")
+                meta_verdict = meta.get("verdict")
+                if meta_role and meta_verdict:
+                    # Only cross-validate recognized review roles.
+                    # Unrecognized roles (e.g., agent names like
+                    # "code-review-specialist") cannot satisfy any gate
+                    # check, so mismatched metadata is irrelevant -- not
+                    # a spoofing vector.
+                    if meta_role not in _VALID_ROLES:
+                        continue
+                    # Only cross-validate approval verdicts (not BLOCKED/CONDITIONAL)
+                    approval_keywords = {"APPROVED", "SELF-REVIEWED", "REVIEWED", "GO"}
+                    if meta_verdict in approval_keywords:
+                        # Strip metadata HTML comment lines before regex check so
+                        # the hidden JSON tokens don't satisfy the pattern match.
+                        visible_text = re.sub(r"<!--\s*review:.*?-->\s*", "", text)
+                        # Strip fenced code blocks and inline code so that
+                        # approval text inside code examples cannot spoof the
+                        # cross-validation regex.
+                        visible_text = re.sub(r"```.*?```", "", visible_text, flags=re.DOTALL)
+                        visible_text = re.sub(r"`[^`]+`", "", visible_text)
+                        regex_agrees = _matches_approval_pattern(
+                            visible_text, meta_role, meta_verdict
+                        )
+                        if not regex_agrees:
+                            return (
+                                False,
+                                f"❌ Cross-validation failure: metadata says "
+                                f"{meta_role} {meta_verdict} but visible text "
+                                f"does not match. Possible spoofing detected.",
+                                [],
+                            )
+
+        def _meta_has(
+            role: str,
+            verdict: str,
+            provider: str | None = None,
+        ) -> bool:
+            """Check if metadata entries contain a matching approval."""
+            for entry in metadata_entries:
+                if (
+                    entry.get("role") == role
+                    and entry.get("verdict") == verdict
+                    and (provider is None or entry.get("provider") == provider.lower())
+                ):
+                    return True
+            return False
+
+        # --- Role-based approval checking ---
+        # Role → approval checker dispatch
+        _role_checkers: dict[str, Any] = {
+            "TMG": lambda: _meta_has("TMG", "APPROVED") or _has_tmg_approval(searchable_texts),
+            "CRS": lambda: _meta_has("CRS", "APPROVED") or _has_crs_approval(searchable_texts),
+            "CE": lambda: _meta_has("CE", "APPROVED") or _has_ce_approval(searchable_texts),
+            "CIV": lambda: _meta_has("CIV", "APPROVED") or _has_civ_approval(searchable_texts),
+            "PE": lambda: _meta_has("PE", "APPROVED") or _has_pe_approval(searchable_texts),
+            "SR": lambda: (
+                _meta_has("SR", "APPROVED")
+                or _has_sr_approval(searchable_texts)
+                # Legacy GR visible-text check only (no _meta_has("GR") —
+                # GR not in VALID_ROLES so metadata bypasses cross-validation)
+                or _has_gr_approval(searchable_texts)
+            ),
+        }
+
+        # TIER_1_SELF: self-review logic (no external reviewers required)
+        if tier == "TIER_1_SELF" and (required_roles is None or len(required_roles) == 0):
+            for entry in metadata_entries:
+                if entry.get("verdict") == "SELF-REVIEWED":
+                    return True, "✓ Self-review found (metadata)", []
+            if _meta_has("HO", "REVIEWED"):
+                return True, "✓ HO supervisory review found (metadata)", []
+            if _meta_has("CRS", "APPROVED"):
+                return True, "✓ CRS approval satisfies self-review (metadata)", []
+            if _has_self_review(searchable_texts):
+                return True, "✓ Self-review found", []
+            if _has_approval(searchable_texts, "HO", "REVIEWED"):
+                return True, "✓ HO supervisory review found", []
+            if _has_crs_approval(searchable_texts):
+                return True, "✓ CRS approval satisfies self-review requirement", []
+            return False, "❌ Missing: SELF-REVIEWED or HO REVIEWED comment", []
+
+        # Determine effective roles to check
+        effective_roles = required_roles if required_roles is not None else set()
+
+        # DEPRECATED: Tier-only API cannot distinguish code vs governance PRs.
+        # Use classify_pr_facets() + required_roles for accurate routing.
+        # This fallback maps tiers to code-review roles only (no SR).
+        if not effective_roles and tier:
+            _tier_role_map: dict[str, set[str]] = {
+                "TIER_2_STANDARD": {"TMG", "CRS", "CE"},
+                "TIER_3_CRITICAL": {"TMG", "CRS", "CE", "CIV"},
+                "TIER_4_STRATEGIC": {"TMG", "CRS", "CE", "CIV", "PE"},
+            }
+            effective_roles = _tier_role_map.get(tier, set())
+            if not effective_roles:
+                return False, f"❌ Unrecognized tier: {tier}", []
+
+        # Check each required role (SECURITY: fail-closed for unknown roles)
+        missing_roles: list[str] = []
+        missing_display: list[str] = []
+        for role in sorted(effective_roles):
+            checker = _role_checkers.get(role)
+            if checker is None or not checker():
+                missing_roles.append(role)
+                missing_display.append(f"{role} APPROVED or {role} GO")
+
+        if not missing_roles:
+            role_names = ", ".join(sorted(effective_roles))
+            return True, f"✓ All required approvals found ({role_names})", []
+
+        return False, f"❌ Missing: {', '.join(missing_display)}", missing_roles
+
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        # SECURITY FIX: Fail closed in CI, permissive locally
+        if "CI" in os.environ:
+            return False, f"❌ Error checking PR comments: {e}", []
+        return True, "Unable to check PR comments (local mode)", []
+
+
+def log_emergency_bypass() -> None:
+    """Create audit trail for emergency bypass."""
+    # Create audit directory
+    audit_dir = Path.cwd() / ".hestai" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_log = audit_dir / "bypass-log.jsonl"
+
+    # Get metadata
+    pr_number = os.environ.get("PR_NUMBER", "unknown")
+
+    # Get git user info
+    try:
+        user_name = subprocess.run(
+            ["git", "config", "user.name"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+        user_email = subprocess.run(
+            ["git", "config", "user.email"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        user_name = "unknown"
+        user_email = "unknown"
+
+    # Get commit SHA
+    try:
+        commit_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        commit_sha = "unknown"
+
+    # Create audit entry
+    entry = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "reason": "EMERGENCY_BYPASS",
+        "pr_number": pr_number,
+        "commit": commit_sha,
+        "user_name": user_name,
+        "user_email": user_email,
+    }
+
+    # Append to audit log
+    with open(audit_log, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def check_emergency_bypass() -> bool:
+    """Check if this is an emergency bypass commit."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--pretty=%B"], capture_output=True, text=True, check=True
+        )
+        return "EMERGENCY:" in result.stdout
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _get_head_sha() -> str:
+    """Get the current HEAD commit SHA for tracking in JSON output.
+
+    Returns:
+        The HEAD commit SHA string, or 'unknown' if git rev-parse fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+def _get_pr_body() -> str:
+    """Fetch the PR description text for declaration scanning (issue #412).
+
+    Uses ``gh pr view <PR_NUMBER> --json body``. Returns an empty string outside
+    CI (no PR context), when PR_NUMBER is unset, or on any gh/parse failure —
+    the bitemporal union simply omits the PR_BODY source rather than crashing.
+    """
+    if "CI" not in os.environ:
+        return ""
+    pr_number = os.environ.get("PR_NUMBER")
+    if not pr_number:
+        return ""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "body"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(result.stdout)
+        body = data.get("body")
+        return body if isinstance(body, str) else ""
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError):
+        return ""
+
+
+def _get_base_ref_sha() -> str:
+    """Get the current tip SHA of the base branch.
+
+    Computes ``git rev-parse origin/{base_ref}`` to obtain the same value that
+    the GitHub API returns as ``pr.base.sha``.  The review-gate workflow stores
+    ``pr.base.sha`` (the base branch tip) in its cached data, so the Python
+    validator must resolve the identical commit to keep the fast-path SHA
+    comparison aligned.
+
+    Uses PR_BASE_REF or GITHUB_BASE_REF environment variables to determine
+    the base branch.  Falls back to 'unknown' if git rev-parse fails.
+
+    Returns:
+        The base branch tip SHA string, or 'unknown' on failure.
+    """
+    base_ref = os.environ.get("PR_BASE_REF") or os.environ.get("GITHUB_BASE_REF", "main")
+    # Ensure we have the origin/ prefix for remote comparison
+    if not base_ref.startswith("origin/"):
+        base_ref = f"origin/{base_ref}"
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", base_ref],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+
+
+def _emit_json_summary(
+    tier: str,
+    reason: str,
+    reviewers: list[str],
+    status: str,
+    required_count: int,
+    found_count: int,
+    sha: str = "unknown",
+    provenance: dict[str, list[str]] | None = None,
+) -> None:
+    """Emit a structured JSON summary as an HTML comment for machine parsing.
+
+    The JSON is wrapped in an HTML comment so it doesn't appear in human-readable
+    output but IS captured in the output variable by the CI workflow. The JS parser
+    in review-gate.yml can extract this for structured data instead of relying on
+    fragile regex patterns.
+
+    Format: <!-- REVIEW_GATE_JSON:{"tier":"...","reason":"...","sha":"...",...} -->
+
+    The ``sha`` field tracks which commit the review gate evaluated. Downstream
+    consumers can compare this against the PR head SHA to detect stale approvals
+    when new commits are pushed after approval.
+
+    The ``provenance`` field (issue #412) maps each required role to the list of
+    sources that contributed it — drawn from {"DIFF", "HEAD", "BASE", "PR_BODY"} —
+    so the status comment can render a per-role audit trail. A role present in
+    BASE but absent from HEAD shows ``BASE`` only (visible attempted reduction).
+    """
+    summary = {
+        "tier": tier,
+        "reason": reason,
+        "reviewers": reviewers,
+        "status": status,
+        "required_count": required_count,
+        "found_count": found_count,
+        "sha": sha,
+        "provenance": provenance or {},
+    }
+    print(f"<!-- REVIEW_GATE_JSON:{json.dumps(summary)} -->")
+
+
+def main() -> int:
+    """Main validation logic."""
+
+    # Get HEAD SHA early for inclusion in all JSON output paths
+    head_sha = _get_head_sha()
+
+    # Check for emergency bypass
+    if check_emergency_bypass():
+        print("⚠️  EMERGENCY BYPASS - Review required post-merge")
+        log_emergency_bypass()
+        return 0
+
+    # --- Comment-event fast path ---
+    # When CACHED_GATE_DATA is set (by the workflow on issue_comment events with
+    # matching SHA), skip file classification and use cached tier/reviewers.
+    # The diff hasn't changed — only approvals may have changed.
+    cached_gate_json = os.environ.get("CACHED_GATE_DATA", "")
+    cached_gate: dict[str, Any] | None = None
+    if cached_gate_json:
+        try:
+            cached_gate = json.loads(cached_gate_json)
+            # SHA comparison guard: verify cached data matches current HEAD
+            # before trusting it. Stale data (workflow bug, manual run) must
+            # not silently apply incorrect tier/roles.
+            # Guard against 'unknown' matching 'unknown' when git fails —
+            # both sides returning a placeholder must not enable the fast path.
+            cached_sha_val = cached_gate.get("sha")
+            if cached_sha_val == head_sha and head_sha != "unknown" and cached_sha_val != "unknown":
+                # Base-ref guard: if the base branch moved while the PR head
+                # stayed the same, the diff (and thus file classification) has
+                # changed. Validate base branch tip SHA to detect this.
+                cached_base_sha = cached_gate.get("base_sha")
+                if cached_base_sha is None:
+                    # Backward compatibility: old status comments without base_sha
+                    # must be treated as cache miss to ensure correctness.
+                    print(
+                        "⚠️  Cached data missing base_sha (old format), "
+                        "falling back to normal classification"
+                    )
+                    cached_gate = None
+                else:
+                    base_ref_sha = _get_base_ref_sha()
+                    if base_ref_sha == "unknown" or str(cached_base_sha) != base_ref_sha:
+                        print(
+                            f"⚠️  Base ref SHA {str(cached_base_sha)[:7]} != "
+                            f"current {base_ref_sha[:7]}, "
+                            f"falling back to normal classification"
+                        )
+                        cached_gate = None
+                    else:
+                        print(
+                            f"⚡ Comment-event fast path: cached SHA "
+                            f"{head_sha[:7]} matches HEAD, "
+                            f"base ref {base_ref_sha[:7]} matches"
+                        )
+            else:
+                cached_sha = str(cached_gate.get("sha", "none"))
+                print(
+                    f"⚠️  Cached SHA {cached_sha[:7]} != HEAD {head_sha[:7]}, "
+                    f"falling back to normal classification"
+                )
+                cached_gate = None
+        except (json.JSONDecodeError, TypeError):
+            cached_gate = None
+
+    # Per-role provenance map (issue #412): role -> sorted list of contributing
+    # sources from {"DIFF", "HEAD", "BASE", "PR_BODY"}. Rendered by review-gate.yml.
+    provenance: dict[str, list[str]] = {}
+
+    if cached_gate is not None:
+        tier = str(cached_gate.get("tier", "UNKNOWN"))
+        reason = str(cached_gate.get("reason", ""))
+        required_roles = set(cached_gate.get("roles", []))
+        # Reuse cached provenance when present (display-only; diff unchanged).
+        cached_prov = cached_gate.get("provenance")
+        if isinstance(cached_prov, dict):
+            provenance = {k: list(v) for k, v in cached_prov.items()}
+    else:
+        # Get changed files
+        files = get_changed_files()
+        if not files:
+            print("✓ No files changed")
+            return 0
+
+        # Show changed files summary
+        total_lines = sum(int(f["total_changed"]) for f in files)
+        print(f"📊 Changed Files: {len(files)} files, {total_lines} lines")
+        for f in files[:5]:  # Show first 5
+            print(f"   - {f['path']} (+{f['added']}/-{f['deleted']})")
+        if len(files) > 5:
+            print(f"   ... and {len(files) - 5} more")
+
+        # --- Content-aware escalation: bitemporal declaration union (issue #412) ---
+        # Collect declarations from PR body + BASE blob + HEAD blob per changed
+        # file, intersect with ALLOWED_ESCALATION_ROLES, then union into the
+        # diff-computed floor. Reads are safe on missing blobs (new/deleted files).
+        base_sha = _get_base_ref_sha()
+        pr_body = _get_pr_body()
+        declared_roles, decl_provenance = _collect_bitemporal_declarations(
+            files=files,
+            pr_body=pr_body,
+            base_sha=None if base_sha == "unknown" else base_sha,
+            head_sha=None if head_sha == "unknown" else head_sha,
+        )
+
+        # Classify PR content into facets and compute required reviewers,
+        # unioning the (whitelist-filtered) declared roles BEFORE early returns.
+        _facets, required_roles, tier, reason = classify_pr_facets(
+            files, declared_roles=declared_roles
+        )
+
+        # Compute the diff/facet-only role floor (no declaration) so provenance
+        # can attribute DIFF independently of any declared source. A role that is
+        # BOTH diff-required AND declared must show ALL its sources.
+        _df, diff_roles, _dt, _dr = classify_pr_facets(files)
+
+        # Build the provenance map: every required role gets a source list. A
+        # role's sources are the UNION of its declaration origins (HEAD/BASE/
+        # PR_BODY) and DIFF when it is in the diff/facet floor — a role from
+        # multiple sources shows all of them.
+        for role in sorted(required_roles):
+            sources = set(decl_provenance.get(role, set()))
+            if role in diff_roles:
+                sources.add("DIFF")
+            if not sources:
+                # Defensive: a required role with no traced source (should not
+                # happen) is attributed to DIFF so provenance is never empty.
+                sources.add("DIFF")
+            provenance[role] = sorted(sources)
+
+    print(f"\n📋 Review Tier: {tier}")
+    print(f"   Reason: {reason}")
+
+    # Check if tier is exempt
+    if tier == "TIER_0_EXEMPT":
+        print("✓ Review not required")
+        _emit_json_summary(
+            tier=tier,
+            reason=reason,
+            reviewers=[],
+            status="pass",
+            required_count=0,
+            found_count=0,
+            sha=head_sha,
+        )
+        return 0
+
+    # Check for required approvals
+    approved, message, missing_roles = check_pr_comments(required_roles=required_roles, tier=tier)
+    print(f"   {message}")
+
+    reviewers_list = sorted(required_roles)
+
+    if not approved:
+        # Compute found_count from structured missing_roles data.
+        found_count = len(required_roles) - len(missing_roles)
+
+        print("\n⚠️  Review Requirements:")
+        if tier == "TIER_1_SELF":
+            print("   Add comment: '{your-role} SELF-REVIEWED: [your rationale]'")
+            print("   Any role or name accepted (e.g., IL, skills-expert, Shaun)")
+            print("   -- or --")
+            print("   Add comment: 'HO REVIEWED: [rationale after delegated work]'")
+            print("   Example: 'skills-expert SELF-REVIEWED: Updated GATES section'")
+        else:
+            print("   Need comments:")
+            for role in sorted(required_roles):
+                print(f"   - '{role} APPROVED: [assessment]' (or {role} GO:)")
+
+        _emit_json_summary(
+            tier=tier,
+            reason=reason,
+            reviewers=reviewers_list,
+            status="fail",
+            required_count=len(required_roles),
+            found_count=found_count,
+            sha=head_sha,
+            provenance=provenance,
+        )
+
+        # Only block in CI context
+        if "CI" in os.environ:
+            print("\n❌ Blocking merge - reviews required")
+            return 1
+        else:
+            print("\n   ℹ️  Local check only - not blocking")
+            return 0
+
+    _emit_json_summary(
+        tier=tier,
+        reason=reason,
+        reviewers=reviewers_list,
+        status="pass",
+        required_count=len(required_roles),
+        found_count=len(required_roles),
+        sha=head_sha,
+        provenance=provenance,
+    )
+    print("\n✓ Review requirements satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hestai_context_mcp/tools/shared/review_formats.py
+++ b/src/hestai_context_mcp/tools/shared/review_formats.py
@@ -1,15 +1,23 @@
-"""Shared review format constants and pattern matching utilities.
+"""
+Shared review format constants and pattern matching utilities.
 
-Single source of truth for review comment formats used by the submit_review
-MCP tool. Harvested from hestai-mcp legacy with the proven pattern-matching
-logic for review-gate CI compliance.
+Single source of truth for review comment formats used by both:
+- scripts/validate_review.py (CI gate validation)
+- submit_review MCP tool (programmatic review submission)
 
-Roles: CE, CIV, CRS, HO, IL, PE, SR, TMG
-Verdicts: APPROVED, BLOCKED, CONDITIONAL
+Extracted from validate_review.py to prevent format drift (I2 tension).
 """
 
 import json
 import re
+
+# --- Review tier constants ---
+TIER_0_EXEMPT = "TIER_0_EXEMPT"
+TIER_1_SELF = "TIER_1_SELF"
+TIER_2_STANDARD = "TIER_2_STANDARD"
+TIER_3_STRICT = "TIER_3_STRICT"  # Deprecated: use TIER_3_CRITICAL
+TIER_3_CRITICAL = "TIER_3_CRITICAL"
+TIER_4_STRATEGIC = "TIER_4_STRATEGIC"
 
 # --- Valid roles and verdicts ---
 VALID_ROLES: frozenset[str] = frozenset({"CRS", "CE", "SR", "IL", "HO", "TMG", "CIV", "PE"})
@@ -27,12 +35,24 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
 
     Matches patterns like:
       - 'CRS APPROVED:' (original exact format)
-      - 'CRS (Gemini): APPROVED' (parenthetical model annotation)
-      - 'CRS --- APPROVED' (em dash separator)
+      - 'CRS (Gemini): APPROVED' (parenthetical model annotation with colon)
+      - 'CRS (Gemini) --- APPROVED' (parenthetical with em dash separator)
+      - 'CRS (Gemini) -- APPROVED' (parenthetical with en dash separator)
+      - 'CRS (Gemini) - APPROVED' (parenthetical with hyphen separator)
+      - 'CRS --- APPROVED' (em dash separator, no parenthetical)
+      - 'CRS: APPROVED' (colon separator, no parenthetical)
+      - 'CRS  APPROVED' (extra whitespace)
       - 'IL SELF-REVIEWED:' and 'IL (Claude): SELF-REVIEWED:'
+      - '| CRS | Gemini | **APPROVED** |' (markdown table with bold)
+      - '## TMG APPROVED ✅' (markdown heading, stripped before matching)
+      - '  ## CRS APPROVED:' (indented markdown heading)
 
     Uses word boundaries around both prefix and keyword to prevent false
-    positives. Strips markdown bold/italic formatting before matching.
+    positives (e.g., 'XCRS' must not match 'CRS', 'APPROVEDLY' must not
+    match 'APPROVED').
+
+    Strips markdown bold/italic formatting before matching, then checks
+    each line for both tokens in order with word boundaries.
 
     Args:
         text: The text to search for the approval pattern.
@@ -45,14 +65,23 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
     # Strip markdown bold/italic markers so **APPROVED** matches as APPROVED
     cleaned = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)
 
+    # Role must appear at a line-start position to prevent false positives
+    # from prose like "TMG+CRS+CE+CIV+PE by tier), GO aliases".
+    # Valid positions: actual start of line (with optional whitespace) or
+    # after a markdown table pipe character.
     prefix_re = re.compile(rf"(?:^|(?<=\|))\s*{re.escape(prefix)}\b", re.MULTILINE | re.IGNORECASE)
     keyword_re = re.compile(rf"\b{re.escape(keyword)}\b", re.IGNORECASE)
+    # Strip markdown heading markers (##, ###, etc.) per-line so agents that
+    # write '## TMG APPROVED ✅' are accepted alongside the canonical format.
+    heading_re = re.compile(r"^\s*#{1,6}\s*")
 
     for line in cleaned.splitlines():
-        prefix_match = prefix_re.search(line)
+        stripped = heading_re.sub("", line)
+        prefix_match = prefix_re.search(stripped)
         if not prefix_match:
             continue
-        keyword_match = keyword_re.search(line, prefix_match.end())
+        # Keyword must appear after the prefix on the same line
+        keyword_match = keyword_re.search(stripped, prefix_match.end())
         if keyword_match:
             return True
 
@@ -65,38 +94,79 @@ def _has_approval(texts: list[str], prefix: str, keyword: str) -> bool:
 
 
 def has_crs_approval(texts: list[str]) -> bool:
-    """Check if any text contains a CRS approval (APPROVED or GO)."""
+    """Check if any text contains a CRS approval (APPROVED or GO).
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if CRS approval found.
+    """
     return _has_approval(texts, "CRS", "APPROVED") or _has_approval(texts, "CRS", "GO")
 
 
+def has_crs_model_approval(texts: list[str], model: str) -> bool:
+    """Check if any text contains a CRS approval from a specific model.
+
+    Matches patterns like 'CRS (Gemini) APPROVED:' or 'CRS (Gemini): GO'.
+    The model tag must be directly followed by the approval keyword with only
+    separator characters (whitespace, colon, dashes) in between. This prevents
+    spoofing where a single APPROVED keyword satisfies multiple model checks,
+    or where intervening tokens like BLOCKED are ignored.
+
+    Note: this function does NOT strip markdown heading markers. It is
+    intentionally stricter than matches_approval_pattern() — its purpose is
+    spoofing prevention (ensuring a specific model name is present), not
+    format tolerance.
+
+    Args:
+        texts: List of comment/body texts to search.
+        model: The model name to match (e.g., 'Gemini', 'Codex').
+
+    Returns:
+        True if model-specific CRS approval found.
+    """
+    # Strict pattern: CRS(model) followed by only separator chars then APPROVED|GO.
+    # Allowed separators: whitespace, colon, em dash, en dash, hyphen (0 or more).
+    # No arbitrary tokens (like "and CRS (Codex)" or "BLOCKED") permitted between.
+    # CRS must appear at line-start position (same rule as matches_approval_pattern).
+    pattern = re.compile(
+        rf"(?:^|(?<=\|))\s*CRS\s*\(\s*{re.escape(model)}\s*\)\s*[:—–\-]*\s*(?:APPROVED|GO)\b",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    for text in texts:
+        # Strip markdown bold/italic markers
+        cleaned = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)
+        for line in cleaned.splitlines():
+            if pattern.search(line):
+                return True
+    return False
+
+
 def has_ce_approval(texts: list[str]) -> bool:
-    """Check if any text contains a CE approval (APPROVED or GO)."""
+    """Check if any text contains a CE approval (APPROVED or GO).
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if CE approval found.
+    """
     return _has_approval(texts, "CE", "APPROVED") or _has_approval(texts, "CE", "GO")
 
 
-def has_tmg_approval(texts: list[str]) -> bool:
-    """Check if any text contains a TMG approval (APPROVED or GO)."""
-    return _has_approval(texts, "TMG", "APPROVED") or _has_approval(texts, "TMG", "GO")
-
-
-def has_civ_approval(texts: list[str]) -> bool:
-    """Check if any text contains a CIV approval (APPROVED or GO)."""
-    return _has_approval(texts, "CIV", "APPROVED") or _has_approval(texts, "CIV", "GO")
-
-
-def has_pe_approval(texts: list[str]) -> bool:
-    """Check if any text contains a PE approval (APPROVED or GO)."""
-    return _has_approval(texts, "PE", "APPROVED") or _has_approval(texts, "PE", "GO")
-
-
-def has_sr_approval(texts: list[str]) -> bool:
-    """Check if any text contains an SR approval (APPROVED or GO)."""
-    return _has_approval(texts, "SR", "APPROVED") or _has_approval(texts, "SR", "GO")
-
-
 # Compiled regex for role-agnostic self-review matching.
+# Matches any word (including hyphenated identifiers like "skills-expert")
+# at line-start position (consistent with matches_approval_pattern),
+# optionally followed by a parenthetical model annotation and separators,
+# then SELF-REVIEWED with word boundary.
 _SELF_REVIEW_RE = re.compile(
-    r"(?:^|(?<=\|))\s*" r"\w[\w-]*" r"(?:\s*\([^)]*\))?" r"[\s:—–\-]*" r"SELF-REVIEWED\b",
+    r"(?:^|(?<=\|))\s*"  # Line-start or after pipe (consistent with approval matcher)
+    r"\w[\w-]*"  # Role/name word (e.g., IL, skills-expert, Shaun)
+    r"(?:\s*\([^)]*\))?"  # Optional parenthetical (e.g., (Claude))
+    r"[\s:—–\-]*"  # Separators (whitespace, colon, dashes)
+    r"SELF-REVIEWED\b",  # Keyword with word boundary
     re.MULTILINE | re.IGNORECASE,
 )
 
@@ -106,6 +176,14 @@ def has_self_review(texts: list[str]) -> bool:
 
     Role-agnostic: matches any word/identifier followed by SELF-REVIEWED.
 
+    Matches patterns like:
+      - 'IL SELF-REVIEWED: fixed typo'
+      - 'skills-expert SELF-REVIEWED: updated GATES'
+      - 'Shaun SELF-REVIEWED: quick config change'
+      - 'IL (Claude): SELF-REVIEWED: quick fix' (via flexible matching)
+
+    A bare 'SELF-REVIEWED' without a preceding role/name does NOT match.
+
     Args:
         texts: List of comment/body texts to search.
 
@@ -113,6 +191,7 @@ def has_self_review(texts: list[str]) -> bool:
         True if any text contains a valid self-review pattern.
     """
     for text in texts:
+        # Strip markdown bold/italic markers for consistency
         cleaned = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)
         for line in cleaned.splitlines():
             if _SELF_REVIEW_RE.search(line):
@@ -120,9 +199,110 @@ def has_self_review(texts: list[str]) -> bool:
     return False
 
 
+def has_il_self_review(texts: list[str]) -> bool:
+    """Check if any text contains an IL self-review.
+
+    Deprecated: Use has_self_review() for role-agnostic matching.
+    Kept for backward compatibility.
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if IL SELF-REVIEWED found.
+    """
+    return has_self_review(texts)
+
+
 def has_ho_review(texts: list[str]) -> bool:
-    """Check if any text contains an HO supervisory review (REVIEWED)."""
+    """Check if any text contains an HO supervisory review.
+
+    When HO delegates to IL and then reviews the work, this constitutes
+    a supervisory review (higher authority than self-review) and satisfies T1.
+
+    Matches patterns like:
+      - 'HO REVIEWED: delegated to IL, verified output'
+      - 'HO (Claude): REVIEWED: verified'
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if HO REVIEWED found.
+    """
     return _has_approval(texts, "HO", "REVIEWED")
+
+
+def has_tmg_approval(texts: list[str]) -> bool:
+    """Check if any text contains a TMG approval (APPROVED or GO).
+
+    TMG (Test Methodology Guardian) validates test coverage and quality.
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if TMG approval found.
+    """
+    return _has_approval(texts, "TMG", "APPROVED") or _has_approval(texts, "TMG", "GO")
+
+
+def has_civ_approval(texts: list[str]) -> bool:
+    """Check if any text contains a CIV approval (APPROVED or GO).
+
+    CIV (Critical Implementation Validator) validates implementation
+    correctness against specifications.
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if CIV approval found.
+    """
+    return _has_approval(texts, "CIV", "APPROVED") or _has_approval(texts, "CIV", "GO")
+
+
+def has_pe_approval(texts: list[str]) -> bool:
+    """Check if any text contains a PE approval (APPROVED or GO).
+
+    PE (Principal Engineer) validates long-term architectural sustainability.
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if PE approval found.
+    """
+    return _has_approval(texts, "PE", "APPROVED") or _has_approval(texts, "PE", "GO")
+
+
+def has_sr_approval(texts: list[str]) -> bool:
+    """Check if any text contains an SR approval (APPROVED or GO).
+
+    SR (Standards Reviewer) validates system standards documentation for
+    alignment, contradiction detection, completeness, and structural integrity.
+
+    Args:
+        texts: List of comment/body texts to search.
+
+    Returns:
+        True if SR approval found.
+    """
+    return _has_approval(texts, "SR", "APPROVED") or _has_approval(texts, "SR", "GO")
+
+
+def has_gr_approval(texts: list[str]) -> bool:
+    """Check if any text contains a GR or SR approval (APPROVED or GO).
+
+    Deprecated: Use has_sr_approval(). GR was renamed to SR (Standards Reviewer).
+    Kept for backward compatibility -- matches both GR and SR prefixes so
+    legacy "GR APPROVED" comments still clear the gate.
+    """
+    return (
+        has_sr_approval(texts)
+        or _has_approval(texts, "GR", "APPROVED")
+        or _has_approval(texts, "GR", "GO")
+    )
 
 
 def format_review_comment(
@@ -135,14 +315,18 @@ def format_review_comment(
     """Format a review comment that will clear the review gate.
 
     Produces comments in the canonical format that matches_approval_pattern()
-    will accept. For IL role with APPROVED verdict, the keyword is mapped to
-    SELF-REVIEWED. For HO role with APPROVED verdict, the keyword is mapped
-    to REVIEWED.
+    will accept. This ensures submit_review produces gate-clearing comments.
 
-    Appends a machine-readable metadata HTML comment on a second line.
+    For IL role with APPROVED verdict, the keyword is mapped to SELF-REVIEWED.
+    For HO role with APPROVED verdict, the keyword is mapped to REVIEWED.
+    For BLOCKED/CONDITIONAL verdicts, the comment uses the verdict directly
+    (these don't clear the gate but are valid review comments).
+
+    Appends a machine-readable metadata HTML comment on a second line for
+    structured audit trail parsing.
 
     Args:
-        role: Reviewer role (TMG, CRS, CE, CIV, PE, IL, HO, SR).
+        role: Reviewer role (TMG, CRS, CE, CIV, PE, IL, HO).
         verdict: Review verdict (APPROVED, BLOCKED, CONDITIONAL).
         assessment: Review assessment content.
         model_annotation: Optional model name (e.g., 'Gemini') for annotation.
@@ -180,3 +364,48 @@ def format_review_comment(
     meta_line = f"<!-- review: {meta_json} -->"
 
     return f"{human_line}\n{meta_line}"
+
+
+# --- Metadata regex for parsing structured review metadata ---
+_METADATA_RE = re.compile(r"<!-- review: (\{.*?\}) -->")
+
+
+def parse_review_metadata(text: str) -> dict[str, str | None] | None:
+    """Extract structured metadata from a review comment.
+
+    Looks for ``<!-- review: {...} -->`` HTML comment and parses the JSON.
+
+    Args:
+        text: Review comment text to parse.
+
+    Returns:
+        Parsed metadata dict or None if not found or invalid.
+    """
+    # Strip markdown code blocks and inline code to avoid matching
+    # example metadata in documentation (e.g., PR body with backtick-quoted examples).
+    stripped = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    stripped = re.sub(r"`[^`]+`", "", stripped)
+    match = _METADATA_RE.search(stripped)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(1))  # type: ignore[no-any-return]
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def extract_review_metadata(texts: list[str]) -> list[dict[str, str | None]]:
+    """Batch extraction of metadata from multiple comments.
+
+    Args:
+        texts: List of comment texts to scan.
+
+    Returns:
+        List of parsed metadata dicts (only for comments that have metadata).
+    """
+    results: list[dict[str, str | None]] = []
+    for text in texts:
+        meta = parse_review_metadata(text)
+        if meta is not None:
+            results.append(meta)
+    return results

--- a/tests/test_validate_review.py
+++ b/tests/test_validate_review.py
@@ -1850,6 +1850,40 @@ class TestStructuredMissingRoles:
             "TMG",
         }, f"Expected missing_roles={{'CE', 'CRS', 'TMG'}}, got {set(missing_roles)}"
 
+    def test_check_pr_comments_handles_null_author(self, ci_environment, monkeypatch):
+        """A comment/review with author=null (ghost/deleted user) must not crash the gate.
+
+        Regression: ``comment.get("author", {})`` returns None when the key exists
+        with a null value, so ``.get("login")`` raised AttributeError and failed the
+        gate on otherwise-valid PR data.
+        """
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+        def mock_run(*args, **kwargs):
+            mock = MagicMock()
+            mock.stdout = json.dumps(
+                {
+                    "body": "",
+                    "comments": [
+                        {"author": None, "body": "just some prose from a ghost user"},
+                        {"author": {"login": "reviewer1"}, "body": "CE APPROVED: real"},
+                    ],
+                    "reviews": [
+                        {"author": None, "state": "COMMENTED", "body": "ghost review"},
+                    ],
+                }
+            )
+            return mock
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        # Must not raise AttributeError on null author; real reviewer satisfies CE.
+        approved, _message, missing_roles = validate_review.check_pr_comments(
+            required_roles={"CE"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True
+        assert missing_roles == []
+
     def test_check_pr_comments_returns_empty_missing_on_success(self, ci_environment, monkeypatch):
         """When all approvals found, missing_roles must be an empty list."""
         monkeypatch.setenv("PR_NUMBER", "999")

--- a/tests/test_validate_review.py
+++ b/tests/test_validate_review.py
@@ -1,0 +1,2642 @@
+#!/usr/bin/env python3
+"""
+Test suite for scripts/validate_review.py
+
+Validates fail-closed behavior in CI, local mode permissiveness,
+fork PR support, and emergency bypass audit trail.
+
+SECURITY: Tests marked with @pytest.mark.security validate critical
+fail-closed behavior - failures indicate security vulnerabilities.
+"""
+
+import json
+import re
+import subprocess
+
+# Import the module under test
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import validate_review
+
+
+@pytest.fixture
+def ci_environment(monkeypatch):
+    """Set up CI environment variables."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_BASE_REF", "origin/main")
+    monkeypatch.setenv("PR_NUMBER", "123")
+
+
+@pytest.fixture
+def local_environment(monkeypatch):
+    """Set up local development environment."""
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+
+
+@pytest.mark.security
+class TestFailClosedBehavior:
+    """Critical security tests - validate fail-closed behavior in CI."""
+
+    def test_get_changed_files_git_failure_in_ci_exits_nonzero(self, ci_environment, monkeypatch):
+        """SECURITY: Git failures in CI must exit non-zero, not return empty list."""
+
+        # Mock subprocess.run to raise CalledProcessError
+        def mock_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, "git diff")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        # In CI context, git failures should raise, not return []
+        with pytest.raises(SystemExit) as exc_info:
+            validate_review.get_changed_files()
+        assert exc_info.value.code == 1, "Git failure in CI must exit code 1"
+
+    def test_check_pr_comments_failure_in_ci_blocks(self, ci_environment, monkeypatch):
+        """SECURITY: PR comment check failures in CI must return False, not True."""
+
+        # Mock gh CLI to raise CalledProcessError
+        def mock_run(*args, **kwargs):
+            if "gh" in args[0]:
+                raise subprocess.CalledProcessError(1, "gh pr view")
+            # Allow other git commands to succeed
+            return MagicMock(stdout="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        # In CI context, comment check failures should return False
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, "Comment check failure in CI must return False"
+        assert "error" in message.lower() or "failed" in message.lower()
+
+    def test_main_blocks_on_missing_review_in_ci(self, ci_environment, monkeypatch):
+        """SECURITY: main() must exit 1 when reviews missing in CI."""
+        # Mock get_changed_files to return non-exempt files
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}],
+        )
+
+        # Mock check_pr_comments to return False (missing review)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (False, "Missing review", []),
+        )
+
+        # Mock check_emergency_bypass to return False
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        # main() should exit 1 in CI when reviews missing
+        exit_code = validate_review.main()
+        assert exit_code == 1, "main() must exit 1 when reviews missing in CI"
+
+
+@pytest.mark.behavior
+class TestLocalModePermissiveness:
+    """Validate that local mode remains permissive for developer UX."""
+
+    def test_get_changed_files_git_failure_local_returns_empty(
+        self, local_environment, monkeypatch
+    ):
+        """Local mode: Git failures return empty list (permissive)."""
+
+        # Mock subprocess.run to raise CalledProcessError
+        def mock_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, "git diff")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        # In local context, git failures should return empty list
+        files = validate_review.get_changed_files()
+        assert files == [], "Git failure in local mode should return empty list"
+
+    def test_check_pr_comments_skips_in_local_mode(self, local_environment):
+        """Local mode: PR comment checks are skipped."""
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "Local mode should skip PR comment checks"
+        assert "local" in message.lower() or "skip" in message.lower()
+
+    def test_main_permits_without_review_locally(self, local_environment, monkeypatch):
+        """Local mode: main() exits 0 even without reviews (permissive)."""
+        # Mock get_changed_files to return non-exempt files
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}],
+        )
+
+        # Mock check_emergency_bypass to return False
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        # main() should exit 0 in local mode even without reviews
+        exit_code = validate_review.main()
+        assert exit_code == 0, "main() should exit 0 in local mode (permissive)"
+
+
+@pytest.mark.behavior
+class TestForkPRSupport:
+    """Validate fork PR support (already fixed in PR #193)."""
+
+    def test_get_changed_files_uses_base_ref_in_ci(self, ci_environment, monkeypatch):
+        """CI mode: Uses GITHUB_BASE_REF for fork PRs."""
+        calls = []
+
+        def mock_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return MagicMock(
+                stdout="10\t5\tsrc/core.py\n", stderr="", returncode=0, check=lambda: None
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.get_changed_files()
+
+        # Verify git diff command uses base_ref
+        assert len(calls) > 0
+        assert any("origin/main...HEAD" in " ".join(cmd) for cmd in calls)
+
+    def test_get_changed_files_uses_cached_locally(self, local_environment, monkeypatch):
+        """Local mode: Uses --cached for staged files."""
+        calls = []
+
+        def mock_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return MagicMock(
+                stdout="10\t5\tsrc/core.py\n", stderr="", returncode=0, check=lambda: None
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.get_changed_files()
+
+        # Verify git diff command uses --cached
+        assert len(calls) > 0
+        assert any("--cached" in cmd for cmd in calls)
+
+
+@pytest.mark.security
+class TestEmergencyBypassAudit:
+    """Validate emergency bypass creates audit trail."""
+
+    def test_emergency_bypass_creates_audit_log(self, ci_environment, monkeypatch, tmp_path):
+        """SECURITY: Emergency bypass must create audit log entry."""
+        # Set up temporary audit directory
+        audit_dir = tmp_path / ".hestai" / "audit"
+        audit_log = audit_dir / "bypass-log.jsonl"
+
+        # Mock get_changed_files
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}],
+        )
+
+        # Mock check_emergency_bypass to return True
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: True)
+
+        # Mock Path.cwd() to return tmp_path
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+
+        # Run main() - should create audit log
+        exit_code = validate_review.main()
+        assert exit_code == 0, "Emergency bypass should exit 0"
+
+        # Verify audit log was created
+        assert audit_log.exists(), "Audit log must be created for emergency bypass"
+
+        # Verify audit log content
+        with open(audit_log) as f:
+            entries = [json.loads(line) for line in f]
+            assert len(entries) > 0, "Audit log must contain at least one entry"
+            entry = entries[-1]
+            assert "timestamp" in entry
+            assert "pr_number" in entry or "commit" in entry
+            assert "reason" in entry
+            assert entry["reason"] == "EMERGENCY_BYPASS"
+
+    def test_emergency_bypass_audit_includes_metadata(self, ci_environment, monkeypatch, tmp_path):
+        """Emergency bypass audit log includes PR number and user metadata."""
+        audit_dir = tmp_path / ".hestai" / "audit"
+        audit_log = audit_dir / "bypass-log.jsonl"
+
+        # Mock functions
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}],
+        )
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: True)
+        monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+
+        # Mock git user info
+        def mock_run(cmd, *args, **kwargs):
+            if "config" in cmd and "user.name" in cmd:
+                return MagicMock(stdout="Test User\n")
+            if "config" in cmd and "user.email" in cmd:
+                return MagicMock(stdout="test@example.com\n")
+            return MagicMock(stdout="", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+
+        # Verify audit log includes metadata
+        with open(audit_log) as f:
+            entry = json.loads(f.read())
+            assert "pr_number" in entry or "commit" in entry
+            assert entry.get("pr_number") == "123" or "commit" in entry
+
+
+@pytest.mark.behavior
+class TestReviewTierLogic:
+    """Validate review tier determination logic."""
+
+    def test_tier_0_exempt_for_markdown_only(self):
+        """TIER_0_EXEMPT for markdown-only changes."""
+        files = [
+            {"path": "README.md", "added": 10, "deleted": 5, "total_changed": 15},
+            {"path": "docs/guide.md", "added": 20, "deleted": 10, "total_changed": 30},
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT"
+        assert "exempt" in reason.lower()
+
+    def test_tier_1_self_for_small_single_file(self):
+        """TIER_1_SELF for <10 lines in single file (5-tier system threshold)."""
+        files = [{"path": "src/utils.py", "added": 5, "deleted": 3, "total_changed": 8}]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier == "TIER_1_SELF"
+
+    def test_tier_2_crs_for_medium_changes(self):
+        """TIER_2_STANDARD for 50-500 lines."""
+        files = [{"path": "src/core.py", "added": 100, "deleted": 50, "total_changed": 150}]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD"
+
+    def test_tier_3_full_for_large_changes(self):
+        """TIER_3_CRITICAL for >500 lines (5-tier system)."""
+        files = [{"path": "src/core.py", "added": 400, "deleted": 200, "total_changed": 600}]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL"
+
+    def test_tier_0_exempt_for_architecture_markdown(self):
+        """TIER_0_EXEMPT for architecture markdown (all .md exempt)."""
+        files = [
+            {"path": "docs/architecture/system.md", "added": 10, "deleted": 5, "total_changed": 15}
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT"
+        assert "exempt" in reason.lower()
+
+    def test_oct_md_files_are_not_exempt(self):
+        """GOVERNANCE: .oct.md files must NOT be exempt from review tier calculation.
+
+        .oct.md files are governance code (cognition definitions, agent definitions,
+        skills, patterns) and must be subject to review requirements per I3
+        (Dual-Layer Authority). The markdown exemption must not apply to them.
+        Under the 5-tier system, 15 lines falls into T2 (10-500 range).
+        """
+        files = [
+            {
+                "path": ".hestai-sys/library/cognitions/logos.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            }
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier != "TIER_0_EXEMPT", f".oct.md files must NOT be exempt, got {tier}"
+
+    def test_oct_md_agent_files_are_not_exempt(self):
+        """GOVERNANCE: Agent definition .oct.md files must NOT be exempt."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/agents/implementation-lead.oct.md",
+                "added": 30,
+                "deleted": 10,
+                "total_changed": 40,
+            }
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert tier != "TIER_0_EXEMPT", f"Agent .oct.md files must NOT be exempt, got {tier}"
+
+    def test_regular_md_files_remain_exempt(self):
+        """Regular .md files (README, CLAUDE, docs) must still be exempt."""
+        files = [
+            {"path": "README.md", "added": 5, "deleted": 2, "total_changed": 7},
+            {"path": "CLAUDE.md", "added": 3, "deleted": 1, "total_changed": 4},
+            {"path": "docs/ARCHITECTURE.md", "added": 10, "deleted": 5, "total_changed": 15},
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_0_EXEMPT"
+        ), "Regular .md files must remain exempt from review tier calculation"
+
+    def test_mixed_oct_md_and_regular_md_only_oct_md_counts(self):
+        """When .oct.md and regular .md are mixed, only .oct.md should count."""
+        files = [
+            {"path": "README.md", "added": 50, "deleted": 20, "total_changed": 70},
+            {
+                "path": ".hestai-sys/library/cognitions/logos.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            },
+        ]
+        tier, reason = validate_review.determine_review_tier(files)
+        assert (
+            tier != "TIER_0_EXEMPT"
+        ), ".oct.md changes must prevent TIER_0_EXEMPT even when mixed with regular .md"
+
+
+@pytest.mark.behavior
+class TestPRCommentValidation:
+    """Validate PR comment checking logic."""
+
+    def test_tier_1_requires_self_review_comment(self, ci_environment, monkeypatch):
+        """TIER_1_SELF requires 'IL SELF-REVIEWED:' or 'HO REVIEWED:' comment."""
+
+        # Mock gh CLI to return comments without self-review
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps({"body": "", "comments": [{"body": "Some other comment"}]}),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is False
+        assert "SELF-REVIEWED" in message or "HO REVIEWED" in message
+
+    def test_tier_2_requires_tmg_crs_and_ce_approval(self, ci_environment, monkeypatch):
+        """TIER_2_STANDARD requires TMG + CRS + CE approval (5-tier system)."""
+
+        # Mock gh CLI to return comments with TMG, CRS and CE approval
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests cover critical paths"},
+                            {"body": "CRS APPROVED: Logic correct, tests pass"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True
+        assert "TMG" in message and "CRS" in message and "CE" in message
+
+    def test_tier_2_missing_ce_fails(self, ci_environment, monkeypatch):
+        """TIER_2_STANDARD with only CRS approval (no CE) should fail."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {"body": "", "comments": [{"body": "CRS APPROVED: Logic correct, tests pass"}]}
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False
+        assert "CE APPROVED" in message or "CE GO" in message
+
+    def test_tier_3_requires_tmg_crs_ce_civ(self, ci_environment, monkeypatch):
+        """TIER_3_CRITICAL requires TMG + CRS + CE + CIV (5-tier system)."""
+
+        # Mock gh CLI to return comments with only CRS approval (missing TMG, CE, CIV)
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: Logic correct"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is False
+        assert "TMG" in message or "CE" in message or "CIV" in message
+
+
+@pytest.mark.behavior
+class TestPRBodyScanning:
+    """Validate that PR body is scanned for approval patterns in addition to comments."""
+
+    def test_tmg_crs_and_ce_approval_in_pr_body_is_accepted(self, ci_environment, monkeypatch):
+        """Approval patterns in PR body should satisfy the review gate (5-tier)."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "## Review Summary\nTMG APPROVED: tests verified\nCRS APPROVED: Logic correct, tests pass\nCE APPROVED: Architecture sound",
+                        "comments": [],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "TMG, CRS and CE approval in PR body should be accepted"
+
+    def test_self_review_in_pr_body_is_accepted(self, ci_environment, monkeypatch):
+        """Self-review pattern in PR body should satisfy TIER_1_SELF."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "IL SELF-REVIEWED: Small config change",
+                        "comments": [],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "Self-review in PR body should be accepted"
+        assert "Self-review found" in message
+
+    def test_tier_3_approvals_split_between_body_and_comments(self, ci_environment, monkeypatch):
+        """TIER_3_CRITICAL: TMG+CRS+CE+CIV split between body and comments should pass."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "TMG APPROVED: tests verified\nCRS APPROVED: Logic verified",
+                        "comments": [
+                            {"body": "CE APPROVED: Performance acceptable"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, "Approvals split between body and comments should pass"
+
+    def test_gh_cli_fetches_body_and_comments(self, ci_environment, monkeypatch):
+        """The gh CLI call should request 'body', 'comments', and 'reviews' fields."""
+        captured_cmds = []
+
+        def mock_run(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: ok"},
+                            {"body": "CE APPROVED: ok"},
+                        ],
+                        "reviews": [],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.check_pr_comments("TIER_2_STANDARD")
+
+        # Verify gh pr view fetches body, comments, and reviews
+        assert len(captured_cmds) > 0
+        gh_cmd = captured_cmds[0]
+        json_arg = next((a for a in gh_cmd if "comments" in a and "body" in a), None)
+        assert json_arg is not None, f"gh CLI should fetch comments and body, got: {gh_cmd}"
+        assert "reviews" in json_arg, f"gh CLI should also fetch reviews, got: {gh_cmd}"
+
+    def test_empty_pr_body_still_checks_comments(self, ci_environment, monkeypatch):
+        """Empty or null PR body should not break comment checking."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": None,
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Looks good"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "Null PR body should not block comment-based approval"
+
+
+@pytest.mark.behavior
+class TestHOSupervisoryReview:
+    """Validate that HO REVIEWED is accepted as an alternative T1 approval.
+
+    When HO delegates to IL and then reviews the work, it's a supervisory
+    review (higher authority than self-review) and should satisfy T1.
+    """
+
+    def test_tier_1_ho_reviewed_passes(self, ci_environment, monkeypatch):
+        """'HO REVIEWED: delegated to IL, verified output' should pass T1."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "HO REVIEWED: delegated to IL, verified output"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "'HO REVIEWED' should satisfy T1"
+        assert "HO supervisory review found" in message
+
+    def test_tier_1_ho_reviewed_with_model_format(self, ci_environment, monkeypatch):
+        """'HO (Claude): REVIEWED: verified' should also pass T1."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "HO (Claude): REVIEWED: verified"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "'HO (Claude): REVIEWED' should satisfy T1"
+        assert "HO supervisory review found" in message
+
+    def test_tier_1_il_self_reviewed_still_passes(self, ci_environment, monkeypatch):
+        """Existing IL SELF-REVIEWED must still pass T1 after HO REVIEWED addition."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "IL SELF-REVIEWED: Fixed typo in error message"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "IL SELF-REVIEWED must still pass T1"
+        assert "Self-review found" in message
+
+    def test_tier_1_ho_reviewed_in_pr_body(self, ci_environment, monkeypatch):
+        """HO REVIEWED in PR body should also satisfy T1."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "HO REVIEWED: delegated implementation verified",
+                        "comments": [],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "HO REVIEWED in PR body should satisfy T1"
+
+    def test_tier_1_crs_still_satisfies_after_ho_addition(self, ci_environment, monkeypatch):
+        """CRS approval should still satisfy T1 (hierarchy rule preserved)."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "CRS APPROVED: Logic correct, tests pass"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "CRS approval should still satisfy T1"
+        assert "CRS approval satisfies" in message
+
+
+@pytest.mark.behavior
+class TestFlexiblePatternMatching:
+    """Validate flexible approval pattern matching beyond exact string match."""
+
+    def test_crs_parenthetical_model_format(self, ci_environment, monkeypatch):
+        """'CRS (Gemini): APPROVED' format should be recognized at TIER_2."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "TMG APPROVED: tests verified\nCRS (Gemini): APPROVED - Logic correct, tests pass",
+                        "comments": [{"body": "CE APPROVED: Architecture sound"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "'CRS (Gemini): APPROVED' + TMG + CE should be recognized"
+
+    def test_ce_parenthetical_model_format(self, ci_environment, monkeypatch):
+        """'CE (Claude): APPROVED' format should be recognized at TIER_3_CRITICAL."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Logic ok"},
+                            {"body": "CE (Claude): APPROVED - Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, "'CE (Claude): APPROVED' with TMG+CRS+CIV should be recognized"
+
+    def test_crs_with_extra_whitespace(self, ci_environment, monkeypatch):
+        """Patterns with varied whitespace should still match."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "TMG APPROVED: ok\nCRS  APPROVED: Logic correct",
+                        "comments": [{"body": "CE APPROVED: Sound"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "CRS APPROVED with extra whitespace should match"
+
+    def test_il_parenthetical_model_format(self, ci_environment, monkeypatch):
+        """'IL (Claude): SELF-REVIEWED' format should be recognized."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "IL (Claude): SELF-REVIEWED: Quick fix",
+                        "comments": [],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, "'IL (Claude): SELF-REVIEWED' should be recognized"
+
+    def test_original_exact_format_still_works(self, ci_environment, monkeypatch):
+        """Original exact format 'CRS APPROVED:' must continue to work at TIER_2."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Logic correct, tests pass"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "Original exact format must continue to work"
+
+
+@pytest.mark.behavior
+class TestSubstringFalsePositivePrevention:
+    """Regression tests for CRS MEDIUM finding: keyword substring false positive.
+
+    The keyword 'APPROVED' could match as a substring of longer words like
+    'APPROVEDLY' or 'APPROVEDISH'. The approval regex must use word boundaries
+    after the keyword to prevent such false positives. Note: prefix substrings
+    like 'DISAPPROVED' are already prevented by the regex structure (the prefix
+    must be followed by whitespace then the keyword), but suffix substrings
+    require an explicit word boundary.
+    """
+
+    def test_approved_suffix_word_does_not_match(self):
+        """REGRESSION: 'CRS APPROVEDLY' must NOT match as 'CRS APPROVED'."""
+        result = validate_review._matches_approval_pattern(
+            "CRS APPROVEDLY noted", "CRS", "APPROVED"
+        )
+        assert (
+            result is False
+        ), "APPROVEDLY must not match as APPROVED - suffix substring false positive"
+
+    def test_approved_suffix_compound_does_not_match(self):
+        """REGRESSION: 'CRS APPROVEDISH' must NOT match as approval."""
+        result = validate_review._matches_approval_pattern(
+            "CRS APPROVEDISH maybe", "CRS", "APPROVED"
+        )
+        assert (
+            result is False
+        ), "APPROVEDISH must not match as APPROVED - suffix substring false positive"
+
+    def test_disapproved_does_not_match_as_approval(self):
+        """REGRESSION: 'CRS DISAPPROVED' must NOT match as 'CRS APPROVED'."""
+        result = validate_review._matches_approval_pattern(
+            "CRS DISAPPROVED: This change has issues", "CRS", "APPROVED"
+        )
+        assert result is False, "DISAPPROVED must not match as APPROVED"
+
+    def test_disapproved_with_parenthetical_does_not_match(self):
+        """REGRESSION: 'CRS (Gemini): DISAPPROVED' must NOT match as approval."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini): DISAPPROVED - Rejected", "CRS", "APPROVED"
+        )
+        assert result is False, "Parenthetical DISAPPROVED must not match as APPROVED"
+
+    def test_approved_still_matches_after_fix(self):
+        """Sanity check: 'CRS APPROVED' must still match after word boundary fix."""
+        result = validate_review._matches_approval_pattern(
+            "CRS APPROVED: Logic correct", "CRS", "APPROVED"
+        )
+        assert result is True, "APPROVED must still match after word boundary fix"
+
+    def test_approved_with_colon_suffix_still_matches(self):
+        """Sanity check: 'APPROVED:' (with colon) must still match with word boundary."""
+        result = validate_review._matches_approval_pattern(
+            "CRS APPROVED: tests pass", "CRS", "APPROVED"
+        )
+        assert result is True, "APPROVED followed by colon must still match"
+
+    def test_approved_at_end_of_line_still_matches(self):
+        """Sanity check: 'CRS APPROVED' at end of string must still match."""
+        result = validate_review._matches_approval_pattern("CRS APPROVED", "CRS", "APPROVED")
+        assert result is True, "APPROVED at end of string must still match"
+
+    def test_ce_disapproved_does_not_match(self):
+        """REGRESSION: 'CE DISAPPROVED' must NOT match as 'CE APPROVED'."""
+        result = validate_review._matches_approval_pattern(
+            "CE DISAPPROVED: Architecture concerns", "CE", "APPROVED"
+        )
+        assert result is False, "CE DISAPPROVED must not match as CE APPROVED"
+
+
+@pytest.mark.behavior
+class TestGoKeywordApproval:
+    """Validate that 'GO' is accepted as an approval synonym alongside 'APPROVED'.
+
+    Agents sometimes write 'CRS (Gemini): GO (9/10)' or 'CE (Codex): GO after fix'
+    instead of the standard 'APPROVED' keyword. Both must be accepted for CRS and CE
+    tiers. TIER_1_SELF (IL SELF-REVIEWED) is NOT affected.
+    """
+
+    def test_crs_go_matches_as_crs_approval(self, ci_environment, monkeypatch):
+        """'CRS (Gemini): GO' should match as CRS approval at TIER_2."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "TMG APPROVED: ok\nCRS (Gemini): GO",
+                        "comments": [{"body": "CE APPROVED: Sound"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "'CRS (Gemini): GO' + TMG + CE should be recognized"
+
+    def test_ce_go_after_fix_matches_as_ce_approval(self, ci_environment, monkeypatch):
+        """'CE (Codex): GO after fix' should match as CE approval at TIER_3_CRITICAL."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: ok"},
+                            {"body": "CE (Codex): GO after fix"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, "'CE (Codex): GO after fix' with TMG+CRS+CIV should pass"
+
+    def test_crs_go_with_score_matches(self, ci_environment, monkeypatch):
+        """'CRS (Gemini): GO (9/10)' should match -- the real-world failing case."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "TMG APPROVED: ok\nCRS (Gemini): GO (9/10)",
+                        "comments": [{"body": "CE APPROVED: Sound"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, "'CRS (Gemini): GO (9/10)' + TMG + CE should pass"
+
+    def test_tier_3_go_plus_ce_approved_passes(self, ci_environment, monkeypatch):
+        """TIER_3_CRITICAL with TMG+CRS GO+CE+CIV should pass."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS GO: Logic sound"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, "TMG+CRS GO+CE+CIV should satisfy TIER_3_CRITICAL"
+
+    def test_tier_3_approved_plus_ce_go_passes(self, ci_environment, monkeypatch):
+        """TIER_3_CRITICAL with TMG+CRS+CE GO+CIV should pass."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE (Codex): GO - looks good"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, "TMG+CRS+CE GO+CIV should satisfy TIER_3_CRITICAL"
+
+    def test_go_substring_does_not_false_positive(self):
+        """'CRS GOING' must NOT match as 'CRS GO' -- word boundary enforcement."""
+        result = validate_review._matches_approval_pattern("CRS GOING ahead", "CRS", "GO")
+        assert result is False, "GOING must not match as GO - suffix substring false positive"
+
+    def test_tier_3_missing_all_mentions_roles_in_error(self, ci_environment, monkeypatch):
+        """Error message for TIER_3_CRITICAL missing approvals should mention required roles."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "Some other comment"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is False
+        assert "TMG" in message, "Error message should mention TMG"
+        assert "CRS" in message, "Error message should mention CRS"
+        assert "CE" in message, "Error message should mention CE"
+        assert "CIV" in message, "Error message should mention CIV"
+
+    def test_tier_2_missing_mentions_go_in_error(self, ci_environment, monkeypatch):
+        """Error message for TIER_2_STANDARD missing approval should mention GO as alternative."""
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [{"body": "Some other comment"}],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False
+        assert "GO" in message, "Error message should mention GO as an accepted format"
+
+
+@pytest.mark.behavior
+class TestFlexibleSeparatorMatching:
+    """Validate that em dash, en dash, hyphen, and colon separators are accepted.
+
+    Real-world approval text uses varied separators between the prefix/parenthetical
+    and the keyword. For example:
+      - 'CRS (Gemini) \u2014 APPROVED (98/100)' (em dash U+2014)
+      - 'CE (Codex) \u2014 APPROVED (GO)' (em dash)
+      - 'CRS (Gemini) \u2013 APPROVED' (en dash U+2013)
+      - 'CRS (Gemini) - APPROVED' (hyphen)
+      - 'CRS \u2014 APPROVED' (em dash, no parenthetical)
+      - 'CRS: APPROVED' (colon, no parenthetical)
+
+    The regex must handle any mix of whitespace, colons, and dashes as separators.
+    """
+
+    # --- Em dash separator (the actual failing case from issue #213) ---
+
+    def test_crs_em_dash_with_parenthetical_approved(self):
+        """'CRS (Gemini) \u2014 APPROVED (98/100)' must match -- the real-world failing case."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini) \u2014 APPROVED (98/100)", "CRS", "APPROVED"
+        )
+        assert result is True, "Em dash separator with parenthetical must match"
+
+    def test_ce_em_dash_with_parenthetical_approved_go(self):
+        """'CE (Codex) \u2014 APPROVED (GO)' must match for APPROVED keyword."""
+        result = validate_review._matches_approval_pattern(
+            "CE (Codex) \u2014 APPROVED (GO)", "CE", "APPROVED"
+        )
+        assert result is True, "Em dash separator CE with parenthetical must match"
+
+    def test_crs_em_dash_no_parenthetical(self):
+        """'CRS \u2014 APPROVED' must match (no model annotation, em dash separator)."""
+        result = validate_review._matches_approval_pattern("CRS \u2014 APPROVED", "CRS", "APPROVED")
+        assert result is True, "Em dash separator without parenthetical must match"
+
+    def test_crs_em_dash_go_keyword(self):
+        """'CRS (Gemini) \u2014 GO (9/10)' must match for GO keyword."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini) \u2014 GO (9/10)", "CRS", "GO"
+        )
+        assert result is True, "Em dash separator with GO keyword must match"
+
+    # --- En dash separator (defensive) ---
+
+    def test_crs_en_dash_with_parenthetical(self):
+        """'CRS (Gemini) \u2013 APPROVED' must match (en dash separator)."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini) \u2013 APPROVED", "CRS", "APPROVED"
+        )
+        assert result is True, "En dash separator with parenthetical must match"
+
+    def test_crs_en_dash_no_parenthetical(self):
+        """'CRS \u2013 APPROVED' must match (en dash, no parenthetical)."""
+        result = validate_review._matches_approval_pattern("CRS \u2013 APPROVED", "CRS", "APPROVED")
+        assert result is True, "En dash separator without parenthetical must match"
+
+    # --- Hyphen separator (defensive) ---
+
+    def test_crs_hyphen_with_parenthetical(self):
+        """'CRS (Gemini) - APPROVED' must match (hyphen separator)."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini) - APPROVED", "CRS", "APPROVED"
+        )
+        assert result is True, "Hyphen separator with parenthetical must match"
+
+    def test_crs_hyphen_no_parenthetical(self):
+        """'CRS - APPROVED' must match (hyphen, no parenthetical)."""
+        result = validate_review._matches_approval_pattern("CRS - APPROVED", "CRS", "APPROVED")
+        assert result is True, "Hyphen separator without parenthetical must match"
+
+    # --- Colon separator without parenthetical ---
+
+    def test_crs_colon_no_parenthetical(self):
+        """'CRS: APPROVED' must match (colon separator, no parenthetical)."""
+        result = validate_review._matches_approval_pattern("CRS: APPROVED", "CRS", "APPROVED")
+        assert result is True, "Colon separator without parenthetical must match"
+
+    # --- IL / SELF-REVIEWED with dash separators ---
+
+    def test_il_em_dash_self_reviewed(self):
+        """'IL (Claude) \u2014 SELF-REVIEWED' must match."""
+        result = validate_review._matches_approval_pattern(
+            "IL (Claude) \u2014 SELF-REVIEWED: quick fix", "IL", "SELF-REVIEWED"
+        )
+        assert result is True, "IL with em dash separator must match SELF-REVIEWED"
+
+    # --- Negative cases: separators must not cause false positives ---
+
+    def test_approved_suffix_with_em_dash_does_not_false_positive(self):
+        """'CRS (Gemini) \u2014 APPROVEDLY' must NOT match (word boundary still enforced)."""
+        result = validate_review._matches_approval_pattern(
+            "CRS (Gemini) \u2014 APPROVEDLY noted", "CRS", "APPROVED"
+        )
+        assert result is False, "Word boundary must still prevent suffix false positives"
+
+    def test_going_with_em_dash_does_not_false_positive(self):
+        """'CRS \u2014 GOING' must NOT match as GO."""
+        result = validate_review._matches_approval_pattern("CRS \u2014 GOING ahead", "CRS", "GO")
+        assert result is False, "Word boundary must still prevent GOING matching as GO"
+
+
+@pytest.mark.security
+class TestCRSModelApprovalSpoofing:
+    """Regression tests for CE review finding: approval-spoofing bypass.
+
+    has_crs_model_approval() must not allow:
+    1. Single-line dual-model spoof: one APPROVED keyword satisfying two model checks
+    2. BLOCKED-then-APPROVED on same line: intervening BLOCKED before APPROVED
+    """
+
+    def test_single_line_dual_model_spoof_does_not_satisfy_both(self):
+        """SECURITY: 'CRS (Gemini) and CRS (Codex) APPROVED' must NOT satisfy both models.
+
+        A single APPROVED keyword at the end of a line must not count as approval
+        for both CRS (Gemini) and CRS (Codex) when both appear earlier on that line.
+        """
+        texts = ["CRS (Gemini) and CRS (Codex) APPROVED"]
+        gemini_approved = validate_review._has_crs_model_approval(texts, "Gemini")
+        codex_approved = validate_review._has_crs_model_approval(texts, "Codex")
+        assert not (
+            gemini_approved and codex_approved
+        ), "Single APPROVED must not satisfy both CRS (Gemini) and CRS (Codex)"
+
+    def test_blocked_then_approved_on_same_line_does_not_pass(self):
+        """SECURITY: 'CRS (Gemini) BLOCKED but later APPROVED' must NOT pass.
+
+        If BLOCKED appears between the model tag and APPROVED, the function must
+        not treat this as an approval. Only direct CRS(model) -> APPROVED with
+        separator-only tokens in between should count.
+        """
+        texts = ["CRS (Gemini) BLOCKED but later APPROVED"]
+        result = validate_review._has_crs_model_approval(texts, "Gemini")
+        assert result is False, "BLOCKED-then-APPROVED must not count as model approval"
+
+    def test_legitimate_separate_line_approvals_still_work(self):
+        """Sanity: Separate per-model approval lines must still pass."""
+        texts = [
+            "CRS (Gemini) APPROVED: Logic correct",
+            "CRS (Codex) APPROVED: Verified",
+        ]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "Separate Gemini approval line must pass"
+        assert validate_review._has_crs_model_approval(
+            texts, "Codex"
+        ), "Separate Codex approval line must pass"
+
+    def test_model_approval_with_separator_still_works(self):
+        """Sanity: 'CRS (Gemini): APPROVED' with colon separator must still pass."""
+        texts = ["CRS (Gemini): APPROVED - Logic verified"]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "Colon-separated model approval must pass"
+
+    def test_model_approval_with_go_keyword_still_works(self):
+        """Sanity: 'CRS (Gemini) GO' must still pass."""
+        texts = ["CRS (Gemini) GO (9/10)"]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "GO keyword model approval must pass"
+
+    def test_model_approval_with_dash_separator_still_works(self):
+        """Sanity: 'CRS (Gemini) - APPROVED' with dash separator must still pass."""
+        texts = ["CRS (Gemini) - APPROVED: Architecture sound"]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "Dash-separated model approval must pass"
+
+    def test_model_approval_with_em_dash_still_works(self):
+        """Sanity: 'CRS (Gemini) \u2014 APPROVED' with em dash must still pass."""
+        texts = ["CRS (Gemini) \u2014 APPROVED (98/100)"]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "Em dash-separated model approval must pass"
+
+    def test_model_approval_with_double_dash_still_works(self):
+        """Sanity: 'CRS (Gemini) -- APPROVED' with double dash must still pass."""
+        texts = ["CRS (Gemini) -- APPROVED: Logic verified"]
+        assert validate_review._has_crs_model_approval(
+            texts, "Gemini"
+        ), "Double-dash-separated model approval must pass"
+
+
+@pytest.mark.security
+class TestCrossValidationUnrecognizedRoles:
+    """Regression tests for cross-validation false positive on unrecognized roles.
+
+    When a comment contains review metadata with a role not in VALID_ROLES
+    (e.g., "code-review-specialist"), cross-validation should skip it because
+    unrecognized roles cannot satisfy any gate check. Cross-validating them
+    causes a false positive "spoofing detected" failure that blocks the PR.
+
+    Security invariant: recognized roles (CRS, CE, IL, HO) with mismatched
+    metadata MUST still fail cross-validation (spoofing detection preserved).
+    """
+
+    def test_unrecognized_role_in_metadata_does_not_trigger_cross_validation(
+        self, ci_environment, monkeypatch
+    ):
+        """Unrecognized role (e.g., code-review-specialist) must NOT cause false positive.
+
+        When metadata has role='code-review-specialist' and verdict='APPROVED',
+        the cross-validation should skip it because 'code-review-specialist' is
+        not in VALID_ROLES. Previously this caused a hard fail: "possible spoofing detected."
+        """
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "body": (
+                                    "code-review-specialist APPROVED: looks good\n"
+                                    '<!-- review: {"role": "code-review-specialist", '
+                                    '"verdict": "APPROVED", "provider": "gemini"} -->'
+                                )
+                            },
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, (
+            "Unrecognized role in metadata must not cause cross-validation failure. "
+            f"Got: {message}"
+        )
+
+    def test_unrecognized_role_without_visible_match_does_not_fail(
+        self, ci_environment, monkeypatch
+    ):
+        """Unrecognized role with no visible text match must NOT fail.
+
+        This is the exact failure scenario: metadata says role='code-review-specialist'
+        verdict='APPROVED', but visible text does NOT contain
+        'code-review-specialist APPROVED:' pattern. Previously this caused the
+        cross-validation to fail with "possible spoofing detected."
+        """
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "body": (
+                                    "## Review Assessment\n\nAll checks pass.\n"
+                                    '<!-- review: {"role": "code-review-specialist", '
+                                    '"verdict": "APPROVED", "provider": "gemini"} -->'
+                                )
+                            },
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, (
+            "Unrecognized role without visible text match must not trigger spoofing detection. "
+            f"Got: {message}"
+        )
+
+    def test_recognized_role_with_mismatched_metadata_still_fails(
+        self, ci_environment, monkeypatch
+    ):
+        """SECURITY: Recognized role (CRS) with mismatched visible text MUST still fail.
+
+        If metadata says role='CRS' verdict='APPROVED' but visible text shows
+        'CRS BLOCKED:', this mismatch must be detected as potential spoofing.
+        This test ensures the security behavior is preserved for recognized roles.
+        """
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "body": (
+                                    "CRS BLOCKED: Major issues found\n"
+                                    '<!-- review: {"role": "CRS", '
+                                    '"verdict": "APPROVED", "provider": "gemini"} -->'
+                                )
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, (
+            "Recognized role with mismatched metadata must fail cross-validation "
+            "(spoofing detection). "
+            f"Got: {message}"
+        )
+        assert (
+            "spoofing" in message.lower() or "cross-validation" in message.lower()
+        ), f"Error message should mention spoofing or cross-validation. Got: {message}"
+
+
+@pytest.mark.behavior
+class TestImportlibFallbackDiagnostic:
+    """Validate that the importlib fallback produces clear diagnostics on failure.
+
+    These tests exercise the ACTUAL production code in validate_review.py by
+    running it as a subprocess with manipulated paths, ensuring that if the
+    FileNotFoundError handling is removed from production code, these tests fail.
+    """
+
+    def test_missing_review_formats_raises_file_not_found_error(self, tmp_path):
+        """importlib fallback must raise FileNotFoundError with path info when file missing.
+
+        The fallback path uses importlib.util.spec_from_file_location to load
+        review_formats.py. When the file doesn't exist, the error message must
+        include the expected file path for diagnostic clarity.
+
+        This test exercises the ACTUAL production code by running validate_review.py
+        in a subprocess where the normal import fails (via -S to skip site-packages)
+        and the fallback path computes a _module_path that doesn't exist.
+        """
+        # Create a fake scripts/ directory with a copy of validate_review.py
+        # but NO src/hestai_mcp/modules/tools/shared/review_formats.py
+        fake_scripts = tmp_path / "scripts"
+        fake_scripts.mkdir()
+
+        # Copy the real validate_review.py
+        real_script = Path(__file__).parent.parent / "scripts" / "validate_review.py"
+        (fake_scripts / "validate_review.py").write_text(real_script.read_text())
+
+        # Run with -S (no site-packages) so hestai_mcp is NOT importable,
+        # forcing the except ImportError fallback path in validate_review.py.
+        # The fallback will compute _module_path relative to the script location,
+        # but since there's no src/ tree in tmp_path, the path won't exist.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-S",
+                "-c",
+                "import sys; " f"sys.path.insert(0, '{fake_scripts}'); " "import validate_review",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+        )
+
+        # The import should fail with FileNotFoundError since
+        # review_formats.py doesn't exist at the computed fallback path
+        assert result.returncode != 0, (
+            f"Expected non-zero exit (FileNotFoundError), got 0.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert (
+            "FileNotFoundError" in result.stderr
+        ), f"Expected FileNotFoundError in stderr.\nstderr: {result.stderr}"
+        assert "review_formats.py not found" in result.stderr, (
+            f"Error message must include 'review_formats.py not found'.\n"
+            f"stderr: {result.stderr}"
+        )
+
+    def test_missing_review_formats_error_includes_path(self, tmp_path):
+        """FileNotFoundError message must include the expected file path.
+
+        Exercises the production code's importlib fallback to verify the
+        diagnostic message contains the computed path for troubleshooting.
+        """
+        fake_scripts = tmp_path / "scripts"
+        fake_scripts.mkdir()
+
+        real_script = Path(__file__).parent.parent / "scripts" / "validate_review.py"
+        (fake_scripts / "validate_review.py").write_text(real_script.read_text())
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-S",
+                "-c",
+                "import sys; " f"sys.path.insert(0, '{fake_scripts}'); " "import validate_review",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+        )
+
+        # Verify the error message includes path information for diagnostics
+        assert (
+            "Expected relative to scripts/ directory" in result.stderr
+        ), f"Error must include diagnostic path hint.\nstderr: {result.stderr}"
+
+
+@pytest.mark.behavior
+class TestCallerTemplateAlignment:
+    """Validate that the caller template YAML has aligned bot-exclusion filters.
+
+    The caller template (.github/workflows/review-gate-caller.yml.template) must
+    include the same bot-exclusion and keyword filters as the main workflow
+    (review-gate.yml) to prevent bot noise from triggering unnecessary workflow_call
+    invocations in consuming repos.
+    """
+
+    @pytest.fixture
+    def template_content(self):
+        """Load the caller template YAML content."""
+        template_path = (
+            Path(__file__).parent.parent
+            / ".github"
+            / "workflows"
+            / "review-gate-caller.yml.template"
+        )
+        assert template_path.exists(), f"Caller template not found at {template_path}"
+        return template_path.read_text()
+
+    def test_template_is_valid_yaml(self, template_content):
+        """Caller template must be valid YAML."""
+        import yaml
+
+        # Should not raise an exception
+        parsed = yaml.safe_load(template_content)
+        assert parsed is not None
+        assert "jobs" in parsed
+
+    def test_template_has_bot_exclusion_filter(self, template_content):
+        """Caller template must exclude bot comments (user.type != 'Bot')."""
+        assert "github.event.comment.user.type != 'Bot'" in template_content, (
+            "Caller template must include bot-exclusion filter "
+            "(github.event.comment.user.type != 'Bot') to prevent bot noise "
+            "from triggering workflow_call invocations"
+        )
+
+    def test_template_has_keyword_filters(self, template_content):
+        """Caller template must filter issue_comment events by review keywords."""
+        # These keywords match what review-gate.yml uses
+        assert (
+            "APPROVED" in template_content
+        ), "Caller template must filter comments containing 'APPROVED'"
+        assert (
+            "REVIEWED" in template_content
+        ), "Caller template must filter comments containing 'REVIEWED'"
+        assert "GO" in template_content, "Caller template must filter comments containing 'GO'"
+
+    def test_template_preserves_pr_event_pass_through(self, template_content):
+        """Caller template must still pass through pull_request events unconditionally."""
+        assert (
+            "github.event_name == 'pull_request'" in template_content
+        ), "Caller template must pass through pull_request events"
+
+
+@pytest.mark.behavior
+class TestStructuredJsonOutput:
+    """Validate that main() emits a structured JSON summary as an HTML comment.
+
+    The JSON line is formatted as:
+      <!-- REVIEW_GATE_JSON:{"tier":"T2","reason":"...","reviewers":["TMG"],...} -->
+
+    This enables the JS parser in review-gate.yml to consume structured data
+    instead of relying solely on fragile regex patterns against human-readable output.
+    """
+
+    def test_main_emits_json_comment_for_tier_2(self, ci_environment, monkeypatch, capsys):
+        """main() must emit a REVIEW_GATE_JSON HTML comment for TIER_2_STANDARD."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        # Must contain the JSON comment marker
+        assert (
+            "<!-- REVIEW_GATE_JSON:" in output
+        ), "main() must emit structured JSON as HTML comment"
+
+        # Extract and parse the JSON
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be parseable"
+
+        data = json.loads(json_match.group(1))
+        assert "tier" in data
+        assert "status" in data
+        assert data["status"] == "pass"
+        assert data["tier"] == "TIER_2_STANDARD"
+
+    def test_main_emits_json_comment_for_failed_review(self, ci_environment, monkeypatch, capsys):
+        """main() must emit JSON comment with status=fail when reviews missing."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (False, "Missing CE APPROVED", ["CE"]),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be emitted even on failure"
+
+        data = json.loads(json_match.group(1))
+        assert data["status"] == "fail"
+
+    def test_json_comment_includes_reviewers_list(self, ci_environment, monkeypatch, capsys):
+        """JSON output must include the reviewers list from classify_pr_facets."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [
+                {
+                    "path": "scripts/validate_review.py",
+                    "added": 10,
+                    "deleted": 5,
+                    "total_changed": 15,
+                    "status": "M",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found", []),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert "reviewers" in data
+        assert isinstance(data["reviewers"], list)
+        # validate_review.py is META_CONTROL_PLANE, which requires CIV, CE, CRS, SR, TMG
+        assert len(data["reviewers"]) > 0
+
+    def test_json_comment_includes_required_count(self, ci_environment, monkeypatch, capsys):
+        """JSON output must include required_count and found_count."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert "required_count" in data
+        assert "found_count" in data
+        assert isinstance(data["required_count"], int)
+        assert isinstance(data["found_count"], int)
+
+    def test_json_comment_not_emitted_for_exempt_tier(self, monkeypatch, capsys):
+        """TIER_0_EXEMPT should still emit JSON with tier and status info."""
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "README.md", "added": 5, "deleted": 2, "total_changed": 7}],
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be emitted even for exempt tier"
+
+        data = json.loads(json_match.group(1))
+        assert data["tier"] == "TIER_0_EXEMPT"
+        assert data["status"] == "pass"
+
+    def test_found_count_reflects_partial_approvals_on_failure(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """found_count must reflect actual approvals found, not hardcoded 0 on failure.
+
+        When 2 of 3 required roles have approved but one is missing, the JSON
+        output should report found_count=2, not found_count=0. This is critical
+        for downstream consumers that need accurate progress information.
+        """
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        # ROUTINE_CODE file -> requires CE, CRS, TMG (3 roles)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        # Simulate 2 of 3 approvals present: TMG approved, CRS approved, CE missing
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (
+                False,
+                "\u274c Missing: CE APPROVED or CE GO",
+                ["CE"],
+            ),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be emitted on failure path"
+
+        data = json.loads(json_match.group(1))
+        assert data["status"] == "fail"
+        assert (
+            data["required_count"] == 3
+        ), f"Expected 3 required roles, got {data['required_count']}"
+        # The key assertion: found_count must NOT be hardcoded 0
+        assert data["found_count"] == 2, (
+            f"Expected found_count=2 (2 of 3 roles approved), got {data['found_count']}. "
+            "found_count must reflect actual approvals found, not hardcoded 0."
+        )
+
+    def test_found_count_is_zero_when_no_approvals_found(self, ci_environment, monkeypatch, capsys):
+        """found_count=0 is correct when genuinely no approvals are found."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        # All 3 roles missing
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (
+                False,
+                "\u274c Missing: CE APPROVED or CE GO, CRS APPROVED or CRS GO, TMG APPROVED or TMG GO",
+                ["CE", "CRS", "TMG"],
+            ),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert (
+            data["found_count"] == 0
+        ), f"Expected found_count=0 (no approvals found), got {data['found_count']}"
+
+    def test_found_count_equals_required_count_on_pass(self, ci_environment, monkeypatch, capsys):
+        """found_count must equal required_count on the pass path."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert data["status"] == "pass"
+        assert data["found_count"] == data["required_count"], (
+            f"On pass path, found_count ({data['found_count']}) must equal "
+            f"required_count ({data['required_count']})"
+        )
+
+    def test_json_comment_reason_field_matches_output(self, ci_environment, monkeypatch, capsys):
+        """JSON reason field must match the human-readable reason string."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found", []),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert "reason" in data
+        assert isinstance(data["reason"], str)
+        assert len(data["reason"]) > 0
+
+
+@pytest.mark.behavior
+class TestStructuredMissingRoles:
+    """check_pr_comments must return structured missing roles, not just a message string.
+
+    CE BLOCKED finding: found_count was computed by string-scraping the human-readable
+    error message from check_pr_comments(). This is brittle because if the message format
+    changes, found_count silently breaks. The fix: check_pr_comments returns a third
+    element — the list of missing role names — so callers use structured data.
+    """
+
+    def test_check_pr_comments_returns_missing_roles_list(self, ci_environment, monkeypatch):
+        """check_pr_comments must return (bool, str, list[str]) with missing roles."""
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+        def mock_run(*args, **kwargs):
+            mock = MagicMock()
+            mock.stdout = json.dumps(
+                {
+                    "body": "",
+                    "comments": [],
+                }
+            )
+            return mock
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        result = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG"}, tier="TIER_2_STANDARD"
+        )
+
+        # Must return a 3-tuple
+        assert (
+            len(result) == 3
+        ), f"check_pr_comments must return (bool, str, list[str]), got {len(result)}-tuple"
+        approved, message, missing_roles = result
+        assert approved is False
+        assert isinstance(missing_roles, list)
+        # All 3 roles should be missing (no approvals in comments)
+        assert set(missing_roles) == {
+            "CE",
+            "CRS",
+            "TMG",
+        }, f"Expected missing_roles={{'CE', 'CRS', 'TMG'}}, got {set(missing_roles)}"
+
+    def test_check_pr_comments_returns_empty_missing_on_success(self, ci_environment, monkeypatch):
+        """When all approvals found, missing_roles must be an empty list."""
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+        def mock_run(*args, **kwargs):
+            mock = MagicMock()
+            mock.stdout = json.dumps(
+                {
+                    "body": "",
+                    "comments": [
+                        {
+                            "author": {"login": "reviewer1"},
+                            "body": "CE APPROVED: looks good",
+                        },
+                        {
+                            "author": {"login": "reviewer2"},
+                            "body": "CRS APPROVED: standards met",
+                        },
+                        {
+                            "author": {"login": "reviewer3"},
+                            "body": "TMG APPROVED: tests verified",
+                        },
+                    ],
+                }
+            )
+            return mock
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        result = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG"}, tier="TIER_2_STANDARD"
+        )
+
+        assert (
+            len(result) == 3
+        ), f"check_pr_comments must return (bool, str, list[str]), got {len(result)}-tuple"
+        approved, message, missing_roles = result
+        assert approved is True
+        assert missing_roles == [], f"Expected empty missing_roles on success, got {missing_roles}"
+
+    def test_check_pr_comments_partial_approvals_structured(self, ci_environment, monkeypatch):
+        """With partial approvals, missing_roles lists only the actually missing ones."""
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+        def mock_run(*args, **kwargs):
+            mock = MagicMock()
+            mock.stdout = json.dumps(
+                {
+                    "body": "",
+                    "comments": [
+                        {
+                            "author": {"login": "reviewer1"},
+                            "body": "CRS APPROVED: standards met",
+                        },
+                        {
+                            "author": {"login": "reviewer2"},
+                            "body": "TMG APPROVED: tests verified",
+                        },
+                    ],
+                }
+            )
+            return mock
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        result = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG"}, tier="TIER_2_STANDARD"
+        )
+
+        assert len(result) == 3
+        approved, message, missing_roles = result
+        assert approved is False
+        assert missing_roles == ["CE"], f"Expected only CE missing, got {missing_roles}"
+
+    def test_found_count_uses_structured_data_not_string_scraping(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """main() must compute found_count from structured missing_roles, not string scraping.
+
+        This is the core CE BLOCKED finding: the old code scraped the human-readable
+        error message to count missing roles. The new code must use the structured
+        missing_roles list returned by check_pr_comments.
+        """
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        # Mock returns structured data: CE is missing, CRS and TMG approved
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (
+                False,
+                "\u274c Missing: CE APPROVED or CE GO",
+                ["CE"],
+            ),
+        )
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        import re
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert data["required_count"] == 3
+        assert data["found_count"] == 2, (
+            f"found_count must be computed from structured missing_roles (3 required - 1 missing = 2), "
+            f"got {data['found_count']}"
+        )
+
+
+@pytest.mark.behavior
+class TestShaTrackingInJsonSummary:
+    """Validate that JSON summary includes SHA for approval-commit validation.
+
+    The SHA field enables downstream consumers (review-gate.yml JS parser) to:
+    1. Track which commit the review gate evaluated
+    2. Validate that approvals were made against the correct commit
+    3. Detect stale approvals when new commits are pushed after approval
+    """
+
+    def test_json_summary_includes_sha_field(self, ci_environment, monkeypatch, capsys):
+        """JSON output must include a 'sha' field with the current HEAD commit SHA."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="abc123def456\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be emitted"
+
+        data = json.loads(json_match.group(1))
+        assert "sha" in data, "JSON output must include 'sha' field for commit tracking"
+        assert (
+            data["sha"] == "abc123def456"
+        ), f"SHA must match HEAD commit, expected 'abc123def456', got '{data['sha']}'"
+
+    def test_json_summary_sha_is_string(self, ci_environment, monkeypatch, capsys):
+        """SHA field must be a non-empty string."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="deadbeef1234\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert isinstance(data["sha"], str), "SHA must be a string"
+        assert len(data["sha"]) > 0, "SHA must not be empty"
+
+    def test_json_summary_sha_on_failure_path(self, ci_environment, monkeypatch, capsys):
+        """SHA must be included in JSON output even when review fails."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (False, "Missing CE APPROVED", ["CE"]),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="sha_on_fail_path\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None, "JSON comment must be emitted even on failure"
+
+        data = json.loads(json_match.group(1))
+        assert "sha" in data, "SHA must be present even when review fails"
+        assert data["sha"] == "sha_on_fail_path"
+
+    def test_json_summary_sha_on_exempt_path(self, monkeypatch, capsys):
+        """SHA must be included in JSON output even for TIER_0_EXEMPT."""
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "README.md", "added": 5, "deleted": 2, "total_changed": 7}],
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="sha_exempt_path\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert "sha" in data, "SHA must be present even for TIER_0_EXEMPT"
+
+    def test_json_summary_sha_fallback_on_git_failure(self, ci_environment, monkeypatch, capsys):
+        """If git rev-parse fails, SHA should be 'unknown' rather than crashing."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                raise subprocess.CalledProcessError(1, "git rev-parse HEAD")
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+
+        data = json.loads(json_match.group(1))
+        assert (
+            data["sha"] == "unknown"
+        ), f"SHA must fall back to 'unknown' on git failure, got '{data['sha']}'"
+
+
+@pytest.mark.behavior
+class TestCommentEventFastPath:
+    """Validate that CACHED_GATE_DATA enables comment-event fast path.
+
+    On issue_comment events, the diff hasn't changed — only approvals may have.
+    When CACHED_GATE_DATA is set with matching SHA, validate_review.py should
+    skip file classification and use cached tier/reviewers, then only re-check
+    comment approvals.
+    """
+
+    def test_cached_gate_data_skips_file_classification(self, ci_environment, monkeypatch, capsys):
+        """When CACHED_GATE_DATA is set, get_changed_files must NOT be called."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached reason",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "abc123",
+                "base_sha": "base_abc",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        def explode():
+            raise AssertionError("get_changed_files must not be called with cached gate data")
+
+        monkeypatch.setattr(validate_review, "get_changed_files", explode)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="abc123\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="base_abc\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        assert "fast path" in output.lower(), "Output must indicate fast path was used"
+
+    def test_cached_gate_data_uses_cached_tier(self, ci_environment, monkeypatch, capsys):
+        """When cached, tier from CACHED_GATE_DATA must be used in JSON output."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        cached = json.dumps(
+            {
+                "tier": "TIER_3_CRITICAL",
+                "reason": "Cached: META_CONTROL_PLANE",
+                "roles": ["CE", "CRS", "CIV", "SR", "TMG"],
+                "sha": "def456",
+                "base_sha": "base_def",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="def456\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="base_def\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        json_match = re.search(r"<!-- REVIEW_GATE_JSON:(.*?) -->", output)
+        assert json_match is not None
+        data = json.loads(json_match.group(1))
+        assert (
+            data["tier"] == "TIER_3_CRITICAL"
+        ), f"Tier must come from cached data, got {data['tier']}"
+
+    def test_cached_gate_data_passes_roles_to_comment_check(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """Cached roles must be passed to check_pr_comments as required_roles."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "abc",
+                "base_sha": "base_abc",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        captured_kwargs: dict = {}
+
+        def mock_check(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return (True, "All approvals found", [])
+
+        monkeypatch.setattr(validate_review, "check_pr_comments", mock_check)
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="abc\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="base_abc\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+
+        assert "required_roles" in captured_kwargs, "check_pr_comments must receive required_roles"
+        assert captured_kwargs["required_roles"] == {"CE", "CRS", "TMG"}, (
+            f"required_roles must match cached roles, " f"got {captured_kwargs['required_roles']}"
+        )
+
+    def test_invalid_cached_gate_data_falls_back_to_normal(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """Invalid CACHED_GATE_DATA JSON must fall back to normal file classification."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setenv("CACHED_GATE_DATA", "not-valid-json{{{")
+
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="sha123\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        assert "fast path" not in output.lower(), "Invalid cached data must not trigger fast path"
+
+    def test_empty_cached_gate_data_uses_normal_path(self, ci_environment, monkeypatch, capsys):
+        """Empty CACHED_GATE_DATA string must use normal file classification."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setenv("CACHED_GATE_DATA", "")
+
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="sha456\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        assert "fast path" not in output.lower(), "Empty cached data must not trigger fast path"
+
+    def test_stale_cached_sha_falls_back_to_normal_classification(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """Stale cached SHA (different from HEAD) must fall back to normal classification.
+
+        Bug fix: The original code unconditionally trusts CACHED_GATE_DATA without
+        comparing cached_gate['sha'] against the locally computed head_sha. If the
+        env var contains stale data (workflow bug, manual run), incorrect tier/roles
+        would be silently applied.
+        """
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        # Cached data has SHA "stale_sha_abc" but HEAD will be "current_sha_xyz"
+        cached = json.dumps(
+            {
+                "tier": "TIER_3_CRITICAL",
+                "reason": "Stale cached reason",
+                "roles": ["CE", "CRS", "CIV", "SR", "TMG"],
+                "sha": "stale_sha_abc",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+
+        # get_changed_files MUST be called when SHA mismatches (fallback path)
+        get_changed_files_called = False
+
+        def mock_get_changed_files():
+            nonlocal get_changed_files_called
+            get_changed_files_called = True
+            return [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}]
+
+        monkeypatch.setattr(validate_review, "get_changed_files", mock_get_changed_files)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="current_sha_xyz\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        # Must NOT use the fast path when SHA mismatches
+        assert (
+            "fast path" not in output.lower() or "falling back" in output.lower()
+        ), "Stale SHA must not use fast path without fallback indication"
+        # Must call get_changed_files for normal classification
+        assert (
+            get_changed_files_called
+        ), "get_changed_files must be called when cached SHA differs from HEAD"
+
+    def test_stale_cached_sha_logs_warning(self, ci_environment, monkeypatch, capsys):
+        """Stale cached SHA must produce a visible warning in output."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Stale",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "old_sha_111",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}],
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="new_sha_222\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        validate_review.main()
+        output = capsys.readouterr().out
+
+        # Must contain a warning about SHA mismatch
+        assert (
+            "falling back" in output.lower() or "!=" in output
+        ), "Output must warn about SHA mismatch and indicate fallback to normal classification"
+
+    def test_stale_base_ref_sha_falls_back_to_normal_classification(
+        self, ci_environment, monkeypatch, capsys
+    ):
+        """Stale base ref SHA must fall back to normal classification.
+
+        When the base branch moves while PR head stays the same, the cached
+        tier/roles could be stale because the diff changes with the base.
+        The fast path must validate both head SHA AND base branch tip SHA.
+        """
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        # Cached data has matching head SHA but STALE base ref SHA
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached reason",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "head_sha_match",
+                "base_sha": "old_base_ref_aaa",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        # get_changed_files MUST be called when base ref mismatches
+        get_changed_files_called = False
+
+        def mock_get_changed_files():
+            nonlocal get_changed_files_called
+            get_changed_files_called = True
+            return [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}]
+
+        monkeypatch.setattr(validate_review, "get_changed_files", mock_get_changed_files)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="head_sha_match\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="new_base_ref_bbb\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        # Must NOT use the fast path when base ref mismatches
+        assert (
+            "fast path" not in output.lower() or "falling back" in output.lower()
+        ), "Stale base ref SHA must not use fast path without fallback indication"
+        # Must call get_changed_files for normal classification
+        assert (
+            get_changed_files_called
+        ), "get_changed_files must be called when cached base ref SHA differs from current"
+
+    def test_both_sha_and_base_sha_match_uses_fast_path(self, ci_environment, monkeypatch, capsys):
+        """When both head SHA and base ref SHA match, fast path must be used."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached reason",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "head_sha_match",
+                "base_sha": "base_ref_match",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        def explode():
+            raise AssertionError("get_changed_files must not be called with valid cached data")
+
+        monkeypatch.setattr(validate_review, "get_changed_files", explode)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="head_sha_match\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="base_ref_match\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        output = capsys.readouterr().out
+        assert "fast path" in output.lower(), "Output must indicate fast path was used"
+
+    def test_missing_base_sha_in_cached_data_falls_back(self, ci_environment, monkeypatch, capsys):
+        """Cached data without base_sha (old format) must fall back to normal classification.
+
+        Backward compatibility: old status comments that don't include base_sha
+        should be treated as a cache miss to ensure correctness.
+        """
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        # Old format: no base_sha field
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached reason",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "head_sha_match",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        get_changed_files_called = False
+
+        def mock_get_changed_files():
+            nonlocal get_changed_files_called
+            get_changed_files_called = True
+            return [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}]
+
+        monkeypatch.setattr(validate_review, "get_changed_files", mock_get_changed_files)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="head_sha_match\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                return MagicMock(stdout="some_base_ref\n", returncode=0)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        # Must fall back to normal classification when base_sha is missing
+        assert (
+            get_changed_files_called
+        ), "get_changed_files must be called when base_sha is missing from cached data"
+
+    def test_base_ref_git_failure_falls_back_gracefully(self, ci_environment, monkeypatch, capsys):
+        """If git rev-parse for base ref fails, must fall back to normal classification."""
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+
+        cached = json.dumps(
+            {
+                "tier": "TIER_2_STANDARD",
+                "reason": "Cached reason",
+                "roles": ["CE", "CRS", "TMG"],
+                "sha": "head_sha_match",
+                "base_sha": "some_base_ref",
+            }
+        )
+        monkeypatch.setenv("CACHED_GATE_DATA", cached)
+        monkeypatch.setenv("PR_BASE_REF", "main")
+
+        get_changed_files_called = False
+
+        def mock_get_changed_files():
+            nonlocal get_changed_files_called
+            get_changed_files_called = True
+            return [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}]
+
+        monkeypatch.setattr(validate_review, "get_changed_files", mock_get_changed_files)
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *args, **kwargs: (True, "All approvals found (CE, CRS, TMG)", []),
+        )
+
+        original_run = subprocess.run
+
+        def mock_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" in cmd:
+                return MagicMock(stdout="head_sha_match\n", returncode=0)
+            if isinstance(cmd, list) and "rev-parse" in cmd and "HEAD" not in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+            return original_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        # Must fall back when git rev-parse for base ref fails
+        assert (
+            get_changed_files_called
+        ), "get_changed_files must be called when git rev-parse for base ref fails"

--- a/tests/tools/test_review_formats.py
+++ b/tests/tools/test_review_formats.py
@@ -1,152 +1,773 @@
-"""Tests for the shared review_formats module.
+"""
+Tests for shared review format constants and pattern matching.
 
-Verifies the formatting and pattern-matching utilities that underpin
-the submit_review tool's gate-compliance behavior.
+TDD RED phase: These tests define the contract for review_formats module.
+Tests written FIRST before implementation exists.
+
+Coverage:
+- Review tier constants
+- matches_approval_pattern() with all supported formats
+- Format generation produces valid patterns
+- Edge cases: markdown bold, extra whitespace, model annotations
+- Helper functions: has_crs_approval, has_ce_approval, has_il_self_review
 """
 
 import pytest
 
 
 @pytest.mark.unit
-class TestValidConstants:
-    """Verify the role and verdict constants."""
+class TestReviewTierConstants:
+    """Test that tier constants are defined correctly."""
 
-    def test_valid_roles_contains_all_eight(self):
-        """VALID_ROLES must contain exactly the 8 defined roles."""
+    def test_tier_0_exempt_value(self) -> None:
+        """TIER_0_EXEMPT constant exists and has correct value."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_0_EXEMPT
+
+        assert TIER_0_EXEMPT == "TIER_0_EXEMPT"
+
+    def test_tier_1_self_value(self) -> None:
+        """TIER_1_SELF constant exists and has correct value."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_1_SELF
+
+        assert TIER_1_SELF == "TIER_1_SELF"
+
+    def test_tier_2_crs_value(self) -> None:
+        """TIER_2_STANDARD constant exists and has correct value."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_2_STANDARD
+
+        assert TIER_2_STANDARD == "TIER_2_STANDARD"
+
+    def test_tier_3_full_value(self) -> None:
+        """TIER_3_STRICT constant exists and has correct value."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_3_STRICT
+
+        assert TIER_3_STRICT == "TIER_3_STRICT"
+
+    def test_valid_roles_contains_expected(self) -> None:
+        """VALID_ROLES includes CRS, CE, IL."""
         from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
 
-        expected = {"CE", "CIV", "CRS", "HO", "IL", "PE", "SR", "TMG"}
-        assert expected == VALID_ROLES
+        assert "CRS" in VALID_ROLES
+        assert "CE" in VALID_ROLES
+        assert "IL" in VALID_ROLES
 
-    def test_valid_verdicts_contains_all_three(self):
-        """VALID_VERDICTS must contain exactly the 3 defined verdicts."""
+    def test_valid_verdicts_contains_expected(self) -> None:
+        """VALID_VERDICTS includes APPROVED, BLOCKED, CONDITIONAL."""
         from hestai_context_mcp.tools.shared.review_formats import VALID_VERDICTS
 
-        expected = {"APPROVED", "BLOCKED", "CONDITIONAL"}
-        assert expected == VALID_VERDICTS
+        assert "APPROVED" in VALID_VERDICTS
+        assert "BLOCKED" in VALID_VERDICTS
+        assert "CONDITIONAL" in VALID_VERDICTS
+
+
+@pytest.mark.unit
+class TestMatchesApprovalPattern:
+    """Test the pattern matching function extracted from validate_review.py."""
+
+    def test_exact_crs_approved(self) -> None:
+        """Matches 'CRS APPROVED: assessment text'."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS APPROVED: Looks good", "CRS", "APPROVED")
+
+    def test_exact_ce_approved(self) -> None:
+        """Matches 'CE APPROVED: assessment text'."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CE APPROVED: Architecture sound", "CE", "APPROVED")
+
+    def test_il_self_reviewed(self) -> None:
+        """Matches 'IL SELF-REVIEWED: rationale'."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("IL SELF-REVIEWED: Fixed typo", "IL", "SELF-REVIEWED")
+
+    def test_parenthetical_model_annotation_with_colon(self) -> None:
+        """Matches 'CRS (Gemini): APPROVED' format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS (Gemini): APPROVED - all good", "CRS", "APPROVED")
+
+    def test_parenthetical_model_with_em_dash(self) -> None:
+        """Matches 'CRS (Gemini) \u2014 APPROVED' format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern(
+            "CRS (Gemini) \u2014 APPROVED: assessment", "CRS", "APPROVED"
+        )
+
+    def test_parenthetical_model_with_en_dash(self) -> None:
+        """Matches 'CRS (Gemini) \u2013 APPROVED' format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern(
+            "CRS (Gemini) \u2013 APPROVED: assessment", "CRS", "APPROVED"
+        )
+
+    def test_parenthetical_model_with_hyphen(self) -> None:
+        """Matches 'CRS (Gemini) - APPROVED' format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS (Gemini) - APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_em_dash_no_parenthetical(self) -> None:
+        """Matches 'CRS \u2014 APPROVED' without model annotation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS \u2014 APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_colon_separator(self) -> None:
+        """Matches 'CRS: APPROVED' format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS: APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_extra_whitespace(self) -> None:
+        """Matches 'CRS  APPROVED' with extra whitespace."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS  APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_markdown_bold_keyword(self) -> None:
+        """Matches '**APPROVED**' with markdown bold stripped."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("| CRS | Gemini | **APPROVED** |", "CRS", "APPROVED")
+
+    def test_markdown_table_format(self) -> None:
+        """Matches markdown table row format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern(
+            "| CE | Claude | **APPROVED** | Architecture is sound |", "CE", "APPROVED"
+        )
+
+    def test_crs_go_keyword(self) -> None:
+        """Matches 'CRS GO' format (alternative to APPROVED)."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CRS GO: Ship it", "CRS", "GO")
+
+    def test_no_match_wrong_prefix(self) -> None:
+        """Does NOT match when prefix is wrong."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert not matches_approval_pattern("XCRS APPROVED: nope", "CRS", "APPROVED")
+
+    def test_no_match_wrong_keyword(self) -> None:
+        """Does NOT match when keyword is wrong."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert not matches_approval_pattern("CRS REJECTED: no", "CRS", "APPROVED")
+
+    def test_no_match_keyword_before_prefix(self) -> None:
+        """Does NOT match when keyword appears before prefix."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert not matches_approval_pattern("APPROVED CRS: wrong order", "CRS", "APPROVED")
+
+    def test_multiline_matches_correct_line(self) -> None:
+        """Matches when pattern is on one line of multiline text."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        text = "Some preamble\nCRS APPROVED: Looks good\nMore text"
+        assert matches_approval_pattern(text, "CRS", "APPROVED")
+
+    def test_empty_text_no_match(self) -> None:
+        """Empty text does not match."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert not matches_approval_pattern("", "CRS", "APPROVED")
+
+    def test_markdown_h2_heading_format(self) -> None:
+        """Matches '## TMG APPROVED ✅' — agents naturally use heading format."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("## TMG APPROVED ✅", "TMG", "APPROVED")
+
+    def test_markdown_h1_heading_format(self) -> None:
+        """Matches '# CRS APPROVED: assessment' with h1 heading marker."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("# CRS APPROVED: assessment", "CRS", "APPROVED")
+
+    def test_markdown_h3_heading_format(self) -> None:
+        """Matches '### CIV APPROVED: assessment' with deep heading marker."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("### CIV APPROVED: assessment", "CIV", "APPROVED")
+
+    def test_markdown_heading_with_go_keyword(self) -> None:
+        """Matches '## TMG GO ✅' — heading format with GO keyword."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("## TMG GO ✅", "TMG", "GO")
+
+    def test_markdown_heading_in_multiline(self) -> None:
+        """Matches heading-format approval within multiline review comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        text = "Review summary:\n\n## TMG APPROVED ✅\n\nAll checks passed."
+        assert matches_approval_pattern(text, "TMG", "APPROVED")
+
+    def test_indented_markdown_heading_format(self) -> None:
+        """Matches '  ## TMG APPROVED ✅' — heading with leading indentation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("  ## TMG APPROVED ✅", "TMG", "APPROVED")
+
+
+@pytest.mark.unit
+class TestHelperFunctions:
+    """Test convenience helper functions."""
+
+    def test_has_crs_approval_with_approved(self) -> None:
+        """has_crs_approval returns True for CRS APPROVED."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["CRS APPROVED: Good code"])
+
+    def test_has_crs_approval_with_go(self) -> None:
+        """has_crs_approval returns True for CRS GO."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["CRS GO: Ship it"])
+
+    def test_has_crs_approval_false(self) -> None:
+        """has_crs_approval returns False when no CRS approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert not has_crs_approval(["CE APPROVED: Not CRS"])
+
+    def test_has_ce_approval_with_approved(self) -> None:
+        """has_ce_approval returns True for CE APPROVED."""
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert has_ce_approval(["CE APPROVED: Architecture sound"])
+
+    def test_has_ce_approval_with_go(self) -> None:
+        """has_ce_approval returns True for CE GO."""
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert has_ce_approval(["CE GO: Proceed"])
+
+    def test_has_ce_approval_false(self) -> None:
+        """has_ce_approval returns False when no CE approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert not has_ce_approval(["CRS APPROVED: Not CE"])
+
+    def test_has_il_self_review_true(self) -> None:
+        """has_il_self_review returns True for IL SELF-REVIEWED."""
+        from hestai_context_mcp.tools.shared.review_formats import has_il_self_review
+
+        assert has_il_self_review(["IL SELF-REVIEWED: Fixed typo"])
+
+    def test_has_il_self_review_false(self) -> None:
+        """has_il_self_review returns False when missing."""
+        from hestai_context_mcp.tools.shared.review_formats import has_il_self_review
+
+        assert not has_il_self_review(["CRS APPROVED: Not IL"])
+
+
+@pytest.mark.unit
+class TestHelperFunctionsHeadingFormat:
+    """Test that helper functions accept heading-format approvals via matches_approval_pattern."""
+
+    def test_has_crs_approval_with_h2_heading(self) -> None:
+        """has_crs_approval returns True for an H2 CRS approval heading."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["## CRS APPROVED: looks good"])
+
+    def test_has_ce_approval_with_h2_heading(self) -> None:
+        """has_ce_approval returns True for an H2 CE approval heading."""
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert has_ce_approval(["## CE APPROVED: architecture sound"])
+
+    def test_has_tmg_approval_with_h2_heading(self) -> None:
+        """has_tmg_approval returns True for an H2 TMG approval heading."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["## TMG APPROVED ✅"])
+
+    def test_has_civ_approval_with_h2_heading(self) -> None:
+        """has_civ_approval returns True for an H2 CIV approval heading."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["## CIV APPROVED: implementation valid"])
+
+    def test_has_crs_approval_with_indented_heading(self) -> None:
+        """has_crs_approval returns True for an indented H2 CRS approval heading."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval(["  ## CRS APPROVED: indented"])
 
 
 @pytest.mark.unit
 class TestFormatReviewComment:
-    """Verify comment formatting produces gate-compliant output."""
+    """Test comment formatting that produces gate-clearable comments."""
 
-    def test_basic_approved_format(self):
-        """Basic APPROVED comment should have role, keyword, and assessment."""
-        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+    def test_format_crs_approved(self) -> None:
+        """Format CRS APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
 
-        comment = format_review_comment(role="CE", verdict="APPROVED", assessment="LGTM")
-        assert "CE APPROVED: LGTM" in comment
+        comment = format_review_comment(
+            role="CRS", verdict="APPROVED", assessment="Code quality is excellent"
+        )
+        assert matches_approval_pattern(comment, "CRS", "APPROVED")
+        assert "Code quality is excellent" in comment
 
-    def test_il_approved_maps_to_self_reviewed(self):
-        """IL + APPROVED must produce SELF-REVIEWED keyword."""
-        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+    def test_format_ce_approved(self) -> None:
+        """Format CE APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
 
-        comment = format_review_comment(role="IL", verdict="APPROVED", assessment="Fixed")
-        assert "SELF-REVIEWED" in comment
+        comment = format_review_comment(
+            role="CE", verdict="APPROVED", assessment="Architecture is sound"
+        )
+        assert matches_approval_pattern(comment, "CE", "APPROVED")
+        assert "Architecture is sound" in comment
 
-    def test_ho_approved_maps_to_reviewed(self):
-        """HO + APPROVED must produce REVIEWED keyword."""
-        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+    def test_format_il_self_reviewed(self) -> None:
+        """Format IL with APPROVED verdict produces SELF-REVIEWED."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
 
-        comment = format_review_comment(role="HO", verdict="APPROVED", assessment="Verified")
-        assert "HO" in comment
-        assert "REVIEWED" in comment
+        comment = format_review_comment(
+            role="IL", verdict="APPROVED", assessment="Fixed typo in error message"
+        )
+        assert matches_approval_pattern(comment, "IL", "SELF-REVIEWED")
+        assert "Fixed typo in error message" in comment
 
-    def test_model_annotation_format(self):
-        """Model annotation should appear in parentheses."""
-        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+    def test_format_with_model_annotation(self) -> None:
+        """Format comment with model annotation included."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
 
         comment = format_review_comment(
             role="CRS",
             verdict="APPROVED",
-            assessment="Good",
+            assessment="All tests pass",
             model_annotation="Gemini",
         )
-        assert "CRS (Gemini)" in comment
+        assert matches_approval_pattern(comment, "CRS", "APPROVED")
+        assert "Gemini" in comment
+        assert "All tests pass" in comment
 
-    def test_metadata_html_comment(self):
-        """Formatted comment should include metadata HTML comment."""
-        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
-
-        comment = format_review_comment(role="TMG", verdict="APPROVED", assessment="Tests OK")
-        assert "<!-- review:" in comment
-        assert "-->" in comment
-
-    def test_commit_sha_in_metadata(self):
-        """Valid commit SHA should appear in metadata (truncated to 7)."""
+    def test_format_blocked_verdict(self) -> None:
+        """Format BLOCKED verdict comment."""
         from hestai_context_mcp.tools.shared.review_formats import format_review_comment
 
         comment = format_review_comment(
-            role="CE",
-            verdict="APPROVED",
-            assessment="OK",
-            commit_sha="abc1234def5678",
+            role="CRS", verdict="BLOCKED", assessment="Security vulnerability found"
         )
-        assert "abc1234" in comment
+        assert "BLOCKED" in comment
+        assert "Security vulnerability found" in comment
 
-    def test_invalid_sha_dropped(self):
-        """Invalid SHA should be silently dropped."""
+    def test_format_conditional_verdict(self) -> None:
+        """Format CONDITIONAL verdict comment."""
         from hestai_context_mcp.tools.shared.review_formats import format_review_comment
 
         comment = format_review_comment(
-            role="CE",
-            verdict="APPROVED",
-            assessment="OK",
-            commit_sha="not-valid!",
+            role="CE", verdict="CONDITIONAL", assessment="Needs performance testing"
         )
-        assert "not-valid!" not in comment
+        assert "CONDITIONAL" in comment
+        assert "Needs performance testing" in comment
 
-
-@pytest.mark.unit
-class TestApprovalPatternMatching:
-    """Verify the pattern matching for gate clearing."""
-
-    def test_crs_approval_detected(self):
-        """CRS APPROVED pattern should be detected."""
+    def test_formatted_approved_clears_gate(self) -> None:
+        """Formatted APPROVED comment would clear the review gate."""
         from hestai_context_mcp.tools.shared.review_formats import (
             format_review_comment,
             has_crs_approval,
         )
 
-        comment = format_review_comment(role="CRS", verdict="APPROVED", assessment="Good")
-        assert has_crs_approval([comment]) is True
+        comment = format_review_comment(role="CRS", verdict="APPROVED", assessment="All good")
+        assert has_crs_approval([comment])
 
-    def test_ce_approval_detected(self):
-        """CE APPROVED pattern should be detected."""
+    def test_formatted_ce_approved_clears_gate(self) -> None:
+        """Formatted CE APPROVED comment would clear the CE gate."""
         from hestai_context_mcp.tools.shared.review_formats import (
             format_review_comment,
             has_ce_approval,
         )
 
-        comment = format_review_comment(role="CE", verdict="APPROVED", assessment="Good")
-        assert has_ce_approval([comment]) is True
+        comment = format_review_comment(
+            role="CE", verdict="APPROVED", assessment="Sound architecture"
+        )
+        assert has_ce_approval([comment])
 
-    def test_self_review_detected(self):
-        """IL SELF-REVIEWED pattern should be detected."""
+    def test_formatted_il_self_review_clears_gate(self) -> None:
+        """Formatted IL APPROVED comment would clear the IL self-review gate."""
         from hestai_context_mcp.tools.shared.review_formats import (
             format_review_comment,
-            has_self_review,
+            has_il_self_review,
         )
 
-        comment = format_review_comment(role="IL", verdict="APPROVED", assessment="Quick fix")
-        assert has_self_review([comment]) is True
+        comment = format_review_comment(role="IL", verdict="APPROVED", assessment="Trivial fix")
+        assert has_il_self_review([comment])
 
-    def test_ho_review_detected(self):
-        """HO REVIEWED pattern should be detected."""
-        from hestai_context_mcp.tools.shared.review_formats import (
-            format_review_comment,
-            has_ho_review,
-        )
-
-        comment = format_review_comment(role="HO", verdict="APPROVED", assessment="Verified")
-        assert has_ho_review([comment]) is True
-
-    def test_blocked_does_not_match_approval(self):
-        """BLOCKED comments should NOT match approval patterns."""
+    def test_formatted_with_model_clears_gate(self) -> None:
+        """Formatted comment with model annotation still clears gate."""
         from hestai_context_mcp.tools.shared.review_formats import (
             format_review_comment,
             has_crs_approval,
         )
 
-        comment = format_review_comment(role="CRS", verdict="BLOCKED", assessment="Issues")
-        assert has_crs_approval([comment]) is False
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="Tests pass",
+            model_annotation="Claude",
+        )
+        assert has_crs_approval([comment])
+
+    def test_ho_approved_formats_as_ho_reviewed(self) -> None:
+        """Format HO with APPROVED verdict produces HO REVIEWED."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            has_ho_review,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="HO", verdict="APPROVED", assessment="Delegated to IL, verified output"
+        )
+        assert matches_approval_pattern(comment, "HO", "REVIEWED")
+        assert has_ho_review([comment])
+        assert "Delegated to IL, verified output" in comment
+
+
+@pytest.mark.unit
+class TestReviewMetadata:
+    """Test structured machine-readable metadata in review comments."""
+
+    def test_format_includes_metadata_block(self) -> None:
+        """Formatted comment contains <!-- review: JSON --> metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            model_annotation="Gemini",
+            commit_sha="abc1234def5678",
+        )
+        assert "<!-- review:" in comment
+        assert "-->" in comment
+
+    def test_format_metadata_parseable(self) -> None:
+        """Roundtrip: format -> parse returns correct dict."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            model_annotation="Gemini",
+            commit_sha="abc1234def5678",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "CRS"
+        assert meta["provider"] == "gemini"
+        assert meta["verdict"] == "APPROVED"
+        assert meta["sha"] == "abc1234"
+
+    def test_format_without_sha(self) -> None:
+        """SHA is null when not provided."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            model_annotation="Gemini",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["sha"] is None
+
+    def test_format_il_maps_verdict_in_metadata(self) -> None:
+        """IL verdict becomes SELF-REVIEWED in metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="IL",
+            verdict="APPROVED",
+            assessment="Fixed typo",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["verdict"] == "SELF-REVIEWED"
+
+    def test_format_ho_maps_verdict_in_metadata(self) -> None:
+        """HO verdict becomes REVIEWED in metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="HO",
+            verdict="APPROVED",
+            assessment="Verified output",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["verdict"] == "REVIEWED"
+
+    def test_parse_returns_none_for_no_metadata(self) -> None:
+        """Plain text returns None."""
+        from hestai_context_mcp.tools.shared.review_formats import parse_review_metadata
+
+        assert parse_review_metadata("CRS APPROVED: All good") is None
+
+    def test_parse_returns_none_for_invalid_json(self) -> None:
+        """Malformed JSON returns None."""
+        from hestai_context_mcp.tools.shared.review_formats import parse_review_metadata
+
+        assert parse_review_metadata("<!-- review: {broken json -->") is None
+
+    def test_parse_ignores_metadata_in_inline_code(self) -> None:
+        """Metadata inside backtick-quoted inline code is not parsed.
+
+        Prevents PR body documentation examples from being treated as
+        real review metadata.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import parse_review_metadata
+
+        text = (
+            'Example: `<!-- review: {"role":"CRS","provider":"gemini",'
+            '"verdict":"APPROVED","sha":"abc1234"} -->`'
+        )
+        assert parse_review_metadata(text) is None
+
+    def test_parse_ignores_metadata_in_fenced_code_block(self) -> None:
+        """Metadata inside fenced code blocks is not parsed."""
+        from hestai_context_mcp.tools.shared.review_formats import parse_review_metadata
+
+        text = (
+            "```\n"
+            '<!-- review: {"role":"CRS","provider":null,'
+            '"verdict":"APPROVED","sha":"abc1234"} -->\n'
+            "```"
+        )
+        assert parse_review_metadata(text) is None
+
+    def test_formatted_comment_still_clears_regex_gate(self) -> None:
+        """Metadata line doesn't break existing regex matching."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            has_crs_approval,
+        )
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            model_annotation="Gemini",
+            commit_sha="abc1234",
+        )
+        assert has_crs_approval([comment])
+
+    def test_metadata_line_does_not_satisfy_regex_alone(self) -> None:
+        """Metadata HTML comment must not satisfy regex on its own.
+
+        Regression test: if cross-validation checks the full text including
+        the metadata line, the JSON tokens (e.g. "role":"CRS","verdict":"APPROVED")
+        could falsely match the regex, defeating anti-spoofing.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        # A comment where visible text says BLOCKED but metadata says APPROVED
+        spoofed = (
+            "CRS BLOCKED: Security vulnerability found\n"
+            '<!-- review: {"role":"CRS","provider":null,'
+            '"verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+        # The full text WOULD match because the metadata line has CRS + APPROVED
+        # But visible-only text should NOT match APPROVED
+        import re
+
+        visible_only = re.sub(r"<!--\s*review:.*?-->\s*", "", spoofed)
+        assert not matches_approval_pattern(visible_only, "CRS", "APPROVED")
+        # Visible text should match BLOCKED though
+        assert matches_approval_pattern(visible_only, "CRS", "BLOCKED")
+
+    def test_extract_multiple_metadata(self) -> None:
+        """Batch extraction from multiple comments."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            extract_review_metadata,
+            format_review_comment,
+        )
+
+        comments = [
+            format_review_comment(
+                role="CRS",
+                verdict="APPROVED",
+                assessment="Good",
+                model_annotation="Gemini",
+                commit_sha="abc1234",
+            ),
+            "Plain comment with no metadata",
+            format_review_comment(
+                role="CE",
+                verdict="APPROVED",
+                assessment="Sound",
+                commit_sha="def5678",
+            ),
+        ]
+        results = extract_review_metadata(comments)
+        assert len(results) == 2
+        assert results[0]["role"] == "CRS"
+        assert results[1]["role"] == "CE"
+
+    def test_format_rejects_invalid_sha(self) -> None:
+        """Non-hex SHA results in null sha in metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            commit_sha="not-a-real-sha",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["sha"] is None
+
+    def test_format_accepts_valid_short_sha(self) -> None:
+        """7-char hex SHA works and is preserved."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            commit_sha="abc1234",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["sha"] == "abc1234"
+
+    def test_format_accepts_valid_full_sha(self) -> None:
+        """40-char hex SHA is truncated to 7."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        full_sha = "abc1234def5678901234567890abcdef12345678"
+        comment = format_review_comment(
+            role="CRS",
+            verdict="APPROVED",
+            assessment="All tests pass",
+            commit_sha=full_sha,
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["sha"] == full_sha[:7]
+
+    def test_cross_validation_visible_text_strips_code_blocks(self) -> None:
+        """Approval text inside code blocks is not treated as visible approval.
+
+        Regression test: if cross-validation does not strip code blocks, a
+        spoofed comment could embed 'CRS APPROVED:' inside a fenced code block
+        alongside valid metadata, and the regex would match the code block text.
+        """
+        import re
+
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        # Simulate what cross-validation does: strip metadata, strip code blocks
+        spoofed = (
+            "CRS BLOCKED: Security issue found\n"
+            "```\n"
+            "CRS APPROVED: spoofed inside code block\n"
+            "```\n"
+            '<!-- review: {"role":"CRS","provider":null,'
+            '"verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+        # Reproduce the cross-validation stripping pipeline
+        visible_text = re.sub(r"<!--\s*review:.*?-->\s*", "", spoofed)
+        visible_text = re.sub(r"```.*?```", "", visible_text, flags=re.DOTALL)
+        visible_text = re.sub(r"`[^`]+`", "", visible_text)
+
+        # The spoofed APPROVED inside the code block must NOT match
+        assert not matches_approval_pattern(visible_text, "CRS", "APPROVED")
+        # But the visible BLOCKED must still match
+        assert matches_approval_pattern(visible_text, "CRS", "BLOCKED")

--- a/tests/tools/test_review_formats_5tier.py
+++ b/tests/tools/test_review_formats_5tier.py
@@ -1,0 +1,785 @@
+"""
+Contract tests for 5-tier review system roles and constants in review_formats.py.
+
+Tests verify TMG, CIV, PE role support including approval pattern matching,
+format_review_comment() output, metadata roundtrip, and tier constants
+(TIER_3_CRITICAL, TIER_4_STRATEGIC) for the expanded review structure.
+
+Source of truth: review-requirements.oct.md v2.0 (5-tier system)
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A. New roles in VALID_ROLES
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestValidRoles5Tier:
+    """VALID_ROLES must include TMG, CIV, PE alongside existing CRS, CE, IL, HO."""
+
+    def test_valid_roles_contains_tmg(self) -> None:
+        """TMG (Test Methodology Guardian) must be in VALID_ROLES."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "TMG" in VALID_ROLES, "TMG must be a valid review role"
+
+    def test_valid_roles_contains_civ(self) -> None:
+        """CIV (Critical Implementation Validator) must be in VALID_ROLES."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "CIV" in VALID_ROLES, "CIV must be a valid review role"
+
+    def test_valid_roles_contains_pe(self) -> None:
+        """PE (Principal Engineer) must be in VALID_ROLES."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "PE" in VALID_ROLES, "PE must be a valid review role"
+
+    def test_valid_roles_preserves_existing_crs(self) -> None:
+        """CRS must still be in VALID_ROLES after expansion."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "CRS" in VALID_ROLES
+
+    def test_valid_roles_preserves_existing_ce(self) -> None:
+        """CE must still be in VALID_ROLES after expansion."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "CE" in VALID_ROLES
+
+    def test_valid_roles_preserves_existing_il(self) -> None:
+        """IL must still be in VALID_ROLES after expansion."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "IL" in VALID_ROLES
+
+    def test_valid_roles_preserves_existing_ho(self) -> None:
+        """HO must still be in VALID_ROLES after expansion."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "HO" in VALID_ROLES
+
+    def test_valid_roles_contains_sr(self) -> None:
+        """SR (Standards Reviewer) must be in VALID_ROLES."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert "SR" in VALID_ROLES, "SR must be a valid review role"
+
+    def test_valid_roles_has_eight_members(self) -> None:
+        """VALID_ROLES must have exactly 8 members: CRS, CE, SR, IL, HO, TMG, CIV, PE."""
+        from hestai_context_mcp.tools.shared.review_formats import VALID_ROLES
+
+        assert len(VALID_ROLES) == 8, f"Expected 8 roles, got {len(VALID_ROLES)}: {VALID_ROLES}"
+
+
+# ---------------------------------------------------------------------------
+# B. New tier constants
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTierConstants5Tier:
+    """New tier constants for 5-tier system."""
+
+    def test_tier_3_critical_constant_exists(self) -> None:
+        """TIER_3_CRITICAL must exist (replaces TIER_3_STRICT)."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_3_CRITICAL
+
+        assert TIER_3_CRITICAL == "TIER_3_CRITICAL"
+
+    def test_tier_4_strategic_constant_exists(self) -> None:
+        """TIER_4_STRATEGIC must exist for the new top tier."""
+        from hestai_context_mcp.tools.shared.review_formats import TIER_4_STRATEGIC
+
+        assert TIER_4_STRATEGIC == "TIER_4_STRATEGIC"
+
+
+# ---------------------------------------------------------------------------
+# C. TMG approval matching
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTMGApprovalMatching:
+    """has_tmg_approval() must match TMG approval patterns."""
+
+    def test_tmg_approved_basic(self) -> None:
+        """'TMG APPROVED: tests cover critical paths' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["TMG APPROVED: tests cover critical paths"])
+
+    def test_tmg_approved_with_model_annotation(self) -> None:
+        """'TMG (Goose): APPROVED: coverage verified' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["TMG (Goose): APPROVED: coverage verified"])
+
+    def test_tmg_go_keyword(self) -> None:
+        """'TMG GO: sufficient coverage' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["TMG GO: sufficient coverage"])
+
+    def test_tmg_go_with_model(self) -> None:
+        """'TMG (Goose): GO: tests look solid' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["TMG (Goose): GO: tests look solid"])
+
+    def test_tmg_no_false_positive_xtmg(self) -> None:
+        """'XTMG APPROVED' must NOT match (word boundary)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert not has_tmg_approval(["XTMG APPROVED: fake"])
+
+    def test_tmg_no_false_positive_blocked(self) -> None:
+        """'TMG BLOCKED' must NOT match as approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert not has_tmg_approval(["TMG BLOCKED: tests insufficient"])
+
+    def test_tmg_no_match_empty(self) -> None:
+        """Empty list returns False."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert not has_tmg_approval([])
+
+    def test_tmg_approved_with_em_dash(self) -> None:
+        """'TMG (Goose) \u2014 APPROVED' with em dash must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval(["TMG (Goose) \u2014 APPROVED: edge cases covered"])
+
+
+# ---------------------------------------------------------------------------
+# D. CIV approval matching
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCIVApprovalMatching:
+    """has_civ_approval() must match CIV approval patterns."""
+
+    def test_civ_approved_basic(self) -> None:
+        """'CIV APPROVED: implementation matches spec' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["CIV APPROVED: implementation matches spec"])
+
+    def test_civ_approved_with_model_annotation(self) -> None:
+        """'CIV (Goose): APPROVED: DRY verified' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["CIV (Goose): APPROVED: DRY verified"])
+
+    def test_civ_go_keyword(self) -> None:
+        """'CIV GO: abstractions correct' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["CIV GO: abstractions correct"])
+
+    def test_civ_go_with_model(self) -> None:
+        """'CIV (Codex): GO: implementation clean' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["CIV (Codex): GO: implementation clean"])
+
+    def test_civ_no_false_positive_xciv(self) -> None:
+        """'XCIV APPROVED' must NOT match (word boundary)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert not has_civ_approval(["XCIV APPROVED: fake"])
+
+    def test_civ_no_false_positive_blocked(self) -> None:
+        """'CIV BLOCKED' must NOT match as approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert not has_civ_approval(["CIV BLOCKED: implementation flawed"])
+
+    def test_civ_no_match_empty(self) -> None:
+        """Empty list returns False."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert not has_civ_approval([])
+
+    def test_civ_approved_with_em_dash(self) -> None:
+        """'CIV (Goose) \u2014 APPROVED' with em dash must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval(["CIV (Goose) \u2014 APPROVED: validated"])
+
+
+# ---------------------------------------------------------------------------
+# E. PE approval matching
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestPEApprovalMatching:
+    """has_pe_approval() must match PE approval patterns."""
+
+    def test_pe_approved_basic(self) -> None:
+        """'PE APPROVED: architecture sound for 6 months' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert has_pe_approval(["PE APPROVED: architecture sound for 6 months"])
+
+    def test_pe_approved_with_model_annotation(self) -> None:
+        """'PE (Goose): APPROVED: no temporal coupling' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert has_pe_approval(["PE (Goose): APPROVED: no temporal coupling"])
+
+    def test_pe_go_keyword(self) -> None:
+        """'PE GO: sustainable patterns' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert has_pe_approval(["PE GO: sustainable patterns"])
+
+    def test_pe_go_with_model(self) -> None:
+        """'PE (Codex): GO: long-term viable' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert has_pe_approval(["PE (Codex): GO: long-term viable"])
+
+    def test_pe_no_false_positive_xpe(self) -> None:
+        """'XPE APPROVED' must NOT match (word boundary)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert not has_pe_approval(["XPE APPROVED: fake"])
+
+    def test_pe_no_false_positive_blocked(self) -> None:
+        """'PE BLOCKED' must NOT match as approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert not has_pe_approval(["PE BLOCKED: architecture unsound"])
+
+    def test_pe_no_match_empty(self) -> None:
+        """Empty list returns False."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert not has_pe_approval([])
+
+    def test_pe_approved_with_em_dash(self) -> None:
+        """'PE (Goose) \u2014 APPROVED' with em dash must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_pe_approval
+
+        assert has_pe_approval(["PE (Goose) \u2014 APPROVED: strategic review passed"])
+
+
+# ---------------------------------------------------------------------------
+# F. format_review_comment for new roles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestFormatReviewCommentNewRoles:
+    """format_review_comment() must work with TMG, CIV, PE roles."""
+
+    def test_format_tmg_approved(self) -> None:
+        """Format TMG APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="TMG", verdict="APPROVED", assessment="Tests cover critical paths"
+        )
+        assert matches_approval_pattern(comment, "TMG", "APPROVED")
+        assert "Tests cover critical paths" in comment
+
+    def test_format_tmg_with_model(self) -> None:
+        """Format TMG APPROVED with model annotation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="TMG",
+            verdict="APPROVED",
+            assessment="Edge cases covered",
+            model_annotation="Goose",
+        )
+        assert matches_approval_pattern(comment, "TMG", "APPROVED")
+        assert "Goose" in comment
+
+    def test_format_civ_approved(self) -> None:
+        """Format CIV APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="CIV", verdict="APPROVED", assessment="Implementation matches spec"
+        )
+        assert matches_approval_pattern(comment, "CIV", "APPROVED")
+        assert "Implementation matches spec" in comment
+
+    def test_format_civ_with_model(self) -> None:
+        """Format CIV APPROVED with model annotation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="CIV",
+            verdict="APPROVED",
+            assessment="DRY verified",
+            model_annotation="Goose",
+        )
+        assert matches_approval_pattern(comment, "CIV", "APPROVED")
+        assert "Goose" in comment
+
+    def test_format_pe_approved(self) -> None:
+        """Format PE APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="PE", verdict="APPROVED", assessment="Architecture sound for 6 months"
+        )
+        assert matches_approval_pattern(comment, "PE", "APPROVED")
+        assert "Architecture sound for 6 months" in comment
+
+    def test_format_pe_with_model(self) -> None:
+        """Format PE APPROVED with model annotation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="PE",
+            verdict="APPROVED",
+            assessment="No temporal coupling",
+            model_annotation="Goose",
+        )
+        assert matches_approval_pattern(comment, "PE", "APPROVED")
+        assert "Goose" in comment
+
+    def test_format_tmg_blocked(self) -> None:
+        """Format TMG BLOCKED comment with correct prefix and metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+
+        comment = format_review_comment(
+            role="TMG", verdict="BLOCKED", assessment="Tests insufficient"
+        )
+        assert comment.startswith(
+            "TMG BLOCKED:"
+        ), f"TMG BLOCKED comment must start with 'TMG BLOCKED:', got: {comment[:30]}"
+        assert "Tests insufficient" in comment
+        assert "<!-- review:" in comment, "BLOCKED comment must contain metadata line"
+
+    def test_format_civ_blocked(self) -> None:
+        """Format CIV BLOCKED comment with correct prefix and metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+
+        comment = format_review_comment(
+            role="CIV", verdict="BLOCKED", assessment="Implementation flawed"
+        )
+        assert comment.startswith(
+            "CIV BLOCKED:"
+        ), f"CIV BLOCKED comment must start with 'CIV BLOCKED:', got: {comment[:30]}"
+        assert "Implementation flawed" in comment
+        assert "<!-- review:" in comment, "BLOCKED comment must contain metadata line"
+
+    def test_format_pe_blocked(self) -> None:
+        """Format PE BLOCKED comment with correct prefix and metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+
+        comment = format_review_comment(
+            role="PE", verdict="BLOCKED", assessment="Architecture unsound"
+        )
+        assert comment.startswith(
+            "PE BLOCKED:"
+        ), f"PE BLOCKED comment must start with 'PE BLOCKED:', got: {comment[:30]}"
+        assert "Architecture unsound" in comment
+        assert "<!-- review:" in comment, "BLOCKED comment must contain metadata line"
+
+
+# ---------------------------------------------------------------------------
+# G. Metadata parsing for new roles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestMetadataParsingNewRoles:
+    """parse_review_metadata() must handle TMG, CIV, PE metadata correctly."""
+
+    def test_tmg_metadata_roundtrip(self) -> None:
+        """TMG formatted comment has parseable metadata with correct role."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="TMG",
+            verdict="APPROVED",
+            assessment="Tests cover paths",
+            model_annotation="Goose",
+            commit_sha="abc1234",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "TMG"
+        assert meta["provider"] == "goose"
+        assert meta["verdict"] == "APPROVED"
+        assert meta["sha"] == "abc1234"
+
+    def test_civ_metadata_roundtrip(self) -> None:
+        """CIV formatted comment has parseable metadata with correct role."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="CIV",
+            verdict="APPROVED",
+            assessment="Spec match verified",
+            model_annotation="Goose",
+            commit_sha="def5678",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "CIV"
+        assert meta["provider"] == "goose"
+        assert meta["verdict"] == "APPROVED"
+
+    def test_pe_metadata_roundtrip(self) -> None:
+        """PE formatted comment has parseable metadata with correct role."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="PE",
+            verdict="APPROVED",
+            assessment="Sustainable patterns",
+            model_annotation="Goose",
+            commit_sha="ghi9012",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "PE"
+        assert meta["provider"] == "goose"
+        assert meta["verdict"] == "APPROVED"
+
+    def test_tmg_blocked_metadata(self) -> None:
+        """TMG BLOCKED has correct metadata verdict."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="TMG",
+            verdict="BLOCKED",
+            assessment="Tests insufficient",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "TMG"
+        assert meta["verdict"] == "BLOCKED"
+
+
+# ---------------------------------------------------------------------------
+# H. Role-agnostic self-review matching
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestGenericSelfReview:
+    """has_self_review() must match any word/identifier followed by SELF-REVIEWED."""
+
+    def test_has_self_review_with_il(self) -> None:
+        """IL SELF-REVIEWED must match (backward compat)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert has_self_review(["IL SELF-REVIEWED: fixed typo"])
+
+    def test_has_self_review_with_skills_expert(self) -> None:
+        """skills-expert SELF-REVIEWED must match (hyphenated role name)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert has_self_review(["skills-expert SELF-REVIEWED: updated GATES"])
+
+    def test_has_self_review_with_human_name(self) -> None:
+        """Human name like Shaun SELF-REVIEWED must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert has_self_review(["Shaun SELF-REVIEWED: quick config change"])
+
+    def test_has_self_review_with_agent_expert(self) -> None:
+        """agent-expert SELF-REVIEWED must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert has_self_review(["agent-expert SELF-REVIEWED: new agent definition"])
+
+    def test_has_self_review_negative(self) -> None:
+        """Comment without SELF-REVIEWED must not match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert not has_self_review(["NOT-A-REVIEW: just a comment"])
+
+    def test_has_self_review_partial_match(self) -> None:
+        """SELF-REVIEWED alone without role prefix must not match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert not has_self_review(["SELF-REVIEWED"])
+
+    def test_has_il_self_review_backward_compat(self) -> None:
+        """has_il_self_review() must still work as deprecated wrapper."""
+        from hestai_context_mcp.tools.shared.review_formats import has_il_self_review
+
+        assert has_il_self_review(["IL SELF-REVIEWED: backward compat test"])
+
+    def test_has_self_review_empty_list(self) -> None:
+        """Empty list returns False."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert not has_self_review([])
+
+    def test_has_self_review_with_model_annotation(self) -> None:
+        """IL (Claude) SELF-REVIEWED must match via flexible pattern."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert has_self_review(["IL (Claude): SELF-REVIEWED: quick fix"])
+
+    def test_has_self_review_not_matched_in_prose(self) -> None:
+        """SELF-REVIEWED in mid-line prose must not match (line-start anchoring)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_self_review
+
+        assert not has_self_review(["The author submits a SELF-REVIEWED marker for the change"])
+
+
+# ---------------------------------------------------------------------------
+# I. Approval matcher line-start enforcement
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestApprovalMatcherLineStartEnforcement:
+    """matches_approval_pattern() must require role at line-start position.
+
+    Prevents false positives from prose like 'TMG+CRS+CE+CIV+PE by tier), GO aliases'
+    where CE and GO appear on the same line but CE is not at the line start.
+    """
+
+    def test_ce_go_in_prose_not_matched(self) -> None:
+        """CE and GO in prose must NOT match as CE approval.
+
+        Reproduction case from PR #338: TMG review comment contains
+        'TMG+CRS+CE+CIV+PE by tier), GO aliases' which falsely satisfies
+        has_ce_approval() because CE and GO are on the same line.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert not has_ce_approval(
+            ["TMG+CRS+CE+CIV+PE by tier), GO aliases"]
+        ), "CE in prose must NOT satisfy approval gate"
+
+    def test_ce_approved_in_prose_not_matched(self) -> None:
+        """'The CE review found APPROVED patterns' must NOT match."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert not matches_approval_pattern(
+            "The CE review found APPROVED patterns", "CE", "APPROVED"
+        )
+
+    def test_tmg_in_prose_not_matched(self) -> None:
+        """TMG in compound expression must NOT satisfy approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert not has_tmg_approval(["Required: TMG+CRS+CE, with GO keyword support"])
+
+    def test_crs_in_prose_not_matched(self) -> None:
+        """CRS in compound expression must NOT satisfy approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert not has_crs_approval(["Required: TMG+CRS+CE, then APPROVED by reviewers"])
+
+    def test_approval_at_line_start_still_matches(self) -> None:
+        """CE APPROVED at actual line start must still match."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("CE APPROVED: looks good", "CE", "APPROVED")
+
+    def test_approval_after_pipe_still_matches(self) -> None:
+        """CE in markdown table (after pipe) must still match."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("| CE | APPROVED | assessment |", "CE", "APPROVED")
+
+    def test_approval_with_leading_whitespace_matches(self) -> None:
+        """CE APPROVED with leading whitespace must still match."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        assert matches_approval_pattern("  CE APPROVED: looks good", "CE", "APPROVED")
+
+    def test_multiline_prose_then_approval(self) -> None:
+        """Role in prose on line 1 must NOT match, but role at line start on line 2 must."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            matches_approval_pattern,
+        )
+
+        text = "Need CE and CRS reviews\nCE APPROVED: assessment here"
+        assert matches_approval_pattern(text, "CE", "APPROVED")
+
+
+# ---------------------------------------------------------------------------
+# J. SR (Standards Reviewer) approval matching
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSRApprovalMatching:
+    """has_sr_approval() must match SR approval patterns."""
+
+    def test_sr_approved_basic(self) -> None:
+        """'SR APPROVED: standards aligned with North Star' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert has_sr_approval(["SR APPROVED: standards aligned with North Star"])
+
+    def test_sr_approved_with_model_annotation(self) -> None:
+        """'SR (Gemini): APPROVED: no contradictions detected' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert has_sr_approval(["SR (Gemini): APPROVED: no contradictions detected"])
+
+    def test_sr_go_keyword(self) -> None:
+        """'SR GO: standards artifacts complete' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert has_sr_approval(["SR GO: standards artifacts complete"])
+
+    def test_sr_go_with_model(self) -> None:
+        """'SR (Codex): GO: alignment verified' must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert has_sr_approval(["SR (Codex): GO: alignment verified"])
+
+    def test_sr_no_false_positive_xsr(self) -> None:
+        """'XSR APPROVED' must NOT match (word boundary)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert not has_sr_approval(["XSR APPROVED: fake"])
+
+    def test_sr_no_false_positive_blocked(self) -> None:
+        """'SR BLOCKED' must NOT match as approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert not has_sr_approval(["SR BLOCKED: North Star contradiction detected"])
+
+    def test_sr_no_match_empty(self) -> None:
+        """Empty list returns False."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert not has_sr_approval([])
+
+    def test_sr_approved_with_em_dash(self) -> None:
+        """'SR (Gemini) \u2014 APPROVED' with em dash must match."""
+        from hestai_context_mcp.tools.shared.review_formats import has_sr_approval
+
+        assert has_sr_approval(["SR (Gemini) \u2014 APPROVED: standards review passed"])
+
+    def test_has_gr_approval_matches_legacy_gr(self) -> None:
+        """has_gr_approval() must still match legacy 'GR APPROVED' comments."""
+        from hestai_context_mcp.tools.shared.review_formats import has_gr_approval
+
+        assert has_gr_approval(["GR APPROVED: legacy governance review"])
+
+    def test_has_gr_approval_also_matches_sr(self) -> None:
+        """has_gr_approval() must also match new 'SR APPROVED' comments."""
+        from hestai_context_mcp.tools.shared.review_formats import has_gr_approval
+
+        assert has_gr_approval(["SR APPROVED: standards review"])
+
+
+# ---------------------------------------------------------------------------
+# K. format_review_comment and metadata for SR role
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestFormatReviewCommentSR:
+    """format_review_comment() must work with SR role."""
+
+    def test_format_sr_approved(self) -> None:
+        """Format SR APPROVED comment."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="SR", verdict="APPROVED", assessment="Standards aligned with North Star"
+        )
+        assert matches_approval_pattern(comment, "SR", "APPROVED")
+        assert "Standards aligned with North Star" in comment
+
+    def test_format_sr_with_model(self) -> None:
+        """Format SR APPROVED with model annotation."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            matches_approval_pattern,
+        )
+
+        comment = format_review_comment(
+            role="SR",
+            verdict="APPROVED",
+            assessment="No contradictions detected",
+            model_annotation="Gemini",
+        )
+        assert matches_approval_pattern(comment, "SR", "APPROVED")
+        assert "Gemini" in comment
+
+    def test_format_sr_blocked(self) -> None:
+        """Format SR BLOCKED comment with correct prefix and metadata."""
+        from hestai_context_mcp.tools.shared.review_formats import format_review_comment
+
+        comment = format_review_comment(
+            role="SR", verdict="BLOCKED", assessment="North Star contradiction detected"
+        )
+        assert comment.startswith(
+            "SR BLOCKED:"
+        ), f"SR BLOCKED comment must start with 'SR BLOCKED:', got: {comment[:30]}"
+        assert "North Star contradiction detected" in comment
+        assert "<!-- review:" in comment, "BLOCKED comment must contain metadata line"
+
+    def test_sr_metadata_roundtrip(self) -> None:
+        """SR formatted comment has parseable metadata with correct role."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="SR",
+            verdict="APPROVED",
+            assessment="Standards aligned",
+            model_annotation="Gemini",
+            commit_sha="abc1234",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "SR"
+        assert meta["provider"] == "gemini"
+        assert meta["verdict"] == "APPROVED"
+        assert meta["sha"] == "abc1234"
+
+    def test_sr_blocked_metadata(self) -> None:
+        """SR BLOCKED has correct metadata verdict."""
+        from hestai_context_mcp.tools.shared.review_formats import (
+            format_review_comment,
+            parse_review_metadata,
+        )
+
+        comment = format_review_comment(
+            role="SR",
+            verdict="BLOCKED",
+            assessment="Precedence hierarchy violation",
+        )
+        meta = parse_review_metadata(comment)
+        assert meta is not None
+        assert meta["role"] == "SR"
+        assert meta["verdict"] == "BLOCKED"

--- a/tests/unit/scripts/test_validate_review_pr_reviews.py
+++ b/tests/unit/scripts/test_validate_review_pr_reviews.py
@@ -1,0 +1,406 @@
+"""Tests for check_pr_comments() including PR review bodies.
+
+Contract:
+- check_pr_comments() fetches `reviews` alongside `comments,body`
+- Each review's .body is included in searchable_texts for APPROVED and COMMENTED states
+- DISMISSED and PENDING reviews are excluded regardless of body content
+- Bot reviews are excluded using the same _BOT_LOGIN_SET logic
+- A review body containing a valid approval satisfies the relevant role checker
+- Existing comment-path behaviour is unaffected (no regression)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr_data(
+    *,
+    body: str = "",
+    comments: list[dict[str, Any]] | None = None,
+    reviews: list[dict[str, Any]] | None = None,
+) -> str:
+    """Build the JSON string that `gh pr view` would emit."""
+    return json.dumps(
+        {
+            "body": body,
+            "comments": comments or [],
+            "reviews": reviews or [],
+        }
+    )
+
+
+def _run_check(
+    pr_data_json: str,
+    required_roles: set[str] | None = None,
+    tier: str = "",
+) -> tuple[bool, str, list[str]]:
+    """Invoke check_pr_comments with a mocked subprocess and CI env."""
+    mock_result = MagicMock()
+    mock_result.stdout = pr_data_json
+
+    env_patch = {"CI": "true", "PR_NUMBER": "42"}
+
+    with (
+        patch.dict(os.environ, env_patch),
+        patch("scripts.validate_review.subprocess.run", return_value=mock_result),
+    ):
+        from scripts.validate_review import check_pr_comments
+
+        return check_pr_comments(required_roles=required_roles, tier=tier)
+
+
+# ---------------------------------------------------------------------------
+# Tests: review bodies ARE included in searchable_texts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsIncludesReviews:
+    """check_pr_comments() must include PR review bodies in approval search."""
+
+    def test_crs_approval_in_review_body_satisfies_gate(self) -> None:
+        """A CRS APPROVED verdict posted as a PR review body must pass the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: looks good",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_ce_approval_in_review_body_satisfies_gate(self) -> None:
+        """A CE APPROVED verdict in a PR review body must pass the CE check."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: implementation is clean",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_tmg_approval_in_review_body_satisfies_gate(self) -> None:
+        """A TMG APPROVED verdict in a PR review body must pass the TMG check."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "tmg-agent"},
+                    "state": "COMMENTED",
+                    "body": "## TMG APPROVED ✅\nAll checks pass.",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"TMG"})
+        assert approved is True, f"Expected approval from review body; missing={missing}"
+        assert missing == []
+
+    def test_multiple_roles_all_in_review_bodies(self) -> None:
+        """Multiple roles approved via PR review bodies all satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "tmg-agent"},
+                    "state": "COMMENTED",
+                    "body": "TMG APPROVED: structural review complete",
+                },
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: code quality confirmed",
+                },
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: engineering standards met",
+                },
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"TMG", "CRS", "CE"})
+        assert approved is True, f"Expected all roles approved; missing={missing}"
+        assert missing == []
+
+    def test_approvals_split_across_comments_and_reviews(self) -> None:
+        """One role approved via issue comment, another via PR review body."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "ce-user"},
+                    "body": "CE APPROVED: implementation looks correct",
+                }
+            ],
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: passes review",
+                }
+            ],
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE", "CRS"})
+        assert approved is True, f"Expected both roles satisfied; missing={missing}"
+        assert missing == []
+
+    def test_review_body_without_approval_does_not_satisfy(self) -> None:
+        """A review body without an approval pattern must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "reviewer"},
+                    "state": "COMMENTED",
+                    "body": "Looking at this PR now, will review shortly.",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False
+        assert "CRS" in missing
+
+    def test_missing_role_still_reported_when_review_has_different_role(self) -> None:
+        """A review body satisfying CRS must not satisfy CE."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: code quality confirmed",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False
+        assert "CE" in missing
+
+
+# ---------------------------------------------------------------------------
+# Tests: dismissed and pending reviews are excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsReviewStateFiltering:
+    """Only APPROVED and COMMENTED reviews must contribute to approval matching."""
+
+    def test_dismissed_review_approval_is_ignored(self) -> None:
+        """A DISMISSED review containing an approval keyword must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "DISMISSED",
+                    "body": "CRS APPROVED: looked good at the time",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "DISMISSED review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_pending_review_approval_is_ignored(self) -> None:
+        """A PENDING review (not yet submitted) must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "ce-agent"},
+                    "state": "PENDING",
+                    "body": "CE APPROVED: draft review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False, "PENDING review must not satisfy the gate"
+        assert "CE" in missing
+
+    def test_commented_review_approval_is_included(self) -> None:
+        """A COMMENTED review (self-review state) must satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: review complete",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "COMMENTED review must satisfy the gate"
+        assert missing == []
+
+    def test_approved_state_review_is_included(self) -> None:
+        """A review with state=APPROVED must also satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "APPROVED",
+                    "body": "CRS APPROVED: full approval",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "APPROVED-state review must satisfy the gate"
+        assert missing == []
+
+    def test_dismissed_review_does_not_block_valid_comment_approval(self) -> None:
+        """A dismissed review for a role must not prevent a valid comment from satisfying it."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "crs-user"},
+                    "body": "CRS APPROVED: approved via comment",
+                }
+            ],
+            reviews=[
+                {
+                    "author": {"login": "crs-agent"},
+                    "state": "DISMISSED",
+                    "body": "CRS APPROVED: earlier dismissed review",
+                }
+            ],
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "Valid comment approval must satisfy gate despite dismissed review"
+        assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: bot reviews are excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsBotReviewExclusion:
+    """Bot-authored PR review bodies must be excluded from approval matching."""
+
+    def test_bot_review_approval_is_ignored(self) -> None:
+        """A CRS APPROVED in a review from a known bot must not satisfy the gate."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "github-actions"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: auto-generated review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "Bot review approval must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_copilot_review_approval_is_ignored(self) -> None:
+        """A CE APPROVED in a review from github-copilot bot must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "Copilot"},
+                    "state": "COMMENTED",
+                    "body": "CE APPROVED: copilot auto-review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CE"})
+        assert approved is False, "Copilot bot review must not satisfy the gate"
+        assert "CE" in missing
+
+    def test_bot_suffix_review_approval_is_ignored(self) -> None:
+        """A review from any [bot]-suffixed account must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "some-new-bot[bot]"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: auto-review",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "[bot]-suffixed review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_human_review_with_bot_marker_is_excluded(self) -> None:
+        """A review body containing the review-gate-status marker must be excluded."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "some-human"},
+                    "state": "COMMENTED",
+                    "body": "<!-- review-gate-status -->\nCRS APPROVED: injected",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False, "Status-marker review must not satisfy the gate"
+        assert "CRS" in missing
+
+    def test_human_non_bot_review_is_included(self) -> None:
+        """A review from a non-bot human account must be included."""
+        pr_data = _make_pr_data(
+            reviews=[
+                {
+                    "author": {"login": "shaun"},
+                    "state": "COMMENTED",
+                    "body": "CRS APPROVED: reviewed by human",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True, "Human review must satisfy the gate"
+        assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: no regression on existing comment path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckPrCommentsNoRegression:
+    """Existing comment-based approval path must still work after the fix."""
+
+    def test_comment_approval_still_works(self) -> None:
+        """CRS approval in an issue comment still satisfies the gate (no regression)."""
+        pr_data = _make_pr_data(
+            comments=[
+                {
+                    "author": {"login": "crs-user"},
+                    "body": "CRS APPROVED: all good",
+                }
+            ]
+        )
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True
+        assert missing == []
+
+    def test_pr_body_approval_still_works(self) -> None:
+        """CRS approval in the PR body itself still satisfies the gate."""
+        pr_data = _make_pr_data(body="CRS APPROVED: in the PR description")
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is True
+        assert missing == []
+
+    def test_empty_reviews_field_does_not_crash(self) -> None:
+        """When reviews key is absent from API response, the gate must not crash."""
+        # Simulate old response format without reviews key
+        pr_data_dict = {"body": "", "comments": []}
+        pr_data = json.dumps(pr_data_dict)
+        approved, _msg, missing = _run_check(pr_data, required_roles={"CRS"})
+        assert approved is False  # No approval present
+        assert "CRS" in missing

--- a/tests/unit/test_validate_review_5tier.py
+++ b/tests/unit/test_validate_review_5tier.py
@@ -1,0 +1,1535 @@
+"""
+Contract tests for the 5-tier review system in validate_review.py.
+
+Tests verify tier determination, approval requirements, and governance compliance
+for the expanded TMG/CIV/PE role structure:
+- T1 threshold (<10 lines, single non-exempt file, no security paths, no new tests)
+- T2 range (10-500 lines, requires TMG + CRS + CE)
+- T3 triggers (>500 lines, security/architecture paths, requires TMG + CRS + CE + CIV)
+- T4 strategic (manual-only, requires TMG + CRS + CE + CIV + PE)
+- T0 exemptions (docs, tests, locks, generated JSON only)
+
+Source of truth: review-requirements.oct.md v2.0 (5-tier system)
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import validate_review
+
+
+@pytest.fixture
+def ci_environment(monkeypatch):
+    """Set up CI environment variables."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_BASE_REF", "origin/main")
+    monkeypatch.setenv("PR_NUMBER", "999")
+
+
+# ---------------------------------------------------------------------------
+# 1. T1 threshold change: <10 lines (was <50)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier1ThresholdChange:
+    """T1 threshold must be <10 lines (was <50 in old system)."""
+
+    def test_9_lines_single_file_is_tier_1(self) -> None:
+        """9 lines changed in single non-exempt file = TIER_1_SELF."""
+        files = [{"path": "src/utils.py", "added": 5, "deleted": 4, "total_changed": 9}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_1_SELF", f"9 lines in single file should be T1, got {tier}"
+
+    def test_10_lines_single_file_is_not_tier_1(self) -> None:
+        """10 lines changed should be TIER_2_STANDARD, not TIER_1_SELF.
+
+        The governance rule says T1 is non_exempt_lines<10, so 10 lines
+        should NOT qualify for self-review.
+        """
+        files = [{"path": "src/utils.py", "added": 6, "deleted": 4, "total_changed": 10}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"10 lines should be T2, got {tier}"
+
+    def test_30_lines_single_file_is_not_tier_1(self) -> None:
+        """30 lines changed must NOT be TIER_1_SELF under new <10 threshold.
+
+        This was previously T1 under the <50 threshold. Under the new system
+        it must be T2 (10-500 lines).
+        """
+        files = [{"path": "src/utils.py", "added": 20, "deleted": 10, "total_changed": 30}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier != "TIER_1_SELF", f"30 lines must NOT be T1 under new threshold, got {tier}"
+        assert tier == "TIER_2_STANDARD", f"30 lines should be T2, got {tier}"
+
+    def test_49_lines_single_file_is_tier_2_not_tier_1(self) -> None:
+        """49 lines was T1 under old system but must be T2 under new <10 threshold."""
+        files = [{"path": "src/utils.py", "added": 30, "deleted": 19, "total_changed": 49}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"49 lines must be T2 under new threshold, got {tier}"
+
+    def test_1_line_single_file_is_tier_1(self) -> None:
+        """1 line changed in single file = TIER_1_SELF."""
+        files = [{"path": "src/config.py", "added": 1, "deleted": 0, "total_changed": 1}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_1_SELF", f"1 line should be T1, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 2. T1 with security paths -- must be upgraded
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier1SecurityPathUpgrade:
+    """T1 self-review must be denied when security-touching paths are changed."""
+
+    def test_small_change_in_auth_path_not_tier_1(self) -> None:
+        """<10 lines in auth path must NOT be TIER_1_SELF (security guard).
+
+        The governance rule says T1 requires no_security_paths. Changes to
+        auth-related files must always get a higher tier review.
+        """
+        files = [
+            {"path": "src/hestai_mcp/auth/handler.py", "added": 3, "deleted": 2, "total_changed": 5}
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Security-touching path (auth) must be TIER_3_CRITICAL, got {tier}"
+
+    def test_small_change_in_session_management_not_tier_1(self) -> None:
+        """<10 lines in session management must be TIER_3_CRITICAL (security guard)."""
+        files = [
+            {
+                "path": "src/hestai_mcp/session/manager.py",
+                "added": 2,
+                "deleted": 1,
+                "total_changed": 3,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Security-touching path (session) must be TIER_3_CRITICAL, got {tier}"
+
+    def test_small_change_in_env_vars_handling_not_tier_1(self) -> None:
+        """<10 lines changing env var handling must be TIER_3_CRITICAL."""
+        files = [
+            {"path": "src/hestai_mcp/config/env.py", "added": 3, "deleted": 0, "total_changed": 3}
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Security-touching path (env) must be TIER_3_CRITICAL, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 3. T1 with new test files -- must be upgraded
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier1NewTestFileUpgrade:
+    """T1 self-review must be denied when new test files are included.
+
+    Per governance rule: T1 requires no_new_test_files. New test files
+    indicate substantive changes that require TMG review at T2+.
+    """
+
+    def test_small_change_with_new_test_file_not_tier_1(self) -> None:
+        """<10 lines but including a new test file must NOT be TIER_1_SELF.
+
+        New tests indicate functional changes that need TMG review.
+        """
+        files = [
+            {"path": "src/utils.py", "added": 3, "deleted": 0, "total_changed": 3, "status": "M"},
+            {
+                "path": "tests/test_utils.py",
+                "added": 5,
+                "deleted": 0,
+                "total_changed": 5,
+                "status": "A",
+            },
+        ]
+        # Governance says no_new_test_files for T1. The "status": "A" marks the
+        # test file as newly added, which should disqualify T1 self-review.
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_2_STANDARD"
+        ), f"PR with new test files must be TIER_2_STANDARD, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 4. T2 range: 10-500 lines
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier2Range:
+    """T2 must cover 10-500 lines (was 50-500)."""
+
+    def test_10_lines_is_tier_2(self) -> None:
+        """10 lines = lower bound of T2."""
+        files = [{"path": "src/core.py", "added": 6, "deleted": 4, "total_changed": 10}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"10 lines should be T2, got {tier}"
+
+    def test_15_lines_is_tier_2(self) -> None:
+        """15 lines = within T2 range."""
+        files = [{"path": "src/core.py", "added": 10, "deleted": 5, "total_changed": 15}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"15 lines should be T2, got {tier}"
+
+    def test_500_lines_is_tier_2(self) -> None:
+        """500 lines = upper bound of T2."""
+        files = [{"path": "src/core.py", "added": 300, "deleted": 200, "total_changed": 500}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"500 lines should be T2, got {tier}"
+
+    def test_multiple_files_in_range_is_tier_2(self) -> None:
+        """Multiple non-exempt files with total 10-500 lines = T2."""
+        files = [
+            {"path": "src/a.py", "added": 5, "deleted": 0, "total_changed": 5},
+            {"path": "src/b.py", "added": 10, "deleted": 0, "total_changed": 10},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_2_STANDARD", f"Multiple files 15 lines should be T2, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 5. T3 triggers
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier3Triggers:
+    """All T3 triggers from governance rule must produce TIER_3_CRITICAL."""
+
+    def test_over_500_lines_is_tier_3_critical(self) -> None:
+        """>500 lines must trigger TIER_3_CRITICAL."""
+        files = [{"path": "src/core.py", "added": 400, "deleted": 200, "total_changed": 600}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f">500 lines should be TIER_3_CRITICAL, got {tier}"
+
+    def test_base_class_change_is_tier_3(self) -> None:
+        """Changes to base class files must trigger T3.
+
+        Per governance: touches_base_class[**/base.py,**/shared/**,abstract_classes]
+        """
+        files = [{"path": "src/hestai_mcp/base.py", "added": 10, "deleted": 5, "total_changed": 15}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"Base class change should be TIER_3_CRITICAL, got {tier}"
+
+    def test_shared_module_change_is_tier_3(self) -> None:
+        """Changes to shared modules must trigger T3.
+
+        Per governance: touches_base_class[**/shared/**]
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/modules/tools/shared/utils.py",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Shared module change should be TIER_3_CRITICAL, got {tier}"
+
+    def test_security_touching_code_is_tier_3(self) -> None:
+        """Security-touching code must trigger T3.
+
+        Per governance: touches_security[auth,path_handling,session_management,env_vars]
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/auth/handler.py",
+                "added": 50,
+                "deleted": 20,
+                "total_changed": 70,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Security-touching code should be TIER_3_CRITICAL, got {tier}"
+
+    def test_new_tool_addition_is_tier_3(self) -> None:
+        """New tool addition must trigger T3.
+
+        Per governance: is_new_tool[tools/**,clink/agents/**]
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/modules/tools/new_tool.py",
+                "added": 50,
+                "deleted": 0,
+                "total_changed": 50,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"New tool addition should be TIER_3_CRITICAL, got {tier}"
+
+    def test_new_mcp_endpoint_is_tier_3(self) -> None:
+        """New MCP endpoint must trigger T3.
+
+        Per governance: is_new_mcp_endpoint[mcp/tools/**]
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/mcp/tools/new_endpoint.py",
+                "added": 40,
+                "deleted": 0,
+                "total_changed": 40,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"New MCP endpoint should be TIER_3_CRITICAL, got {tier}"
+
+    def test_sql_change_is_tier_3(self) -> None:
+        """SQL file changes must trigger T3."""
+        files = [{"path": "migrations/001.sql", "added": 20, "deleted": 5, "total_changed": 25}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"SQL change should be TIER_3_CRITICAL, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Tier name changes
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTierNameChanges:
+    """Tier names must match the new 5-tier system naming."""
+
+    def test_tier_3_returns_critical_not_strict(self) -> None:
+        """determine_review_tier must return TIER_3_CRITICAL, not TIER_3_STRICT.
+
+        The old system used TIER_3_STRICT. The new 5-tier system renames
+        this to TIER_3_CRITICAL per the governance rule.
+        """
+        files = [{"path": "src/core.py", "added": 400, "deleted": 200, "total_changed": 600}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert "STRICT" not in tier, f"TIER_3_STRICT is deprecated, got {tier}"
+        assert tier == "TIER_3_CRITICAL", f"Must return TIER_3_CRITICAL, got {tier}"
+
+    def test_tier_4_strategic_name(self) -> None:
+        """TIER_4_STRATEGIC must be a recognized tier value.
+
+        This tier is manual-only (triggered by /review --strategic or
+        explicit tier override), so determine_review_tier won't auto-detect it.
+        But the tier constant must exist and be usable.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import TIER_4_STRATEGIC
+
+        assert TIER_4_STRATEGIC == "TIER_4_STRATEGIC"
+
+
+# ---------------------------------------------------------------------------
+# 7. T2 approval checking: TMG + CRS + CE
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier2ApprovalRequirements:
+    """TIER_2_STANDARD must require TMG + CRS + CE approval (was CRS + CE)."""
+
+    def test_tier_2_with_tmg_crs_ce_passes(self, ci_environment, monkeypatch) -> None:
+        """T2 with TMG + CRS + CE approvals must pass."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests cover critical paths"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, f"T2 with TMG+CRS+CE should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_tier_2_without_tmg_fails(self, ci_environment, monkeypatch) -> None:
+        """T2 with only CRS + CE (no TMG) must FAIL.
+
+        Under the old system, CRS+CE was sufficient for T2.
+        Under the new 5-tier system, TMG is also required.
+        """
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"T2 without TMG should fail under 5-tier system, got: {message}"
+        assert "TMG" in message, f"Error message should mention missing TMG, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# 8. T3 approval checking: TMG + CRS + CE + CIV
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier3ApprovalRequirements:
+    """TIER_3_CRITICAL must require TMG + CRS + CE + CIV approval."""
+
+    def test_tier_3_with_tmg_crs_ce_civ_passes(self, ci_environment, monkeypatch) -> None:
+        """T3 with TMG + CRS + CE + CIV approvals must pass."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests cover critical paths"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, f"T3 with TMG+CRS+CE+CIV should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_tier_3_without_civ_fails(self, ci_environment, monkeypatch) -> None:
+        """T3 with TMG + CRS + CE but no CIV must FAIL."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests cover critical paths"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is False, f"T3 without CIV should fail, got: {message}"
+        assert "CIV" in message, f"Error message should mention missing CIV, got: {message}"
+
+    def test_tier_3_without_tmg_fails(self, ci_environment, monkeypatch) -> None:
+        """T3 with CRS + CE + CIV but no TMG must FAIL."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation valid"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is False, f"T3 without TMG should fail, got: {message}"
+        assert "TMG" in message, f"Error message should mention missing TMG, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# 9. T4 approval checking: TMG + CRS + CE + CIV + PE
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier4ApprovalRequirements:
+    """TIER_4_STRATEGIC must require TMG + CRS + CE + CIV + PE approval."""
+
+    def test_tier_4_with_all_five_passes(self, ci_environment, monkeypatch) -> None:
+        """T4 with TMG + CRS + CE + CIV + PE approvals must pass."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests comprehensive"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                            {"body": "PE APPROVED: Architecture sound for 6 months"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_4_STRATEGIC")
+        assert approved is True, f"T4 with TMG+CRS+CE+CIV+PE should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_tier_4_without_pe_fails(self, ci_environment, monkeypatch) -> None:
+        """T4 with TMG + CRS + CE + CIV but no PE must FAIL."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests comprehensive"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_4_STRATEGIC")
+        assert approved is False, f"T4 without PE should fail, got: {message}"
+        assert "PE" in message, f"Error message should mention missing PE, got: {message}"
+
+    def test_tier_4_without_civ_fails(self, ci_environment, monkeypatch) -> None:
+        """T4 with TMG + CRS + CE + PE but no CIV must FAIL."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests comprehensive"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "PE APPROVED: Sustainable"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_4_STRATEGIC")
+        assert approved is False, f"T4 without CIV should fail, got: {message}"
+        assert "CIV" in message, f"Error message should mention missing CIV, got: {message}"
+
+    def test_tier_4_with_only_crs_ce_fails(self, ci_environment, monkeypatch) -> None:
+        """T4 with only CRS + CE (no TMG, CIV, PE) must FAIL."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_4_STRATEGIC")
+        assert approved is False, f"T4 with only CRS+CE should fail, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# C3: T0 exemption tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier0Exemption:
+    """TIER_0_EXEMPT must cover docs-only, tests-only, lock-only PRs.
+
+    Governance defines conditional exemptions for changes that only touch
+    exempt file types. Mixed exempt + non-exempt must NOT be exempt.
+    """
+
+    def test_docs_only_pr_is_exempt(self) -> None:
+        """PR with only .md files -> TIER_0_EXEMPT."""
+        files = [
+            {"path": "docs/README.md", "added": 10, "deleted": 5, "total_changed": 15},
+            {"path": "CHANGELOG.md", "added": 3, "deleted": 0, "total_changed": 3},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT", f"Docs-only PR should be exempt, got {tier}"
+
+    def test_tests_only_pr_no_src_is_exempt(self) -> None:
+        """PR with only test files and no src changes -> TIER_0_EXEMPT."""
+        files = [
+            {"path": "tests/unit/test_foo.py", "added": 20, "deleted": 5, "total_changed": 25},
+            {"path": "tests/conftest.py", "added": 5, "deleted": 0, "total_changed": 5},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT", f"Tests-only PR should be exempt, got {tier}"
+
+    def test_lock_only_pr_is_exempt(self) -> None:
+        """PR with only lock files -> TIER_0_EXEMPT."""
+        files = [
+            {"path": "uv.lock", "added": 100, "deleted": 50, "total_changed": 150},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT", f"Lock-only PR should be exempt, got {tier}"
+
+    def test_mixed_exempt_and_non_exempt_is_not_exempt(self) -> None:
+        """PR with exempt + non-exempt files must NOT be exempt."""
+        files = [
+            {"path": "docs/README.md", "added": 10, "deleted": 0, "total_changed": 10},
+            {"path": "src/utils.py", "added": 5, "deleted": 0, "total_changed": 5},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier != "TIER_0_EXEMPT", f"Mixed PR must NOT be exempt, got {tier}"
+
+    def test_non_generated_json_not_exempt(self) -> None:
+        """Hand-edited .json config files must NOT be TIER_0_EXEMPT.
+
+        Governance says **/*.json[when:generated_file] -- JSON is exempt ONLY
+        when it is a generated file (package-lock.json, coverage reports).
+        Hand-edited config files like src/config/settings.json are NOT exempt.
+        """
+        files = [
+            {
+                "path": "src/config/settings.json",
+                "added": 5,
+                "deleted": 2,
+                "total_changed": 7,
+            },
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier != "TIER_0_EXEMPT", (
+            f"Hand-edited JSON (src/config/settings.json) must NOT be exempt, got {tier}. "
+            "Governance says **/*.json[when:generated_file] — only generated JSON is exempt."
+        )
+
+    def test_oct_md_files_are_not_exempt(self) -> None:
+        """.oct.md files are governance code and must NOT be exempt.
+
+        The exempt pattern uses a negative lookbehind: .*(?<!\\.oct)\\.md$
+        so regular .md files are exempt but .oct.md files are not.
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/skills/foo/SKILL.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            },
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier != "TIER_0_EXEMPT", f".oct.md files must NOT be exempt, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# C4: GO alias tests in validator
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestGOAliasApprovalInValidator:
+    """Governance defines TMG GO, CIV GO, PE GO as valid approval forms.
+
+    check_pr_comments() must accept GO as well as APPROVED for new roles.
+    """
+
+    def test_tier_2_passes_with_tmg_go(self, ci_environment, monkeypatch) -> None:
+        """T2 passes with TMG GO + CRS APPROVED + CE APPROVED."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG GO: sufficient test coverage"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, f"T2 with TMG GO should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_tier_3_passes_with_civ_go(self, ci_environment, monkeypatch) -> None:
+        """T3 passes with TMG APPROVED + CRS APPROVED + CE APPROVED + CIV GO."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests cover critical paths"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV GO: implementation clean"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is True, f"T3 with CIV GO should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_tier_4_passes_with_pe_go(self, ci_environment, monkeypatch) -> None:
+        """T4 passes with all required including PE GO."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests comprehensive"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                            {"body": "CIV APPROVED: Implementation matches spec"},
+                            {"body": "PE GO: long-term sustainable"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_4_STRATEGIC")
+        assert approved is True, f"T4 with PE GO should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+
+# ---------------------------------------------------------------------------
+# H1: Missing T3 trigger paths
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier3TriggersMissing:
+    """Additional T3 triggers from governance not covered by original tests."""
+
+    def test_path_handling_security_path_is_tier_3(self) -> None:
+        """path_handling security path (e.g., src/core/path_utils.py) -> T3."""
+        files = [
+            {
+                "path": "src/core/path_utils.py",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"Path handling code should be T3, got {tier}"
+
+    def test_abstract_class_change_is_tier_3(self) -> None:
+        """Abstract class file -> T3 per governance: abstract_classes."""
+        files = [
+            {
+                "path": "src/hestai_mcp/abstract/base_handler.py",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Abstract class change should be TIER_3_CRITICAL, got {tier}"
+
+    def test_clink_agents_path_is_tier_3(self) -> None:
+        """clink/agents/** path -> T3 per governance: is_new_tool."""
+        files = [
+            {
+                "path": "clink/agents/new_agent.py",
+                "added": 30,
+                "deleted": 0,
+                "total_changed": 30,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"clink/agents path should be TIER_3_CRITICAL, got {tier}"
+
+    def test_new_hooks_change_triggers_tier_3(self) -> None:
+        """Hooks directory files must trigger TIER_3_CRITICAL.
+
+        Per governance: architecture_changes[base_class_mods,new_hooks] is a T3
+        trigger. Files in a hooks directory (e.g., src/hestai_mcp/hooks/pre_commit.py)
+        are classified as TIER_3_CRITICAL.
+        """
+        files = [
+            {
+                "path": "src/hestai_mcp/hooks/pre_commit.py",
+                "added": 20,
+                "deleted": 5,
+                "total_changed": 25,
+            }
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", (
+            f"New hooks file should be TIER_3_CRITICAL, got {tier}. "
+            "Governance says architecture_changes[base_class_mods,new_hooks] triggers T3."
+        )
+
+    def test_501_lines_boundary_is_tier_3(self) -> None:
+        """501 lines (just over the 500 boundary) -> TIER_3_CRITICAL."""
+        files = [{"path": "src/big_module.py", "added": 300, "deleted": 201, "total_changed": 501}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_3_CRITICAL", f"501 lines should be TIER_3_CRITICAL, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# H2: Multi-file <10 lines -> T2 (not T1)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestMultiFileLowLinesIsT2:
+    """Multiple non-exempt files with <10 total lines must be T2 (not T1).
+
+    Governance requires single_non_exempt_file for T1. Two files with 5 total
+    lines should be T2 because the file count guard disqualifies T1.
+    """
+
+    def test_two_files_under_10_lines_is_tier_2(self) -> None:
+        """2 non-exempt files, 3+2=5 total lines -> T2, not T1."""
+        files = [
+            {"path": "src/a.py", "added": 2, "deleted": 1, "total_changed": 3},
+            {"path": "src/b.py", "added": 1, "deleted": 1, "total_changed": 2},
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier == "TIER_2_STANDARD"
+        ), f"Multiple non-exempt files even with <10 lines should be T2, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# H3: T4 auto-detection guard
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier4NeverAutoDetected:
+    """determine_review_tier() must NEVER return TIER_4_STRATEGIC.
+
+    T4 is manual-only, triggered by /review --strategic or explicit override.
+    Even extreme inputs (1000 lines, SQL, security paths) should cap at T3.
+    """
+
+    def test_extreme_inputs_never_return_tier_4(self) -> None:
+        """1000 lines + SQL + security path should still be T3 at most."""
+        files = [
+            {
+                "path": "src/hestai_mcp/auth/critical.py",
+                "added": 500,
+                "deleted": 200,
+                "total_changed": 700,
+            },
+            {
+                "path": "migrations/dangerous.sql",
+                "added": 200,
+                "deleted": 100,
+                "total_changed": 300,
+            },
+        ]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert (
+            tier != "TIER_4_STRATEGIC"
+        ), f"determine_review_tier must never auto-detect T4, got {tier}"
+        # It should be T3 (TIER_3_CRITICAL under the 5-tier system)
+        assert tier == "TIER_3_CRITICAL", f"Extreme inputs should be TIER_3_CRITICAL, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# H4: Metadata/cross-validation tests for new roles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestMetadataCrossValidationNewRoles:
+    """Validator anti-spoof logic must work with TMG/CIV/PE.
+
+    Once TMG/CIV/PE are in VALID_ROLES, the cross-validation at
+    validate_review.py:206-264 must reject spoofed approvals.
+    """
+
+    def test_metadata_backed_tmg_crs_ce_satisfies_tier_2(self, ci_environment, monkeypatch) -> None:
+        """Metadata-backed TMG/CRS/CE approvals satisfy T2 gate."""
+        import subprocess
+
+        tmg_comment = (
+            "TMG APPROVED: tests cover critical paths\n"
+            '<!-- review: {"role":"TMG","provider":"goose","verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+        crs_comment = (
+            "CRS APPROVED: Logic correct\n"
+            '<!-- review: {"role":"CRS","provider":"gemini","verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+        ce_comment = (
+            "CE APPROVED: Architecture sound\n"
+            '<!-- review: {"role":"CE","provider":"codex","verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": tmg_comment},
+                            {"body": crs_comment},
+                            {"body": ce_comment},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, f"Metadata-backed T2 should pass, got: {message}"
+        assert "No review required" not in message, "Must actively validate, not fall through"
+
+    def test_spoofed_tmg_approval_fails_cross_validation(self, ci_environment, monkeypatch) -> None:
+        """Spoofed TMG: metadata says APPROVED but visible text says BLOCKED -> fails.
+
+        The cross-validation logic strips metadata HTML comments and checks
+        that visible text also matches the approval pattern.
+        """
+        import subprocess
+
+        # Visible text says BLOCKED but metadata claims APPROVED
+        spoofed_comment = (
+            "TMG BLOCKED: tests insufficient\n"
+            '<!-- review: {"role":"TMG","provider":"goose","verdict":"APPROVED","sha":"abc1234"} -->'
+        )
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": spoofed_comment},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"Spoofed TMG should fail cross-validation, got: {message}"
+        assert (
+            "Cross-validation" in message or "spoofing" in message.lower()
+        ), f"Error should mention cross-validation or spoofing, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# H5: T1 approval tests in validator
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTier1ApprovalInValidator:
+    """check_pr_comments('TIER_1_SELF') must validate self-review patterns."""
+
+    def test_tier_1_passes_with_il_self_reviewed(self, ci_environment, monkeypatch) -> None:
+        """T1 passes with IL SELF-REVIEWED: rationale."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "IL SELF-REVIEWED: Fixed typo in error message"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, f"T1 with IL SELF-REVIEWED should pass, got: {message}"
+
+    def test_tier_1_passes_with_ho_reviewed(self, ci_environment, monkeypatch) -> None:
+        """T1 passes with HO REVIEWED: rationale."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "HO REVIEWED: delegated to IL, verified output"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, f"T1 with HO REVIEWED should pass, got: {message}"
+
+    def test_tier_1_fails_without_any_review(self, ci_environment, monkeypatch) -> None:
+        """T1 fails without IL SELF-REVIEWED or HO REVIEWED."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "Just a random comment"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is False, f"T1 without self-review should fail, got: {message}"
+
+    def test_tier_1_with_generic_role_self_reviewed(self, ci_environment, monkeypatch) -> None:
+        """T1 passes with any role name followed by SELF-REVIEWED.
+
+        The self-review pattern should be role-agnostic: 'skills-expert SELF-REVIEWED'
+        or 'Shaun SELF-REVIEWED' should satisfy T1, not just 'IL SELF-REVIEWED'.
+        """
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "skills-expert SELF-REVIEWED: updated GATES section"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_1_SELF")
+        assert approved is True, f"T1 with generic role SELF-REVIEWED should pass, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# M2: Missing negative approval tests for new roles in validator
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestNegativeApprovalNewRoles:
+    """BLOCKED comments and wrong-role duplicates must NOT satisfy gates."""
+
+    def test_tmg_blocked_does_not_satisfy_tier_2(self, ci_environment, monkeypatch) -> None:
+        """TMG BLOCKED must NOT satisfy the T2 TMG requirement."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG BLOCKED: tests insufficient"},
+                            {"body": "CRS APPROVED: Logic correct"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"TMG BLOCKED should not satisfy T2, got: {message}"
+
+    def test_duplicate_crs_does_not_substitute_for_tmg(self, ci_environment, monkeypatch) -> None:
+        """Duplicate CRS APPROVED should not substitute for missing TMG approval."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: first review"},
+                            {"body": "CRS APPROVED: second review"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"Duplicate CRS should not substitute for TMG, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# M3: Old T3 dual-CRS rule regression
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestOldTier3DualCRSRegression:
+    """Old TIER_3_STRICT dual-CRS(Gemini)+CRS(Codex)+CE model is replaced.
+
+    Under the new 5-tier system, T3 (now TIER_3_CRITICAL) requires
+    TMG + CRS + CE + CIV. The old dual-CRS model must no longer pass.
+    """
+
+    def test_old_dual_crs_plus_ce_fails_for_tier_3(self, ci_environment, monkeypatch) -> None:
+        """T3 with old-style dual CRS + CE (no TMG, no CIV) -> FAILS."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS (Gemini) APPROVED: Logic verified"},
+                            {"body": "CRS (Codex) APPROVED: Patterns sound"},
+                            {"body": "CE APPROVED: Architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_3_CRITICAL")
+        assert approved is False, f"Old dual-CRS+CE model should NOT satisfy new T3, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# Bot comment filtering
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestBotCommentFiltering:
+    """Bot comments must NOT be included in approval pattern matching.
+
+    Copilot, Cubic, and github-actions bot comments often contain
+    approval-like text ('APPROVED', 'GO', etc.) in their review prose. These
+    must be excluded so only human/agent review comments count.
+    """
+
+    def test_copilot_approval_text_not_counted(self, ci_environment, monkeypatch) -> None:
+        """Copilot bot comment with approval text must NOT satisfy gate."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "copilot"},
+                                "body": "CRS APPROVED: All checks pass\nCE APPROVED: Sound",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert (
+            approved is False
+        ), f"Copilot bot comment must NOT satisfy approval gate, got: {message}"
+
+    def test_human_approval_still_counted(self, ci_environment, monkeypatch) -> None:
+        """Human comments alongside bot comments must still be counted."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "cubic-dev-ai"},
+                                "body": "TMG APPROVED: bot text (should be ignored)",
+                            },
+                            {
+                                "author": {"login": "real-user"},
+                                "body": "TMG APPROVED: tests verified",
+                            },
+                            {
+                                "author": {"login": "another-user"},
+                                "body": "CRS APPROVED: Logic correct",
+                            },
+                            {
+                                "author": {"login": "ce-user"},
+                                "body": "CE APPROVED: Architecture sound",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is True, (
+            f"Human comments should still satisfy gate even with bot comments present, "
+            f"got: {message}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Advisory bot constants and normalization
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestAdvisoryBotsConstant:
+    """Pin test for the ADVISORY_BOTS constant.
+
+    ADVISORY_BOTS is the canonical list of bot accounts whose comments are
+    treated as advisory context (never blocking/satisfying review gates).
+    This test prevents silent drift.
+    """
+
+    def test_advisory_bots_contains_expected_entries(self) -> None:
+        """ADVISORY_BOTS must contain all canonical bot accounts."""
+        assert "cubic-dev-ai[bot]" in validate_review.ADVISORY_BOTS
+        assert "github-copilot[bot]" in validate_review.ADVISORY_BOTS
+
+    def test_advisory_bots_does_not_contain_removed_bots(self) -> None:
+        """ADVISORY_BOTS must NOT contain removed bot accounts (CodeRabbit, Qodo)."""
+        assert "coderabbitai[bot]" not in validate_review.ADVISORY_BOTS
+        assert "qodo-code-review[bot]" not in validate_review.ADVISORY_BOTS
+
+    def test_advisory_bots_length(self) -> None:
+        """ADVISORY_BOTS should have exactly 2 entries (detect unintended additions)."""
+        assert len(validate_review.ADVISORY_BOTS) == 2, (
+            f"Expected 2 advisory bots, got {len(validate_review.ADVISORY_BOTS)}: "
+            f"{validate_review.ADVISORY_BOTS}"
+        )
+
+
+@pytest.mark.unit
+class TestBotLoginSetNormalization:
+    """_BOT_LOGIN_SET must correctly strip [bot] suffix and include legacy logins.
+
+    GitHub APIs return different login formats for the same bot accounts:
+    - ``gh pr view --json comments`` strips the [bot] suffix
+    - ``gh api repos/.../pulls/.../comments`` preserves it
+    _BOT_LOGIN_SET normalizes by stripping [bot] and adding known variants.
+    """
+
+    def test_stripped_bot_suffix_logins_present(self) -> None:
+        """Stripped versions of ADVISORY_BOTS must be in _BOT_LOGIN_SET."""
+        assert "cubic-dev-ai" in validate_review._BOT_LOGIN_SET
+        assert "github-copilot" in validate_review._BOT_LOGIN_SET
+
+    def test_removed_bot_logins_absent(self) -> None:
+        """Fully removed bots (CodeRabbit) must NOT be in _BOT_LOGIN_SET."""
+        assert "coderabbitai" not in validate_review._BOT_LOGIN_SET
+
+    def test_decommissioned_bot_logins_still_excluded(self) -> None:
+        """Bots removed from ADVISORY_BOTS must STAY in _BOT_LOGIN_SET for gate exclusion.
+
+        _BOT_LOGIN_SET is a security filter: it prevents bot comments from
+        satisfying approval gates.  Even after a bot is removed from
+        ADVISORY_BOTS (no longer surfaced in advisory output), its logins must
+        remain excluded to prevent false-approval paths.
+        """
+        assert "qodo-code-review" in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro" in validate_review._BOT_LOGIN_SET
+        assert "qodo-merge-pro-for-open-source" in validate_review._BOT_LOGIN_SET
+
+    def test_legacy_login_variants_present(self) -> None:
+        """Legacy login variants must be in _BOT_LOGIN_SET."""
+        assert "github-actions" in validate_review._BOT_LOGIN_SET
+        assert "copilot" in validate_review._BOT_LOGIN_SET  # Copilot legacy login
+        assert "cubic-bot" in validate_review._BOT_LOGIN_SET
+
+    def test_bot_login_set_is_frozenset(self) -> None:
+        """_BOT_LOGIN_SET must be immutable (frozenset)."""
+        assert isinstance(validate_review._BOT_LOGIN_SET, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Per-variant bot comment exclusion
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestPerVariantBotExclusion:
+    """Each advisory bot variant must be excluded from gate validation.
+
+    Tests cover all known login variants that GitHub APIs may return for
+    each advisory bot account.
+    """
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "cubic-dev-ai",  # gh pr view format (no [bot])
+            "cubic-bot",  # Legacy login variant
+        ],
+    )
+    def test_cubic_variants_excluded(self, login, ci_environment, monkeypatch) -> None:
+        """Cubic bot comment variants must NOT satisfy approval gate."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": login},
+                                "body": "TMG APPROVED: all tests pass\nCRS APPROVED: ok\nCE APPROVED: ok",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"Cubic bot login '{login}' must NOT satisfy gate, got: {message}"
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "qodo-code-review",  # gh pr view format (no [bot])
+            "qodo-merge-pro",  # Legacy login variant
+            "qodo-merge-pro-for-open-source",  # Another legacy variant
+        ],
+    )
+    def test_qodo_variants_excluded(self, login, ci_environment, monkeypatch) -> None:
+        """Qodo bot comment variants must NOT satisfy approval gate.
+
+        Qodo was removed from ADVISORY_BOTS but its logins remain in
+        _BOT_LOGIN_SET as a security filter.  This test verifies that a
+        Qodo comment containing approval text is correctly rejected.
+        """
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": login},
+                                "body": "TMG APPROVED: tests ok\nCRS APPROVED: ok\nCE APPROVED: ok",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert approved is False, f"Qodo bot login '{login}' must NOT satisfy gate, got: {message}"
+
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "github-copilot",  # Stripped [bot] format
+            "copilot",  # Legacy login variant (no [bot], no github- prefix)
+            "Copilot",  # GitHub API returns capital-C variant
+        ],
+    )
+    def test_copilot_variants_excluded(self, login, ci_environment, monkeypatch) -> None:
+        """Copilot bot comment variants must NOT satisfy approval gate."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": login},
+                                "body": "CRS APPROVED: All checks pass\nCE APPROVED: Sound",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, _ = validate_review.check_pr_comments("TIER_2_STANDARD")
+        assert (
+            approved is False
+        ), f"Copilot bot login '{login}' must NOT satisfy gate, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# Skipped-bot logging output
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSkippedBotLogging:
+    """The validator must log which bot comments were skipped and how many."""
+
+    def test_skipped_bot_logging_output(self, ci_environment, monkeypatch, capsys) -> None:
+        """Skipped bot log message must include count and bot names."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "github-copilot"},
+                                "body": "Some copilot review text",
+                            },
+                            {
+                                "author": {"login": "cubic-dev-ai"},
+                                "body": "Some cubic review",
+                            },
+                            {
+                                "author": {"login": "real-user"},
+                                "body": "TMG APPROVED: tests ok",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        validate_review.check_pr_comments("TIER_2_STANDARD")
+
+        captured = capsys.readouterr()
+        assert (
+            "Skipped 2 bot comment(s)" in captured.out
+        ), f"Expected 'Skipped 2 bot comment(s)' in output, got: {captured.out}"
+        assert (
+            "github-copilot" in captured.out
+        ), f"Expected 'github-copilot' in skipped bot names, got: {captured.out}"
+        assert (
+            "cubic-dev-ai" in captured.out
+        ), f"Expected 'cubic-dev-ai' in skipped bot names, got: {captured.out}"
+
+    def test_no_skipped_bot_log_when_no_bots(self, ci_environment, monkeypatch, capsys) -> None:
+        """No skipped-bot log line when there are no bot comments."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "real-user"},
+                                "body": "TMG APPROVED: tests ok",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        validate_review.check_pr_comments("TIER_2_STANDARD")
+
+        captured = capsys.readouterr()
+        assert (
+            "Skipped" not in captured.out or "0 bot" not in captured.out
+        ), f"Should not log skipped bots when there are none, got: {captured.out}"

--- a/tests/unit/test_validate_review_bitemporal.py
+++ b/tests/unit/test_validate_review_bitemporal.py
@@ -1,0 +1,1247 @@
+"""
+Contract tests for content-aware review-depth escalation via bitemporal set-union.
+
+Feature (GitHub issue #412): a change can declare "this needs deeper review than
+the diff-shape suggests" in a way the org-shared gate honours. Declarations are
+extracted from FOUR sources and unioned (escalation-only):
+
+    Required_Roles = Diff_Roles ∪ Base_Roles ∪ Head_Roles ∪ PR_Body_Roles
+
+then intersected with ALLOWED_ESCALATION_ROLES before enforcement.
+
+Schema (LOCKED — do not invent syntax):
+- Canonical field: REQUIRED_REVIEWERS (OCTAVE block field + HTML-comment markers).
+- HTML-comment markers (plain .md + PR body):
+    <!-- review-requirements: [TMG, CRS, CE, CIV, SR] -->
+    <!-- review-tier: TIER_3_CRITICAL: reason -->
+- Whitelist: ALLOWED_ESCALATION_ROLES = VALID_ROLES - {IL, HO}
+            = {TMG, CRS, CE, CIV, PE, SR}
+
+Source of truth: issue #412 test corpus + comments 4569263110 / 4569387061.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import validate_review  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _f(path: str, added: int = 1, deleted: int = 0, status: str = "M") -> dict:
+    """Build a changed-file dict matching get_changed_files() output."""
+    return {
+        "path": path,
+        "added": added,
+        "deleted": deleted,
+        "total_changed": added + deleted,
+        "status": status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 0. ALLOWED_ESCALATION_ROLES is derived, not hardcoded
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestAllowedEscalationRoles:
+    """The whitelist must be derived from review_formats.VALID_ROLES - {IL, HO}."""
+
+    def test_whitelist_value(self) -> None:
+        assert {
+            "TMG",
+            "CRS",
+            "CE",
+            "CIV",
+            "PE",
+            "SR",
+        } == validate_review.ALLOWED_ESCALATION_ROLES
+
+    def test_whitelist_excludes_self_review_roles(self) -> None:
+        assert "IL" not in validate_review.ALLOWED_ESCALATION_ROLES
+        assert "HO" not in validate_review.ALLOWED_ESCALATION_ROLES
+
+    def test_whitelist_derived_from_valid_roles(self) -> None:
+        """Must equal VALID_ROLES - {IL, HO}, not a hardcoded literal."""
+        derived = set(validate_review._VALID_ROLES) - {"IL", "HO"}
+        assert derived == validate_review.ALLOWED_ESCALATION_ROLES
+
+
+# ---------------------------------------------------------------------------
+# 1. The single extractor: _parse_review_declaration
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestParseReviewDeclaration:
+    """_parse_review_declaration(text) -> {tier?, roles?, reason?, source}."""
+
+    def test_html_comment_review_requirements(self) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-requirements: [TMG, CRS, CE, CIV, SR] -->"
+        )
+        assert decl["roles"] == {"TMG", "CRS", "CE", "CIV", "SR"}
+
+    def test_html_comment_review_tier(self) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITICAL: governance ADR -->"
+        )
+        assert decl["tier"] == "TIER_3_CRITICAL"
+        # TIER_3_CRITICAL maps through tier->role table to a set including CIV
+        assert "CIV" in decl["roles"]
+        assert decl["reason"] == "governance ADR"
+
+    def test_octave_required_reviewers_block_field(self) -> None:
+        """OCTAVE REQUIRED_REVIEWERS::"{CE, CRS, SR}" override field."""
+        text = "===ADR===\n" "META:\n" "  TYPE::RULE\n" 'REQUIRED_REVIEWERS::"{CE, CRS, SR}"\n'
+        decl = validate_review._parse_review_declaration(text)
+        assert decl["roles"] == {"CE", "CRS", "SR"}
+
+    def test_frontmatter_review_requirements(self) -> None:
+        """YAML-frontmatter declaration per the issue's _parse_review_declaration spec."""
+        text = "---\n" "review-requirements: [CE, CRS]\n" "---\n" "# Some doc\n"
+        decl = validate_review._parse_review_declaration(text)
+        assert decl["roles"] == {"CE", "CRS"}
+
+    def test_no_declaration_returns_empty_roles(self) -> None:
+        decl = validate_review._parse_review_declaration("Just some prose, no markers.")
+        assert not decl.get("roles")
+
+    def test_malformed_declaration_does_not_crash(self) -> None:
+        """Malformed markers must not raise — return empty/partial, never crash."""
+        decl = validate_review._parse_review_declaration("<!-- review-requirements: [TMG, , -->")
+        # No exception; whatever parsed is a set (possibly empty)
+        assert isinstance(decl.get("roles", set()), set)
+
+
+# ---------------------------------------------------------------------------
+# 2. Bitemporal collection: _collect_bitemporal_declarations
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestCollectBitemporalDeclarations:
+    """Union declarations from PR body + base blob + head blob per changed file."""
+
+    def test_pr_body_declaration(self, monkeypatch) -> None:
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+        roles, prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/ADR.md")],
+            pr_body="<!-- review-requirements: [SR] -->",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "SR" in roles
+        assert "PR_BODY" in prov["SR"]
+
+    def test_head_blob_declaration(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-requirements: [TMG] -->"
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        roles, prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/ADR.md")],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "TMG" in roles
+        assert "HEAD" in prov["TMG"]
+        assert "BASE" not in prov.get("TMG", set())
+
+    def test_base_only_declaration_retained(self, monkeypatch) -> None:
+        """RATCHET core: role declared in BASE but absent from HEAD is retained."""
+
+        def fake_show(sha, path):
+            if sha == "base":
+                return "<!-- review-requirements: [CRS] -->"
+            return ""  # HEAD blob exists but has no declaration
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        roles, prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/ADR.md")],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "CRS" in roles, "BASE-declared role must survive (set-union cannot subtract)"
+        assert prov["CRS"] == {"BASE"}, "BASE-only role must show BASE provenance only"
+
+    def test_missing_base_blob_no_crash(self, monkeypatch) -> None:
+        """New file (no BASE blob): _git_show_file returns None — union uses HEAD only."""
+
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-requirements: [CE] -->"
+            return None  # base blob missing (new file)
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        roles, prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/NEW.md", status="A")],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert roles == {"CE"}
+        assert prov["CE"] == {"HEAD"}
+
+    def test_out_of_whitelist_role_dropped(self, monkeypatch) -> None:
+        """[GOD_MODE] is outside ALLOWED_ESCALATION_ROLES -> dropped, non-fatal."""
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+        roles, prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/ADR.md")],
+            pr_body="<!-- review-requirements: [GOD_MODE, CRS] -->",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "GOD_MODE" not in roles
+        assert "CRS" in roles
+
+    def test_il_ho_dropped_as_self_review_roles(self, monkeypatch) -> None:
+        """IL and HO are self-review roles, not escalation-declarable -> dropped."""
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+        roles, _prov = validate_review._collect_bitemporal_declarations(
+            files=[_f("docs/ADR.md")],
+            pr_body="<!-- review-requirements: [IL, HO, SR] -->",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert roles == {"SR"}
+
+
+# ---------------------------------------------------------------------------
+# 3. classify_pr_facets integration — the 10-test frozen corpus
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestClassifyPrFacetsEscalation:
+    """classify_pr_facets must union declared roles BEFORE both early returns."""
+
+    # --- Corpus #1: regression guard ---
+    def test_diff_only_no_declaration_unchanged(self) -> None:
+        """Diff-only PR, no declaration -> unchanged behaviour."""
+        files = [_f("src/core.py", added=50, deleted=20)]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert roles == {"CE", "CRS", "TMG"}
+        assert tier == "TIER_2_STANDARD"
+
+    def test_diff_only_exempt_still_tier_0(self) -> None:
+        """Pure .md with no declaration still TIER_0_EXEMPT (regression guard)."""
+        files = [_f("docs/README.md", added=10, deleted=5)]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_0_EXEMPT"
+        assert roles == set()
+
+    # --- Corpus #3: .oct.md REQUIRED_REVIEWERS override escalates ---
+    def test_octave_required_reviewers_escalates(self) -> None:
+        """.oct.md declaring REQUIRED_REVIEWERS escalates to declared roles."""
+        files = [_f("docs/governance/POLICY.oct.md", added=5, deleted=2)]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(
+            files, declared_roles={"CIV", "CE", "CRS", "SR", "TMG"}
+        )
+        assert {"CIV", "CE", "CRS", "SR", "TMG"}.issubset(roles)
+        assert tier == "TIER_3_CRITICAL"  # CIV present
+
+    # --- Corpus #4: PR body declares roles ---
+    def test_declared_roles_union_with_diff(self) -> None:
+        """Declared roles union with diff-computed roles (escalation-only ADD)."""
+        files = [_f("src/core.py", added=50, deleted=20)]  # diff -> {CE, CRS, TMG}
+        facets, roles, tier, _ = validate_review.classify_pr_facets(
+            files, declared_roles={"CIV", "SR"}
+        )
+        # union: diff {CE, CRS, TMG} ∪ declared {CIV, SR}
+        assert roles == {"CE", "CRS", "TMG", "CIV", "SR"}
+        assert tier == "TIER_3_CRITICAL"
+
+    # --- Corpus #9 KEYSTONE: all-exempt-escalation ---
+    def test_all_exempt_with_declaration_does_not_return_tier_0(self) -> None:
+        """KEYSTONE (elevana-studio #868): docs-only PR carrying a declaration
+        escalates to the declared role set and does NOT return TIER_0_EXEMPT.
+
+        This proves the union runs BEFORE the `:301 if not facets` early return.
+        """
+        files = [_f("decisions/ADR-HO-AUTH.md", added=40, deleted=0, status="A")]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(
+            files, declared_roles={"TMG", "CRS", "CE", "CIV", "SR"}
+        )
+        assert tier != "TIER_0_EXEMPT", "all-exempt PR with declaration must NOT be exempt"
+        assert roles == {"TMG", "CRS", "CE", "CIV", "SR"}
+        assert tier == "TIER_3_CRITICAL"
+
+    # --- Corpus #10 KEYSTONE: declaration suppresses self-review ---
+    def test_declaration_suppresses_tier_1_self(self) -> None:
+        """KEYSTONE: a declaration on an otherwise TIER_1_SELF-eligible change
+        suppresses self-review (does not short-circuit to TIER_1_SELF).
+
+        Proves the union runs BEFORE the `:319 TIER_1_SELF` early return.
+        """
+        files = [_f("src/config.py", added=3, deleted=1)]  # would be TIER_1_SELF
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles={"CRS"})
+        assert tier != "TIER_1_SELF", "declaration must suppress self-review short-circuit"
+        assert "CRS" in roles
+
+    def test_no_declaration_still_tier_1_self(self) -> None:
+        """Without a declaration, the TIER_1_SELF short-circuit is preserved."""
+        files = [_f("src/config.py", added=3, deleted=1)]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_1_SELF"
+
+    # --- Escalation-only structural property ---
+    def test_declaration_cannot_subtract_diff_roles(self) -> None:
+        """Declaring a SMALLER set never removes diff-computed roles (escalation-only)."""
+        files = [_f("src/core.py", added=50, deleted=20)]  # diff -> {CE, CRS, TMG}
+        facets, roles, tier, _ = validate_review.classify_pr_facets(
+            files, declared_roles={"SR"}  # declares only SR
+        )
+        # diff roles are retained; SR is added
+        assert {"CE", "CRS", "TMG"}.issubset(roles)
+        assert "SR" in roles
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end through the bitemporal collector (corpus #2, #5, #6, #7, #8)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestEndToEndEscalation:
+    """Full path: collector -> classify, exercising the locked HTML-comment markers."""
+
+    # --- Corpus #2: markdown-only PR with review-tier marker escalates ---
+    def test_markdown_only_review_tier_escalates(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-tier: TIER_3_CRITICAL: governance ADR -->"
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("docs/ADR.md", added=40, deleted=0, status="A")]
+        declared, _prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles=declared)
+        assert tier != "TIER_0_EXEMPT"
+        assert "CIV" in roles  # TIER_3 maps to a CIV-bearing set
+        assert tier == "TIER_3_CRITICAL"
+
+    # --- Corpus #5 KEYSTONE: ratchet ---
+    def test_ratchet_base_declaration_removed_in_head_retained(self, monkeypatch) -> None:
+        """KEYSTONE: declaration in BASE, removed in HEAD -> role RETAINED.
+
+        Proves escalation-only is a structural property of set-union, not a rule.
+        """
+
+        def fake_show(sha, path):
+            if sha == "base":
+                return "<!-- review-requirements: [CE, CRS, TMG, CIV, SR] -->"
+            return ""  # HEAD: declaration deleted
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("decisions/ADR.md", added=2, deleted=8)]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == {"CE", "CRS", "TMG", "CIV", "SR"}
+        for role in declared:
+            assert prov[role] == {"BASE"}, f"{role} attempted-reduction must show BASE only"
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles=declared)
+        assert tier == "TIER_3_CRITICAL"
+
+    # --- Corpus #6: malformed declaration falls back, no crash ---
+    def test_malformed_declaration_falls_back_to_diff_floor(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-requirements: [ -->"  # malformed
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("src/core.py", added=50, deleted=20)]
+        declared, _prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        # malformed -> no extra roles; declared is empty (no crash)
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles=declared)
+        # falls back to diff-computed floor for a .py file
+        assert roles == {"CE", "CRS", "TMG"}
+
+    # --- Corpus #7: out-of-whitelist role dropped, gate computes without it ---
+    def test_god_mode_dropped_gate_computes_without_it(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-requirements: [GOD_MODE] -->"
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("docs/ADR.md", added=10, deleted=0)]
+        declared, _prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == set()
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles=declared)
+        # docs-only + no valid declared roles -> still exempt (GOD_MODE dropped non-fatally)
+        assert tier == "TIER_0_EXEMPT"
+
+    # --- Corpus #8: new file, no BASE blob, union on HEAD only ---
+    def test_new_file_no_base_blob_union_head_only(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-requirements: [SR] -->"
+            return None  # no base blob
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("docs/NEW-ADR.md", added=30, deleted=0, status="A")]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == {"SR"}
+        assert prov["SR"] == {"HEAD"}
+
+
+# ---------------------------------------------------------------------------
+# 5. Provenance emitted in JSON output
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestProvenanceInJsonOutput:
+    """_emit_json_summary must include a per-role provenance source map."""
+
+    def test_emit_json_includes_provenance(self, capsys) -> None:
+        import json
+
+        validate_review._emit_json_summary(
+            tier="TIER_3_CRITICAL",
+            reason="escalated",
+            reviewers=["CRS", "TMG"],
+            status="fail",
+            required_count=2,
+            found_count=0,
+            sha="abc1234",
+            provenance={"CRS": ["HEAD", "BASE"], "TMG": ["DIFF"]},
+        )
+        out = capsys.readouterr().out
+        marker = "<!-- REVIEW_GATE_JSON:"
+        assert marker in out
+        payload = out.split(marker, 1)[1].split(" -->", 1)[0]
+        data = json.loads(payload)
+        assert data["provenance"]["CRS"] == ["HEAD", "BASE"]
+        assert data["provenance"]["TMG"] == ["DIFF"]
+
+    def test_emit_json_provenance_optional(self, capsys) -> None:
+        """Backward compat: omitting provenance must not crash; defaults to empty."""
+        validate_review._emit_json_summary(
+            tier="TIER_2_STANDARD",
+            reason="r",
+            reviewers=["CE"],
+            status="pass",
+            required_count=1,
+            found_count=1,
+            sha="abc1234",
+        )
+        out = capsys.readouterr().out
+        assert "<!-- REVIEW_GATE_JSON:" in out
+
+
+# ---------------------------------------------------------------------------
+# 6. git-show + PR-body helpers (safe on missing blobs / missing context)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestGitShowAndPrBodyHelpers:
+    """_git_show_file and _get_pr_body must degrade gracefully, never crash."""
+
+    def test_git_show_returns_content_on_success(self, monkeypatch) -> None:
+        import subprocess as sp
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **k: MagicMock(returncode=0, stdout="hello body"),
+        )
+        assert validate_review._git_show_file("sha", "path") == "hello body"
+
+    def test_git_show_missing_blob_returns_none(self, monkeypatch) -> None:
+        import subprocess as sp
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **k: MagicMock(returncode=128, stdout=""),
+        )
+        assert validate_review._git_show_file("sha", "path") is None
+
+    def test_git_show_empty_sha_returns_none(self) -> None:
+        assert validate_review._git_show_file("", "path") is None
+
+    def test_git_show_oserror_returns_none(self, monkeypatch) -> None:
+        import subprocess as sp
+
+        def boom(*a, **k):
+            raise OSError("no git")
+
+        monkeypatch.setattr(sp, "run", boom)
+        assert validate_review._git_show_file("sha", "path") is None
+
+    def test_git_show_binary_blob_does_not_crash(self, tmp_path) -> None:
+        """P2 (cubic 8): a binary/non-UTF-8 blob must NOT raise UnicodeDecodeError.
+
+        Exercises the REAL subprocess.run decode path against a git blob whose
+        bytes are not valid UTF-8 (e.g. a PNG). The gate runs org-wide on every
+        PR; a single binary file in a PR must not crash it (I2).
+        """
+        import os
+        import subprocess as sp
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+        }
+        # Use a non-"main"/non-"master" branch so the commit never collides
+        # with main-branch protection hooks (global core.hooksPath) present in
+        # some environments — keeps the test portable. -b overrides whatever
+        # init.defaultBranch is configured.
+        sp.run(["git", "init", "-q", "-b", "testwork"], cwd=repo, check=True, env=env)
+        # Invalid UTF-8 bytes (0xFF 0xFE ... 0x80) — a PNG-like binary blob.
+        binary = b"\x89PNG\r\n\x1a\n\xff\xfe\x00\x80\x81\x82binarydata\xc3\x28"
+        (repo / "image.png").write_bytes(binary)
+        sp.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+        sp.run(["git", "commit", "-qm", "add binary"], cwd=repo, check=True, env=env)
+        sha = sp.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        ).stdout.strip()
+
+        # Run _git_show_file from within the repo (it shells out to `git show`).
+        cwd0 = os.getcwd()
+        try:
+            os.chdir(repo)
+            # MUST NOT raise UnicodeDecodeError; returns a (replacement-decoded) str.
+            result = validate_review._git_show_file(sha, "image.png")
+        finally:
+            os.chdir(cwd0)
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_collect_with_binary_file_does_not_crash(self, tmp_path) -> None:
+        """End-to-end: a PR changing a binary file must not crash collection.
+
+        The collector reads BASE/HEAD blobs for every changed file; a binary
+        blob must degrade to "no declaration" rather than raising.
+        """
+        import os
+        import subprocess as sp
+
+        repo = tmp_path / "repo2"
+        repo.mkdir()
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t.t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t.t",
+        }
+        # Non-"main"/non-"master" branch for portability under main-branch
+        # protection hooks (see test_git_show_binary_blob_does_not_crash).
+        sp.run(["git", "init", "-q", "-b", "testwork"], cwd=repo, check=True, env=env)
+        (repo / "logo.png").write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x80\x81")
+        sp.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+        sp.run(["git", "commit", "-qm", "binary"], cwd=repo, check=True, env=env)
+        sha = sp.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        ).stdout.strip()
+
+        cwd0 = os.getcwd()
+        try:
+            os.chdir(repo)
+            roles, prov = validate_review._collect_bitemporal_declarations(
+                files=[_f("logo.png", status="M")],
+                pr_body="",
+                base_sha=sha,
+                head_sha=sha,
+            )
+        finally:
+            os.chdir(cwd0)
+        # Binary blob carries no declaration; collection must succeed (no crash).
+        assert roles == set()
+        assert prov == {}
+
+    def test_get_pr_body_empty_outside_ci(self, monkeypatch) -> None:
+        monkeypatch.delenv("CI", raising=False)
+        assert validate_review._get_pr_body() == ""
+
+    def test_get_pr_body_empty_without_pr_number(self, monkeypatch) -> None:
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.delenv("PR_NUMBER", raising=False)
+        assert validate_review._get_pr_body() == ""
+
+    def test_get_pr_body_returns_body_in_ci(self, monkeypatch) -> None:
+        import json as _json
+        import subprocess as sp
+        from unittest.mock import MagicMock
+
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "412")
+        monkeypatch.setattr(
+            sp,
+            "run",
+            lambda *a, **k: MagicMock(
+                returncode=0, stdout=_json.dumps({"body": "<!-- review-requirements: [SR] -->"})
+            ),
+        )
+        assert "review-requirements" in validate_review._get_pr_body()
+
+
+# ---------------------------------------------------------------------------
+# 7. main() end-to-end — the originating elevana-studio #868 scenario
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestMainEndToEndEscalation:
+    """main() must escalate an all-exempt PR carrying a declaration, in CI."""
+
+    @pytest.fixture(autouse=True)
+    def ci_env(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "868")
+        monkeypatch.delenv("CACHED_GATE_DATA", raising=False)
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(validate_review, "_get_head_sha", lambda: "headsha")
+        monkeypatch.setattr(validate_review, "_get_base_ref_sha", lambda: "basesha")
+
+    def test_all_exempt_markdown_adr_escalates_and_blocks(self, monkeypatch, capsys) -> None:
+        """#868: markdown ADR mandating a T3 chain must NOT be reported mergeable.
+
+        All-exempt diff + a HEAD declaration -> gate escalates to the declared
+        chain, finds no approvals, and BLOCKS (exit 1). Provenance is emitted.
+        """
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [_f("decisions/ADR-HO-AUTH.md", added=40, deleted=0, status="A")],
+        )
+        monkeypatch.setattr(validate_review, "_get_pr_body", lambda: "")
+
+        def fake_show(sha, path):
+            if sha == "headsha":
+                return "<!-- review-requirements: [TMG, CRS, CE, CIV, SR] -->"
+            return None  # new file: no base blob
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        # No approvals present
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *a, **k: (False, "Missing reviews", ["TMG", "CRS", "CE", "CIV", "SR"]),
+        )
+
+        exit_code = validate_review.main()
+        assert exit_code == 1, "all-exempt ADR with T3 declaration must block, not pass"
+
+        out = capsys.readouterr().out
+        assert "TIER_0_EXEMPT" not in out.split("REVIEW_GATE_JSON")[0] or "TIER_3" in out
+        import json as _json
+
+        payload = out.split("<!-- REVIEW_GATE_JSON:", 1)[1].split(" -->", 1)[0]
+        data = _json.loads(payload)
+        assert data["tier"] == "TIER_3_CRITICAL"
+        assert set(data["reviewers"]) == {"TMG", "CRS", "CE", "CIV", "SR"}
+        # Each declared role is attributed to the HEAD blob.
+        for role in {"TMG", "CRS", "CE", "CIV", "SR"}:
+            assert "HEAD" in data["provenance"][role]
+
+    def test_diff_only_no_declaration_still_exempt_in_main(self, monkeypatch, capsys) -> None:
+        """Regression: a pure-docs PR with no declaration still exits 0 (exempt)."""
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [_f("docs/README.md", added=5, deleted=2)],
+        )
+        monkeypatch.setattr(validate_review, "_get_pr_body", lambda: "")
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "TIER_0_EXEMPT" in out
+
+
+# ---------------------------------------------------------------------------
+# 8. Copilot bot-resolution: exclude rules-schema file from declaration scan
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestRulesSchemaFileExcludedFromDeclarationScan:
+    """The gate's own rules-schema doc uses REQUIRED_REVIEWERS:: DESCRIPTIVELY
+    (to define per-facet reviewers). Those lines are config, NOT a PR-level
+    declaration, and must not be picked up by the bitemporal collector.
+
+    Match by basename so BOTH the bundled-hub source and the .hestai-sys runtime
+    copy are skipped as declaration SOURCES.
+    """
+
+    # The rules-schema doc's own content trips the extractor: a descriptive
+    # OCTAVE REQUIRED_REVIEWERS:: line AND the §8 documentation that quotes the
+    # HTML-comment marker example. This fixture reproduces content the extractor
+    # genuinely matches today, so the test is RED (picks up roles) before the
+    # basename-exclusion fix.
+    _SCHEMA_BLOB = (
+        "===REVIEW_REQUIREMENTS===\n"
+        "META:\n"
+        "  TYPE::RULE\n"
+        '  REQUIRED_REVIEWERS::"{CIV, CE, CRS, SR, TMG}"\n'
+        "// §8 documents the marker, which the extractor also matches:\n"
+        "// <!-- review-requirements: [CIV, CE, CRS, SR, TMG] -->\n"
+    )
+
+    def test_bundled_hub_schema_path_not_scanned(self, monkeypatch) -> None:
+        """A PR editing the bundled-hub rules-schema must NOT union its
+        descriptive REQUIRED_REVIEWERS lines as a declaration."""
+
+        def fake_show(sha, path):
+            return self._SCHEMA_BLOB  # both base & head return the schema body
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md")]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == set(), f"schema file must not declare roles, got {declared}"
+        assert prov == {}
+
+    def test_runtime_copy_schema_path_not_scanned(self, monkeypatch) -> None:
+        """The .hestai-sys runtime copy is also excluded (matched by basename)."""
+
+        def fake_show(sha, path):
+            return self._SCHEMA_BLOB
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f(".hestai-sys/standards/rules/review-requirements.oct.md")]
+        declared, _prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == set()
+
+    def test_pr_body_marker_still_scanned_when_schema_changed(self, monkeypatch) -> None:
+        """Excluding the schema file must NOT disable the PR-body marker path."""
+
+        def fake_show(sha, path):
+            return self._SCHEMA_BLOB
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md")]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files,
+            pr_body="<!-- review-requirements: [CIV, CE, CRS, SR, TMG] -->",
+            base_sha="base",
+            head_sha="head",
+        )
+        # Roles come from the PR body ONLY (not the schema's descriptive lines).
+        assert declared == {"CIV", "CE", "CRS", "SR", "TMG"}
+        for role in declared:
+            assert prov[role] == {"PR_BODY"}, f"{role} must be PR_BODY-sourced, got {prov[role]}"
+
+    def test_non_schema_oct_md_still_scanned(self, monkeypatch) -> None:
+        """A DIFFERENT .oct.md (not the rules schema) is still a valid source."""
+
+        def fake_show(sha, path):
+            if sha == "head":
+                return 'REQUIRED_REVIEWERS::"{SR}"\n'
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("docs/governance/SOME-ADR.oct.md")]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == {"SR"}
+        assert prov["SR"] == {"HEAD"}
+
+    def test_this_pr_still_escalates_via_facet_not_schema_lines(self, monkeypatch) -> None:
+        """THIS PR (edits validate_review.py + the rules schema) must STILL
+        escalate to {CE, CIV, CRS, SR, TMG} at TIER_3_CRITICAL — sourced from the
+        META_CONTROL_PLANE FACET + PR body, NOT the schema's descriptive lines."""
+
+        def fake_show(sha, path):
+            # Only the schema doc carries the descriptive markers; the .py code
+            # file has no declaration content (realistic blob contents).
+            if "review-requirements.oct.md" in path:
+                return self._SCHEMA_BLOB
+            return ""
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [
+            _f("scripts/validate_review.py", added=50, deleted=10),  # META_CONTROL_PLANE facet
+            _f("src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md"),
+        ]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files,
+            pr_body="<!-- review-requirements: [CIV, CE, CRS, SR, TMG] -->",
+            base_sha="base",
+            head_sha="head",
+        )
+        # Declared roles come from PR body only (schema lines excluded).
+        assert declared == {"CIV", "CE", "CRS", "SR", "TMG"}
+        for role in declared:
+            assert prov[role] == {"PR_BODY"}, (
+                f"{role} must be PR_BODY-only; schema/code lines must not be a "
+                f"source, got {prov[role]}"
+            )
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files, declared_roles=declared)
+        assert tier == "TIER_3_CRITICAL"
+        assert {"CE", "CIV", "CRS", "SR", "TMG"}.issubset(roles)
+        assert "META_CONTROL_PLANE" in facets, "facet (real routing input) drives escalation"
+
+
+# ---------------------------------------------------------------------------
+# 9. Copilot bot-resolution: warn (non-fatal) on unrecognized review-tier
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestUnrecognizedReviewTierWarns:
+    """A review-tier marker whose value is not in the tier->role map must emit a
+    non-fatal warning (so the author gets a signal) and contribute no roles —
+    never a silent no-op, never a crash."""
+
+    def test_unknown_tier_warns_and_contributes_no_roles(self, capsys) -> None:
+        decl = validate_review._parse_review_declaration("<!-- review-tier: TIER_0_EXEMPT -->")
+        # tier is recorded, but no roles contributed
+        assert decl.get("tier") == "TIER_0_EXEMPT"
+        assert not decl.get("roles")
+        err = capsys.readouterr().err
+        assert "TIER_0_EXEMPT" in err
+        assert "review-tier" in err.lower() or "tier" in err.lower()
+
+    def test_misspelled_tier_warns(self, capsys) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITCAL: typo here -->"
+        )
+        assert decl.get("tier") == "TIER_3_CRITCAL"
+        assert not decl.get("roles")
+        err = capsys.readouterr().err
+        assert "TIER_3_CRITCAL" in err
+
+    def test_recognized_tier_does_not_warn(self, capsys) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITICAL: ok -->"
+        )
+        assert "CIV" in decl["roles"]
+        err = capsys.readouterr().err
+        assert "TIER_3_CRITICAL" not in err  # no warning for a mapped tier
+
+    def test_unknown_tier_does_not_crash_collector(self, monkeypatch) -> None:
+        def fake_show(sha, path):
+            if sha == "head":
+                return "<!-- review-tier: TIER_9_BOGUS -->"
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+        files = [_f("docs/ADR.md")]
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=files, pr_body="", base_sha="base", head_sha="head"
+        )
+        assert declared == set()
+        assert prov == {}
+
+
+# ---------------------------------------------------------------------------
+# 10. Cached-provenance re-read branch in main() (comment-event fast path)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestCachedProvenanceReRead:
+    """On the comment-event fast path, main() reuses the cached provenance map
+    (diff unchanged) instead of re-reading BASE/HEAD blobs, and re-emits it."""
+
+    def test_cached_provenance_reused_and_emitted(self, monkeypatch, capsys) -> None:
+        import json as _json
+
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "414")
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        # Fast-path SHA guards: cached head/base must match the resolved SHAs.
+        monkeypatch.setattr(validate_review, "_get_head_sha", lambda: "headsha")
+        monkeypatch.setattr(validate_review, "_get_base_ref_sha", lambda: "basesha")
+        # Approvals satisfied so main() reaches the success emit (status="pass").
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *a, **k: (True, "all approvals present", []),
+        )
+
+        cached = {
+            "tier": "TIER_3_CRITICAL",
+            "reason": "cached",
+            "roles": ["CE", "CIV", "CRS", "SR", "TMG"],
+            "sha": "headsha",
+            "base_sha": "basesha",
+            "provenance": {
+                "CE": ["DIFF"],
+                "CIV": ["HEAD"],
+                "CRS": ["BASE"],
+                "SR": ["PR_BODY"],
+                "TMG": ["HEAD", "PR_BODY"],
+            },
+        }
+        monkeypatch.setenv("CACHED_GATE_DATA", _json.dumps(cached))
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+
+        out = capsys.readouterr().out
+        payload = out.split("<!-- REVIEW_GATE_JSON:", 1)[1].split(" -->", 1)[0]
+        data = _json.loads(payload)
+        # Provenance is re-read from cache and re-emitted unchanged.
+        assert data["provenance"]["CRS"] == ["BASE"]
+        assert data["provenance"]["TMG"] == ["HEAD", "PR_BODY"]
+        assert data["tier"] == "TIER_3_CRITICAL"
+
+
+# ---------------------------------------------------------------------------
+# 11. CRS F1 — review-tier reason preserves an embedded '>' character
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestReviewTierReasonEmbeddedGt:
+    """The review-tier reason is display/log-only but must not truncate at '>'."""
+
+    def test_reason_with_embedded_gt_preserved(self) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITICAL: foo > bar -->"
+        )
+        assert decl["tier"] == "TIER_3_CRITICAL"
+        assert decl["reason"] == "foo > bar"
+        # tier still maps to roles correctly
+        assert "CIV" in decl["roles"]
+
+    def test_reason_without_gt_still_works(self) -> None:
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITICAL: plain reason -->"
+        )
+        assert decl["reason"] == "plain reason"
+
+    def test_reason_does_not_overcapture_past_terminator(self) -> None:
+        """The reason must stop at the comment terminator, not swallow trailing text."""
+        decl = validate_review._parse_review_declaration(
+            "<!-- review-tier: TIER_3_CRITICAL: r --> trailing text"
+        )
+        assert decl["reason"] == "r"
+
+
+# ---------------------------------------------------------------------------
+# 12. CRS F2 — provenance shows ALL sources for a declared+diff role
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestProvenanceMultiSourceAttribution:
+    """A role both declared (HEAD/BASE/PR_BODY) AND diff/facet-required must show
+    BOTH sources in provenance — including DIFF — not just one."""
+
+    @pytest.fixture(autouse=True)
+    def ci_env(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "414")
+        monkeypatch.delenv("CACHED_GATE_DATA", raising=False)
+        monkeypatch.setattr(validate_review, "check_emergency_bypass", lambda: False)
+        monkeypatch.setattr(validate_review, "_get_head_sha", lambda: "headsha")
+        monkeypatch.setattr(validate_review, "_get_base_ref_sha", lambda: "basesha")
+        monkeypatch.setattr(
+            validate_review,
+            "check_pr_comments",
+            lambda *a, **k: (True, "approvals present", []),
+        )
+
+    def test_declared_and_diff_role_shows_both_sources(self, monkeypatch, capsys) -> None:
+        """CRS, TMG, CE come from the .py DIFF facet (ROUTINE_CODE); the PR body
+        ALSO declares CRS. CRS provenance must be {DIFF, PR_BODY}; CE/TMG stay
+        DIFF-only; SR (PR_BODY only, not diff) stays PR_BODY-only."""
+        import json as _json
+
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [_f("src/core.py", added=50, deleted=20)],  # ROUTINE_CODE -> CE,CRS,TMG
+        )
+        # PR body declares CRS (overlaps diff) + SR (new). No blob declarations.
+        monkeypatch.setattr(
+            validate_review,
+            "_get_pr_body",
+            lambda: "<!-- review-requirements: [CRS, SR] -->",
+        )
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        payload = out.split("<!-- REVIEW_GATE_JSON:", 1)[1].split(" -->", 1)[0]
+        data = _json.loads(payload)
+        prov = data["provenance"]
+        # CRS: declared (PR_BODY) AND diff-required (ROUTINE_CODE) -> BOTH.
+        assert set(prov["CRS"]) == {"DIFF", "PR_BODY"}, prov["CRS"]
+        # CE, TMG: diff-only.
+        assert prov["CE"] == ["DIFF"], prov["CE"]
+        assert prov["TMG"] == ["DIFF"], prov["TMG"]
+        # SR: declared only (not in the diff floor) -> PR_BODY only.
+        assert prov["SR"] == ["PR_BODY"], prov["SR"]
+
+    def test_pure_declared_role_stays_single_source(self, monkeypatch, capsys) -> None:
+        """Regression guard: an all-exempt PR with a PR_BODY-only declaration keeps
+        single-source provenance (no spurious DIFF added)."""
+        import json as _json
+
+        monkeypatch.setattr(
+            validate_review,
+            "get_changed_files",
+            lambda: [_f("docs/ADR.md", added=10, deleted=0)],  # exempt -> no diff roles
+        )
+        monkeypatch.setattr(
+            validate_review,
+            "_get_pr_body",
+            lambda: "<!-- review-requirements: [CIV, CRS] -->",
+        )
+        monkeypatch.setattr(validate_review, "_git_show_file", lambda sha, path: None)
+
+        exit_code = validate_review.main()
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        payload = out.split("<!-- REVIEW_GATE_JSON:", 1)[1].split(" -->", 1)[0]
+        data = _json.loads(payload)
+        prov = data["provenance"]
+        assert prov["CIV"] == ["PR_BODY"], prov["CIV"]
+        assert prov["CRS"] == ["PR_BODY"], prov["CRS"]
+
+
+# ---------------------------------------------------------------------------
+# 13. Rename-aware BASE declaration read (issue #417)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.behavior
+class TestRenameAwareBaseDeclaration:
+    """_collect_bitemporal_declarations must use previous_path for BASE blob lookup
+    when a file has been renamed, so the escalation-only ratchet holds across
+    file renames (issue #417).
+
+    Two defects fixed together:
+    1. get_changed_files() must detect R-status renames and populate previous_path.
+    2. _collect_bitemporal_declarations() must use previous_path for BASE blob.
+    """
+
+    def test_rename_ratchet_keystone(self, monkeypatch) -> None:
+        """RENAME-RATCHET (KEYSTONE): renamed file whose BASE blob (OLD path)
+        declared REQUIRED_REVIEWERS, where the declaration is absent in HEAD
+        (new path) — the role MUST be retained.
+
+        Proves escalation-only set-union holds across a file rename.
+        Without the fix: _git_show_file(base_sha, new_path) returns None
+        (wrong path) -> BASE contribution silently missed -> ratchet bypassed.
+        With the fix: _git_show_file(base_sha, old_path) returns the BASE blob
+        -> role retained.
+        """
+        old_path = "governance/OLD-ADR.oct.md"
+        new_path = "governance/NEW-ADR.oct.md"
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "base" and path == old_path:
+                # BASE blob at OLD path has a declaration
+                return "<!-- review-requirements: [CIV, SR] -->"
+            if sha == "head" and path == new_path:
+                # HEAD blob at NEW path has no declaration (removed)
+                return ""
+            # Any wrong-path call returns None — simulates blob-not-found
+            return None
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        # File dict with previous_path populated (as get_changed_files() will
+        # produce after the fix)
+        renamed_file = {
+            "path": new_path,
+            "previous_path": old_path,
+            "added": 2,
+            "deleted": 8,
+            "total_changed": 10,
+            "status": "renamed",
+        }
+
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[renamed_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "CIV" in declared, (
+            "CIV declared in BASE blob at old path must be retained across rename "
+            "(escalation-only ratchet must hold)"
+        )
+        assert (
+            "SR" in declared
+        ), "SR declared in BASE blob at old path must be retained across rename"
+        assert "BASE" in prov.get("CIV", set()), "CIV must be attributed to BASE source"
+        assert "BASE" in prov.get("SR", set()), "SR must be attributed to BASE source"
+
+    def test_rename_no_previous_path_no_crash(self, monkeypatch) -> None:
+        """RENAME-NO-PREVIOUS: a new file (no previous_path key) is treated as
+        HEAD-only — no crash, no KeyError."""
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "head":
+                return "<!-- review-requirements: [TMG] -->"
+            return None  # no base blob for new file
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        # File dict WITHOUT previous_path (new file, added status)
+        new_file = {
+            "path": "governance/BRAND-NEW.oct.md",
+            "added": 30,
+            "deleted": 0,
+            "total_changed": 30,
+            "status": "A",
+        }
+
+        # Must not crash; must pick up HEAD declaration
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[new_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "TMG" in declared, "HEAD declaration on new file must be collected"
+        assert prov.get("TMG") == {"HEAD"}, "TMG must be attributed to HEAD only"
+
+    def test_rename_same_path_regression_guard(self, monkeypatch) -> None:
+        """RENAME-SAME-PATH: a modified (non-renamed) file with no previous_path
+        still works correctly — regression guard for the fix."""
+
+        def fake_show(sha: str, path: str) -> str | None:
+            if sha == "base" and path == "src/hestai_mcp/core.py":
+                return "<!-- review-requirements: [CE] -->"
+            return ""
+
+        monkeypatch.setattr(validate_review, "_git_show_file", fake_show)
+
+        modified_file = {
+            "path": "src/hestai_mcp/core.py",
+            "added": 10,
+            "deleted": 5,
+            "total_changed": 15,
+            "status": "M",
+        }
+
+        declared, prov = validate_review._collect_bitemporal_declarations(
+            files=[modified_file],
+            pr_body="",
+            base_sha="base",
+            head_sha="head",
+        )
+        assert "CE" in declared, "BASE declaration on modified file must still be collected"
+        assert "BASE" in prov.get("CE", set()), "CE must be attributed to BASE source"
+
+    def _make_rename_mock(self, monkeypatch, numstat_output: str, name_status_output: str):
+        """Helper: wire subprocess.run mocks for get_changed_files() rename tests."""
+        import subprocess as sp
+        from unittest.mock import MagicMock
+
+        def mock_run(cmd, **kwargs):
+            if "--numstat" in cmd:
+                return MagicMock(returncode=0, stdout=numstat_output)
+            if "--name-status" in cmd:
+                return MagicMock(returncode=0, stdout=name_status_output)
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setattr(sp, "run", mock_run)
+        monkeypatch.delenv("CI", raising=False)
+
+    def test_get_changed_files_rename_parsing_plain_arrow(self, monkeypatch) -> None:
+        """Plain arrow: real git --numstat 3-field format for cross-directory rename.
+
+        Real git output:  3\\t1\\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md
+        (single tab-separated 3-field line; ' => ' is inside the filename field)
+        """
+        numstat_output = "3\t1\told/governance/OLD-NAME.oct.md => new/governance/NEW-NAME.oct.md\n"
+        name_status_output = (
+            "R100\told/governance/OLD-NAME.oct.md\tnew/governance/NEW-NAME.oct.md\n"
+        )
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+        assert (
+            f["path"] == "new/governance/NEW-NAME.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        assert (
+            f.get("previous_path") == "old/governance/OLD-NAME.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"
+
+    def test_get_changed_files_rename_parsing_same_dir_brace(self, monkeypatch) -> None:
+        """Same-directory brace notation: git abbreviates same-dir renames with braces.
+
+        Real git output:  3\\t1\\tgovernance/rules/{OLD-NAME.oct.md => NEW-NAME.oct.md}
+        """
+        numstat_output = "3\t1\tgovernance/rules/{OLD-NAME.oct.md => NEW-NAME.oct.md}\n"
+        name_status_output = (
+            "R100\tgovernance/rules/OLD-NAME.oct.md\tgovernance/rules/NEW-NAME.oct.md\n"
+        )
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+        assert (
+            f["path"] == "governance/rules/NEW-NAME.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        assert (
+            f.get("previous_path") == "governance/rules/OLD-NAME.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"
+
+    def test_get_changed_files_rename_parsing_cross_dir_brace(self, monkeypatch) -> None:
+        """Cross-directory brace notation: git abbreviates dir-level renames with braces.
+
+        Real git output:  3\\t1\\t{old/governance => new/governance}/rule.oct.md
+        """
+        numstat_output = "3\t1\t{old/governance => new/governance}/rule.oct.md\n"
+        name_status_output = "R100\told/governance/rule.oct.md\tnew/governance/rule.oct.md\n"
+        self._make_rename_mock(monkeypatch, numstat_output, name_status_output)
+
+        files = validate_review.get_changed_files()
+
+        assert len(files) == 1, f"Expected 1 file, got {len(files)}: {files}"
+        f = files[0]
+        assert (
+            f["path"] == "new/governance/rule.oct.md"
+        ), f"path must be new path only, got: {f['path']!r}"
+        assert (
+            f.get("previous_path") == "old/governance/rule.oct.md"
+        ), f"previous_path must be old path, got: {f.get('previous_path')!r}"
+        assert f.get("status") in (
+            "renamed",
+            "R",
+        ), f"status must indicate rename, got: {f.get('status')!r}"

--- a/tests/unit/test_validate_review_facets.py
+++ b/tests/unit/test_validate_review_facets.py
@@ -1,0 +1,629 @@
+"""
+Contract tests for facet-based content-aware review routing in validate_review.py.
+
+Tests verify that classify_pr_facets() assigns correct facets and required
+reviewer roles based on file content types, and that check_pr_comments()
+validates role-based (not tier-based) approvals.
+
+Source of truth: review-requirements.oct.md v2.0 (5-tier system with facets)
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import validate_review
+
+
+# ---------------------------------------------------------------------------
+# 1. Facet classification tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestFacetClassification:
+    """classify_pr_facets() must assign correct facets based on file paths."""
+
+    def test_pure_markdown_is_exempt(self) -> None:
+        """Pure .md files -> no facets, no roles, TIER_0_EXEMPT."""
+        files = [
+            {"path": "docs/README.md", "added": 10, "deleted": 5, "total_changed": 15},
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert len(facets) == 0, f"Pure .md should have no facets, got {facets}"
+        assert len(roles) == 0, f"Pure .md should need no roles, got {roles}"
+        assert tier == "TIER_0_EXEMPT"
+
+    def test_pure_python_code_is_routine(self) -> None:
+        """Normal .py file -> ROUTINE_CODE facet -> {CE, CRS, TMG}."""
+        files = [
+            {"path": "src/utils.py", "added": 50, "deleted": 20, "total_changed": 70},
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "ROUTINE_CODE" in facets, f"Python file should be ROUTINE_CODE, got {facets}"
+        assert roles == {"CE", "CRS", "TMG"}, f"Expected CE+CRS+TMG, got {roles}"
+
+    def test_octave_rule_is_governance(self) -> None:
+        """.oct.md TYPE::RULE file -> GOVERNANCE facet -> {SR}."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/standards/rules/review-requirements.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "GOVERNANCE" in facets or "META_CONTROL_PLANE" in facets
+        assert "SR" in roles, f"Governance file should require SR, got {roles}"
+
+    def test_octave_agent_is_executable_spec(self) -> None:
+        """.oct.md TYPE::AGENT_DEFINITION -> EXECUTABLE_SPEC facet -> {CE, CRS, SR}."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/agents/implementation-lead.oct.md",
+                "added": 20,
+                "deleted": 10,
+                "total_changed": 30,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "EXECUTABLE_SPEC" in facets, f"Agent .oct.md should be EXECUTABLE_SPEC, got {facets}"
+        assert "CE" in roles, f"Agent def should require CE, got {roles}"
+        assert "CRS" in roles, f"Agent def should require CRS, got {roles}"
+        assert "SR" in roles, f"Agent def should require SR, got {roles}"
+
+    def test_security_path_includes_civ(self) -> None:
+        """Auth path code -> SECURITY facet -> includes CIV."""
+        files = [
+            {
+                "path": "src/hestai_mcp/auth/handler.py",
+                "added": 50,
+                "deleted": 20,
+                "total_changed": 70,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "SECURITY" in facets, f"Auth path should be SECURITY, got {facets}"
+        assert "CIV" in roles, f"Security should require CIV, got {roles}"
+
+    def test_validate_review_is_meta_control_plane(self) -> None:
+        """validate_review.py itself -> META_CONTROL_PLANE -> includes PE."""
+        files = [
+            {
+                "path": "scripts/validate_review.py",
+                "added": 50,
+                "deleted": 20,
+                "total_changed": 70,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "META_CONTROL_PLANE" in facets, f"validate_review.py should be META, got {facets}"
+        assert "CRS" in roles, f"Meta control plane should require CRS, got {roles}"
+        assert "CIV" in roles, f"Meta control plane should require CIV, got {roles}"
+        assert (
+            "PE" not in roles
+        ), f"Meta control plane should NOT require PE (T4 manual), got {roles}"
+
+    def test_skill_md_is_executable_spec(self) -> None:
+        """Bundled hub SKILL.md files must be EXECUTABLE_SPEC, not exempt."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/skills/standards-review/SKILL.md",
+                "added": 20,
+                "deleted": 10,
+                "total_changed": 30,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "EXECUTABLE_SPEC" in facets, f"SKILL.md should be EXECUTABLE_SPEC, got {facets}"
+        assert (
+            "CE" in roles and "CRS" in roles and "SR" in roles
+        ), f"SKILL.md needs CE+CRS+SR, got {roles}"
+        assert tier != "TIER_0_EXEMPT", f"SKILL.md must NOT be exempt, got {tier}"
+
+    def test_pattern_md_is_executable_spec(self) -> None:
+        """Bundled hub pattern .oct.md files must be EXECUTABLE_SPEC, not exempt."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/patterns/tdd-discipline.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier != "TIER_0_EXEMPT", f"Pattern file must NOT be exempt, got {tier}"
+        assert (
+            "EXECUTABLE_SPEC" in facets or "GOVERNANCE" in facets
+        ), f"Pattern file should be EXECUTABLE_SPEC or GOVERNANCE, got {facets}"
+        assert "SR" in roles, f"Pattern file should require SR, got {roles}"
+
+    def test_regular_md_still_exempt(self) -> None:
+        """Regular docs .md files must still be exempt."""
+        files = [
+            {"path": "docs/README.md", "added": 10, "deleted": 5, "total_changed": 15},
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_0_EXEMPT", f"Regular .md should be exempt, got {tier}"
+
+    def test_skill_pr_requires_ce_crs_sr_review(self) -> None:
+        """A PR with only SKILL.md files must require CE+CRS+SR (EXECUTABLE_SPEC)."""
+        files = [
+            {
+                "path": "src/hestai_mcp/_bundled_hub/library/skills/build-execution/SKILL.md",
+                "added": 30,
+                "deleted": 10,
+                "total_changed": 40,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert roles == {"CE", "CRS", "SR"}, f"Skill PR should need CE+CRS+SR, got {roles}"
+
+    def test_mixed_code_and_governance(self) -> None:
+        """Mixed .py + .oct.md -> union of ROUTINE_CODE + GOVERNANCE roles."""
+        files = [
+            {"path": "src/utils.py", "added": 20, "deleted": 10, "total_changed": 30},
+            {
+                "path": ".hestai/state/context/PROJECT-CONTEXT.oct.md",
+                "added": 5,
+                "deleted": 2,
+                "total_changed": 7,
+            },
+        ]
+        facets, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert "SR" in roles, f"Mixed PR should require SR for .oct.md, got {roles}"
+        assert "CRS" in roles, f"Mixed PR should require CRS for .py, got {roles}"
+
+
+# ---------------------------------------------------------------------------
+# 1b. Functional EXECUTABLE_SPEC gate tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestExecutableSpecGateRequiresCRS:
+    """EXECUTABLE_SPEC PRs must fail the gate without CRS approval.
+
+    Since CRS was added to the EXECUTABLE_SPEC facet reviewer set, a PR
+    touching only agent/skill files must require CRS APPROVED alongside
+    CE and SR.  This functional test calls check_pr_comments() to verify
+    the gate rejects when CRS is missing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def ci_environment(self, monkeypatch):
+        """Set CI + PR_NUMBER so check_pr_comments runs its full logic."""
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv("PR_NUMBER", "999")
+
+    def test_executable_spec_fails_without_crs(self, monkeypatch) -> None:
+        """EXECUTABLE_SPEC gate must reject when CRS approval is missing."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "human-ce"},
+                                "body": "CE APPROVED: code looks good",
+                            },
+                            {
+                                "author": {"login": "human-sr"},
+                                "body": "SR APPROVED: standards met",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        # EXECUTABLE_SPEC requires {CE, CRS, SR} — CE and SR present, CRS missing
+        approved, message, missing = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is False, f"Should fail without CRS, got: {message}"
+        assert "CRS" in missing, f"CRS should be in missing roles, got: {missing}"
+
+    def test_executable_spec_passes_with_all_roles(self, monkeypatch) -> None:
+        """EXECUTABLE_SPEC gate must pass when CE, CRS, and SR all approve."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {
+                                "author": {"login": "human-ce"},
+                                "body": "CE APPROVED: code looks good",
+                            },
+                            {
+                                "author": {"login": "human-crs"},
+                                "body": "CRS APPROVED: review complete",
+                            },
+                            {
+                                "author": {"login": "human-sr"},
+                                "body": "SR APPROVED: standards met",
+                            },
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        approved, message, missing = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"Should pass with all roles, got: {message}"
+        assert missing == [], f"No roles should be missing, got: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Tier label computation tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestTierLabelComputation:
+    """Tier labels must be backward-computed from the required role set."""
+
+    def test_exempt_only_is_tier_0(self) -> None:
+        """All exempt files -> TIER_0_EXEMPT."""
+        files = [
+            {"path": "README.md", "added": 5, "deleted": 2, "total_changed": 7},
+        ]
+        _, _, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_0_EXEMPT"
+
+    def test_small_single_file_no_facets_is_tier_1(self) -> None:
+        """<10 lines, single non-exempt file, no special facets -> TIER_1_SELF."""
+        files = [
+            {"path": "src/config.py", "added": 3, "deleted": 1, "total_changed": 4},
+        ]
+        _, _, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_1_SELF"
+
+    def test_routine_code_is_tier_2(self) -> None:
+        """ROUTINE_CODE roles (CE+CRS+TMG, no CIV/PE) -> TIER_2_STANDARD."""
+        files = [
+            {"path": "src/core.py", "added": 50, "deleted": 20, "total_changed": 70},
+        ]
+        _, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_2_STANDARD", f"Routine code should be T2, got {tier}"
+
+    def test_security_path_is_tier_3(self) -> None:
+        """SECURITY facet (has CIV) -> TIER_3_CRITICAL."""
+        files = [
+            {
+                "path": "src/hestai_mcp/auth/handler.py",
+                "added": 20,
+                "deleted": 5,
+                "total_changed": 25,
+            },
+        ]
+        _, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_3_CRITICAL", f"Security path should be T3, got {tier}"
+
+    def test_meta_control_plane_is_tier_3(self) -> None:
+        """META_CONTROL_PLANE (has CIV, no PE) -> TIER_3_CRITICAL."""
+        files = [
+            {
+                "path": "scripts/validate_review.py",
+                "added": 50,
+                "deleted": 20,
+                "total_changed": 70,
+            },
+        ]
+        _, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert (
+            tier == "TIER_3_CRITICAL"
+        ), f"Meta control plane should be T3 (PE excluded), got {tier}"
+
+    def test_governance_only_is_tier_2(self) -> None:
+        """Pure governance .oct.md (SR only, no CIV/PE) -> TIER_2_STANDARD."""
+        files = [
+            {
+                "path": ".hestai/state/context/PROJECT-CONTEXT.oct.md",
+                "added": 10,
+                "deleted": 5,
+                "total_changed": 15,
+            },
+        ]
+        _, roles, tier, _ = validate_review.classify_pr_facets(files)
+        assert tier == "TIER_2_STANDARD", f"Governance-only should be T2, got {tier}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Role-based approval tests
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def ci_environment(monkeypatch):
+    """Set up CI environment variables."""
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_BASE_REF", "origin/main")
+    monkeypatch.setenv("PR_NUMBER", "999")
+
+
+@pytest.mark.unit
+class TestRoleBasedApproval:
+    """check_pr_comments() must validate per-role approvals from required_roles set."""
+
+    def test_sr_only_passes_with_sr_approved(self, ci_environment, monkeypatch) -> None:
+        """required_roles={SR} passes with SR APPROVED only."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "SR APPROVED: standards aligned with North Star"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"SR-only should pass with SR APPROVED, got: {message}"
+
+    def test_routine_code_needs_all_three(self, ci_environment, monkeypatch) -> None:
+        """required_roles={CE, CRS, TMG} needs all three approvals."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: logic correct"},
+                            {"body": "CE APPROVED: architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"CE+CRS+TMG should pass, got: {message}"
+
+    def test_missing_role_fails(self, ci_environment, monkeypatch) -> None:
+        """required_roles={CE, CRS, TMG} fails when TMG is missing."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CRS APPROVED: logic correct"},
+                            {"body": "CE APPROVED: architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is False, f"Missing TMG should fail, got: {message}"
+        assert "TMG" in message
+
+    def test_mixed_code_and_standards_needs_all(self, ci_environment, monkeypatch) -> None:
+        """required_roles={CE, CRS, TMG, SR} needs all four."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "TMG APPROVED: tests verified"},
+                            {"body": "CRS APPROVED: logic correct"},
+                            {"body": "CE APPROVED: architecture sound"},
+                            {"body": "SR APPROVED: standards aligned"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"CE", "CRS", "TMG", "SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"CE+CRS+TMG+SR should pass, got: {message}"
+
+    def test_self_review_still_works_for_tier_1(self, ci_environment, monkeypatch) -> None:
+        """T1 with empty required_roles still accepts SELF-REVIEWED."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "IL SELF-REVIEWED: Fixed typo"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles=set(), tier="TIER_1_SELF"
+        )
+        assert approved is True, f"T1 self-review should still work, got: {message}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Semantic sniffing tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSniffOctaveType:
+    """_sniff_octave_type() must read META.TYPE from .oct.md files."""
+
+    def test_agent_definition_detected(self, tmp_path) -> None:
+        """File with TYPE::AGENT_DEFINITION returns 'AGENT_DEFINITION'."""
+        f = tmp_path / "test.oct.md"
+        f.write_text('===TEST===\nMETA:\n  TYPE::AGENT_DEFINITION\n  VERSION::"1.0"\n')
+        result = validate_review._sniff_octave_type(str(f))
+        assert result == "AGENT_DEFINITION"
+
+    def test_rule_detected(self, tmp_path) -> None:
+        """File with TYPE::RULE returns 'RULE'."""
+        f = tmp_path / "test.oct.md"
+        f.write_text('===TEST===\nMETA:\n  TYPE::RULE\n  VERSION::"1.0"\n')
+        result = validate_review._sniff_octave_type(str(f))
+        assert result == "RULE"
+
+    def test_skill_detected(self, tmp_path) -> None:
+        """File with TYPE::SKILL returns 'SKILL'."""
+        f = tmp_path / "test.oct.md"
+        f.write_text('===TEST===\nMETA:\n  TYPE::SKILL\n  VERSION::"1.0"\n')
+        result = validate_review._sniff_octave_type(str(f))
+        assert result == "SKILL"
+
+    def test_empty_file_returns_empty(self, tmp_path) -> None:
+        """Empty file returns empty string."""
+        f = tmp_path / "test.oct.md"
+        f.write_text("")
+        result = validate_review._sniff_octave_type(str(f))
+        assert result == ""
+
+    def test_no_type_field_returns_empty(self, tmp_path) -> None:
+        """File without TYPE:: returns empty string."""
+        f = tmp_path / "test.oct.md"
+        f.write_text("===TEST===\nMETA:\n  VERSION::1.0\n")
+        result = validate_review._sniff_octave_type(str(f))
+        assert result == ""
+
+    def test_nonexistent_file_returns_empty(self) -> None:
+        """Nonexistent file returns empty string (fail-safe)."""
+        result = validate_review._sniff_octave_type("/nonexistent/path.oct.md")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. Backward compat: determine_review_tier still works
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestDetermineReviewTierBackwardCompat:
+    """determine_review_tier() must still return (tier, reason) tuples."""
+
+    def test_returns_tuple(self) -> None:
+        """determine_review_tier() returns a (str, str) tuple."""
+        files = [{"path": "src/utils.py", "added": 50, "deleted": 20, "total_changed": 70}]
+        result = validate_review.determine_review_tier(files)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], str)
+
+    def test_exempt_files_return_tier_0(self) -> None:
+        """Exempt-only files still return TIER_0_EXEMPT."""
+        files = [{"path": "README.md", "added": 5, "deleted": 2, "total_changed": 7}]
+        tier, _ = validate_review.determine_review_tier(files)
+        assert tier == "TIER_0_EXEMPT"
+
+
+# ---------------------------------------------------------------------------
+# 6. Security: fail-closed for unknown roles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.security
+class TestFailClosedUnknownRoles:
+    """Unknown roles in required_roles must cause the gate to FAIL, not silently pass."""
+
+    def test_unknown_role_causes_failure(self, ci_environment, monkeypatch) -> None:
+        """A required role not in _role_checkers must fail the gate."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "CE APPROVED: architecture sound"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"CE", "UNKNOWN_ROLE"}, tier="TIER_2_STANDARD"
+        )
+        assert (
+            approved is False
+        ), f"Unknown role should cause gate to FAIL (fail-closed), got: {message}"
+        assert "UNKNOWN_ROLE" in message
+
+
+# ---------------------------------------------------------------------------
+# 7. SR checker backward compat with GR
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSRCheckerGRBackwardCompat:
+    """SR checker in check_pr_comments must accept legacy GR APPROVED comments."""
+
+    def test_sr_satisfied_by_legacy_gr_comment(self, ci_environment, monkeypatch) -> None:
+        """required_roles={SR} passes with legacy 'GR APPROVED' comment."""
+        import subprocess
+
+        def mock_run(cmd, *args, **kwargs):
+            return MagicMock(
+                stdout=json.dumps(
+                    {
+                        "body": "",
+                        "comments": [
+                            {"body": "GR APPROVED: legacy governance review"},
+                        ],
+                    }
+                ),
+                returncode=0,
+                check=lambda: None,
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        approved, message, _ = validate_review.check_pr_comments(
+            required_roles={"SR"}, tier="TIER_2_STANDARD"
+        )
+        assert approved is True, f"SR should accept legacy GR APPROVED comments, got: {message}"


### PR DESCRIPTION
## Summary

Ports the **Review Gate (Governance Socket)** from `elevanaltd/HestAI-MCP` into this repo so the review-gate CI workflow + validation engine are hosted here alongside `submit_review` / `submit_governance`. Review-gate **only** — governance auto-ratify is intentionally out of scope.

## What changed

**Ported runtime**
- `scripts/validate_review.py` — the validation engine (stdlib-only)
- `.github/workflows/review-gate.yml` — reusable workflow (local + remote `workflow_call` modes)
- `.github/workflows/review-gate-caller.yml.template` — caller template for repos **outside** the org

**review_formats — single source of truth (Gotcha #5)**
- This repo already shipped a harvested **subset** of `review_formats.py` that `submit_review` imports. `validate_review.py` requires the canonical **superset** (`has_crs_model_approval`, `has_gr_approval`, `parse_review_metadata`, `extract_review_metadata`, `TIER_*` constants, markdown heading/table tolerance).
- Resolution: upgraded `src/hestai_context_mcp/tools/shared/review_formats.py` to the canonical superset so **`validate_review` and `submit_review` share ONE module** (no fork). Replaced the subset test with the canonical 70-test suite + added the 5-tier suite.

**Path / slug fixes** (no `hestai_mcp` namespace — preserves **PROD I6 legacy independence**)
- `validate_review.py`: package import `hestai_mcp.modules.tools.shared` → `hestai_context_mcp.tools.shared`; importlib fallback path `src/hestai_mcp/modules/tools/shared` → `src/hestai_context_mcp/tools/shared` (the `modules/` layer dropped to match this repo).
- workflow: `github.repository` context check, remote-checkout `repository:`, and sparse-checkout `review_formats` path → `elevanaltd/hestai-context-mcp`.
- caller template: reusable-workflow `uses:` ref → this repo `@main`.
- `pyproject.toml`: registered the `security` pytest marker the ported tests use (avoids `--strict-markers` noise).

## Verification

- `ruff check src tests` ✅ · `black --check src tests` ✅ · `mypy src` ✅
- **1929 tests pass, 93.46% coverage** (CI gate ≥85%); `review_formats.py` at 98%
- importlib fallback (the **actual CI path** — workflow runs `python3 scripts/validate_review.py` with no pip install) verified to resolve `review_formats.py` on Python 3.11

## Operator / follow-ups (out of scope for this PR)

- **Org ruleset (ID 12626210, "Require workflows to pass")**: if it references a specific host workflow, repoint it at this repo's `review-gate.yml`. Repos *inside* the org get the check from the ruleset and must **not** also carry a local `review-gate.yml` (dual execution / race). The caller template is for repos *outside* the org.
- **review-tool-placement transition**: the prior RATIFIED `2026-02-14 review-tool-placement` decision (in HestAI-MCP) placed this tooling there; this move refines/supersedes it. To be recorded via `submit_governance` (operator handles ratify) — not silently relitigated.
- `validate_review.py` facet/tier path heuristics retain HestAI-MCP layout patterns (ported verbatim); recalibration to this repo's layout is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosts the Review Gate (Governance Socket) here and exposes a reusable CI workflow for PR review validation. Unifies review format logic with `submit_review` and hardens bot/comment handling; update the org ruleset to use `.github/workflows/review-gate.yml`.

- **New Features**
  - Added `scripts/validate_review.py` and `.github/workflows/review-gate.yml` (local + `workflow_call`) plus `review-gate-caller.yml.template` for external repos.
  - Upgraded `src/hestai_context_mcp/tools/shared/review_formats.py` to the canonical superset shared by `validate_review` and `submit_review`; added tests for tiers, facets, PR reviews, and bitemporal escalation; registered the `security` pytest marker.
  - Fixed repo slugs/import paths for `hestai_context_mcp`.

- **Bug Fixes**
  - Guard null `author` in bot filtering for comments/reviews in `validate_review.py` to prevent crashes; added `test_check_pr_comments_handles_null_author`.
  - In `.github/workflows/review-gate.yml`, update the status comment by targeting the newest marker to match the extract step.

<sup>Written for commit d7ef002e7601957d9a5715934e642f28d8385be8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

