### PR TITLE
feat(config): centralized model resolution with per-repo override (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The server loads configuration at startup from these sources, in priority order:
 | Variable | Purpose | Required |
 |----------|---------|----------|
 | `OPENROUTER_API_KEY` | AI provider key for prose-mode governance compilation | Only if using `prose_input` in `submit_governance` |
-| `HESTAI_AI_MODEL` | Model for prose compilation (e.g. `openai/gpt-4o`) | Only if using prose mode |
+| `HESTAI_AI_MODEL` | Model for prose compilation / synthesis (e.g. `openai/gpt-4o`); optional `HESTAI_AI_MODEL_ANALYSIS` / `HESTAI_AI_MODEL_CRITICAL` per tier | Only if using prose mode |
+| `PER_REPO_OVERRIDE` | When set truthy (`true`/`1`/`yes`/`on`) in a **caller repo's** `.env`, AI-model resolution uses that repo's own `HESTAI_AI_MODEL[_TIER]`; otherwise the model is centralized (the launching process environment wins, consistent across all repos). See `HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED-20260620`. | Optional (per-repo opt-in) |
 | `GITHUB_TOKEN` | GitHub PAT for `submit_review` and `submit_governance` PR creation | For governance and review tools |
 
 ## Claude / Agent Configuration

--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
 import keyring
 
@@ -55,6 +56,13 @@ KEYRING_SERVICE: str = "hestai-context-mcp"
 # Provider / model defaults (match legacy hestai-mcp defaults).
 DEFAULT_PROVIDER: str = "openrouter"
 DEFAULT_MODEL: str = "google/gemini-2.0-flash-lite"
+
+# Issue #106 — per-repo model opt-in flag (HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED).
+# Model selection is centralized-by-default (the process env wins, so every
+# caller repo gets the same model). A caller repo opts in to its OWN model only
+# by setting this key truthy in its ``working_dir/.env``.
+_PER_REPO_OVERRIDE_KEY: str = "PER_REPO_OVERRIDE"
+_TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 
 # Tier -> env-var name for that tier's model. The ``default`` tier reads the
 # base ``HESTAI_AI_MODEL``; richer tiers read their own var and fall back to
@@ -104,7 +112,35 @@ def resolve_provider() -> str:
     return os.environ.get("HESTAI_AI_PROVIDER", DEFAULT_PROVIDER)
 
 
-def resolve_model(tier: str = "default") -> str:
+def _read_caller_env_keys(working_dir: str, keys: tuple[str, ...]) -> dict[str, str]:
+    """Parse ``{working_dir}/.env`` and return ONLY the requested keys.
+
+    Issue #106 / PROD::I2: this is a *read-only parse*, NOT ``load_dotenv`` —
+    the caller's ``.env`` is never merged into ``os.environ``, so no caller
+    secret enters the shared process. Only the keys in ``keys`` are returned;
+    everything else in the file is ignored. A missing or unreadable file
+    yields an empty mapping (the caller falls back to centralized resolution).
+    """
+    try:
+        text = (Path(working_dir) / ".env").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return {}
+    wanted = set(keys)
+    found: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        name = name.strip()
+        if name.startswith("export "):
+            name = name[len("export ") :].strip()
+        if name in wanted:
+            found[name] = value.strip().strip('"').strip("'")
+    return found
+
+
+def resolve_model(tier: str = "default", working_dir: str | None = None) -> str:
     """Return the configured model identifier for ``tier``.
 
     Tiers (issue #77):
@@ -112,14 +148,26 @@ def resolve_model(tier: str = "default") -> str:
         * ``"analysis"`` -> ``HESTAI_AI_MODEL_ANALYSIS``
         * ``"critical"`` -> ``HESTAI_AI_MODEL_CRITICAL``
 
-    Resolution for a tier is a fallback chain: the tier's own env var, then
-    the base ``HESTAI_AI_MODEL``, then :data:`DEFAULT_MODEL`. For the
-    ``"default"`` tier this collapses to the pre-#77 behaviour exactly
-    (``HESTAI_AI_MODEL`` else :data:`DEFAULT_MODEL`), so the zero-arg call
-    remains back-compatible.
+    Resolution is centralized-by-default (issue #106,
+    HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED): the process environment is the
+    source, so every caller repo gets the same model regardless of
+    ``working_dir``. The chain is the tier's own env var, then the base
+    ``HESTAI_AI_MODEL``, then :data:`DEFAULT_MODEL`. The zero-arg call keeps
+    pre-#77 behaviour exactly (back-compatible).
+
+    Per-repo opt-in: when ``working_dir`` is supplied AND that repo's
+    ``.env`` sets ``PER_REPO_OVERRIDE`` truthy, the repo's OWN
+    ``HESTAI_AI_MODEL[_TIER]`` (read from its ``.env``) wins — with the same
+    tier -> base fallback. If the override is on but the repo declares no
+    model, resolution falls through to the centralized chain. The caller
+    ``.env`` is parsed for the flag + model keys ONLY; it is never
+    ``load_dotenv``'d, so no caller secret enters the process (PROD::I2).
 
     Args:
         tier: One of ``"default"``, ``"analysis"``, ``"critical"``.
+        working_dir: Optional caller project root. When ``None`` (the
+            default), resolution is purely centralized — identical to the
+            pre-#106 behaviour.
 
     Raises:
         ValueError: if ``tier`` is not a recognised tier.
@@ -130,7 +178,23 @@ def resolve_model(tier: str = "default") -> str:
         raise ValueError(
             f"Unknown model tier: {tier!r} (expected one of {sorted(_TIER_ENV_VARS)})"
         ) from exc
-    # Tier var first; fall back to the base model var, then the hard default.
+
+    # Per-repo opt-in: only when the caller's .env explicitly enables it.
+    if working_dir is not None:
+        caller = _read_caller_env_keys(
+            working_dir, (_PER_REPO_OVERRIDE_KEY, tier_var, "HESTAI_AI_MODEL")
+        )
+        if caller.get(_PER_REPO_OVERRIDE_KEY, "").strip().lower() in _TRUTHY_VALUES:
+            repo_tier_value = caller.get(tier_var)
+            if repo_tier_value:
+                return repo_tier_value
+            repo_base = caller.get("HESTAI_AI_MODEL")
+            if repo_base:
+                return repo_base
+            # Override on but no model declared in the repo .env -> fall
+            # through to the centralized chain below.
+
+    # Centralized default: tier var first, then base var, then hard default.
     tier_value = os.environ.get(tier_var)
     if tier_value:
         return tier_value

--- a/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
+++ b/src/hestai_context_mcp/adapters/openai_compat_ai_client.py
@@ -384,7 +384,9 @@ class OpenAICompatAIClient:
         )
 
 
-def build_default_ai_client(*, tier: str = "default") -> AIClient | None:
+def build_default_ai_client(
+    *, tier: str = "default", working_dir: str | None = None
+) -> AIClient | None:
     """Build the default :class:`AIClient` from configuration.
 
     Reads provider, model, and API key via :mod:`ai_config`. Returns
@@ -398,6 +400,10 @@ def build_default_ai_client(*, tier: str = "default") -> AIClient | None:
             pre-#77 behaviour (the synthesis tier). Tier only selects the
             *model identifier*; provider and credential resolution are
             unchanged.
+        working_dir: Optional caller project root (issue #106). Forwarded
+            to :func:`ai_config.resolve_model` so a caller repo that sets
+            ``PER_REPO_OVERRIDE`` in its ``.env`` selects its own model;
+            ``None`` keeps centralized (process-env) resolution.
 
     This is the *single* env-reading site for AI client construction.
     Any other code reading ``HESTAI_AI_*`` or ``*_API_KEY`` is a
@@ -413,7 +419,7 @@ def build_default_ai_client(*, tier: str = "default") -> AIClient | None:
         # Misconfigured provider identifier — fail closed.
         logger.warning("Unknown HESTAI_AI_PROVIDER %r; cannot build AIClient", provider)
         return None
-    model = ai_config.resolve_model(tier)
+    model = ai_config.resolve_model(tier, working_dir=working_dir)
     # Issue #96: config-sourced upstream-routing pin (None for providers that
     # take no routing preference). Resolved here, in the composition root, so
     # the wire-protocol adapter stays free of any provider/model magic-string

--- a/src/hestai_context_mcp/core/governance_reviewer.py
+++ b/src/hestai_context_mcp/core/governance_reviewer.py
@@ -159,31 +159,36 @@ _REVIEW_SYSTEM_PROMPT = (
 )
 
 
-def build_default_ai_client(*, tier: str = _DEFAULT_TIER) -> AIClient | None:
+def build_default_ai_client(
+    *, tier: str = _DEFAULT_TIER, working_dir: str | None = None
+) -> AIClient | None:
     """Return the tier-aware default :class:`AIClient`, or ``None``.
 
     Composition-root seam (lazy import of the adapter) so this ``core`` module
     depends only on ``ports`` at module-load time. Tests monkeypatch this
     symbol on the module to inject stubs; it is resolved via the module
     attribute on each call, so patches are honoured.
+
+    ``working_dir`` (issue #106) is forwarded for the caller-repo model opt-in.
     """
     from hestai_context_mcp.adapters.openai_compat_ai_client import (
         build_default_ai_client as _factory,
     )
 
-    return _factory(tier=tier)
+    return _factory(tier=tier, working_dir=working_dir)
 
 
-def _resolve_model_name(tier: str) -> str:
+def _resolve_model_name(tier: str, working_dir: str | None = None) -> str:
     """Return the configured model identifier for ``tier`` (value, not literal).
 
     Lazy import keeps the adapter/config dependency out of module-load scope
     (DIP) and keeps any provider/model *literal* out of this file's source
     (PROD::I3) — the model name is a runtime value resolved below the port.
+    ``working_dir`` (issue #106) enables the caller-repo opt-in.
     """
     from hestai_context_mcp.adapters import ai_config
 
-    return ai_config.resolve_model(tier)
+    return ai_config.resolve_model(tier, working_dir=working_dir)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -332,6 +337,7 @@ async def review_governance(
     tier: str = _DEFAULT_TIER,
     max_output_tokens: int | None = None,
     max_cost_usd: float | None = None,
+    working_dir: str | None = None,
 ) -> ReviewResult:
     """Run a scoped SEMANTIC review of a governance record over the AIClient port.
 
@@ -345,6 +351,8 @@ async def review_governance(
             ``HESTAI_REVIEW_MAX_OUTPUT_TOKENS`` then 2000.
         max_cost_usd: Abort threshold for projected cost. Defaults to
             ``HESTAI_REVIEW_MAX_COST_USD`` then 0.50.
+        working_dir: Optional caller project root (issue #106) forwarded to
+            model resolution + the client factory for the caller-repo opt-in.
 
     Returns:
         :class:`ReviewResult`. A semantic verdict on success; a structured
@@ -363,7 +371,7 @@ async def review_governance(
     )
     price_per_1k = _env_float("HESTAI_REVIEW_USD_PER_1K_TOKENS", _DEFAULT_USD_PER_1K_TOKENS)
 
-    model = _resolve_model_name(tier)
+    model = _resolve_model_name(tier, working_dir)
 
     # --- Cost cap: project BEFORE the call; abort on breach (no fabrication). ---
     projected_tokens = _estimate_input_tokens(octave_content) + out_cap
@@ -384,7 +392,7 @@ async def review_governance(
             tokens=projected_tokens,
         )
 
-    client = build_default_ai_client(tier=tier)
+    client = build_default_ai_client(tier=tier, working_dir=working_dir)
     if client is None:
         # Issue #99 (Finding 3): no credential → definitively $0; the provider
         # was never called so cost_is_estimate=False (not an approximation).

--- a/src/hestai_context_mcp/core/intake_compiler.py
+++ b/src/hestai_context_mcp/core/intake_compiler.py
@@ -94,31 +94,36 @@ class CompileResult(TypedDict):
     error: str | None
 
 
-def build_default_ai_client() -> AIClient | None:
+def build_default_ai_client(working_dir: str | None = None) -> AIClient | None:
     """Return the default :class:`AIClient`, or ``None`` if none available.
 
     Composition-root seam (lazy import of the adapter) so this ``core`` module
     depends only on ``ports`` at module-load time. Tests monkeypatch this symbol
     on the module to inject stubs; it is resolved via the module attribute on
     each call, so patches are honoured.
+
+    ``working_dir`` (issue #106) is forwarded so a caller repo that sets
+    ``PER_REPO_OVERRIDE`` selects its own model; ``None`` keeps centralized
+    resolution.
     """
     from hestai_context_mcp.core.synthesis import (
         build_default_ai_client as _factory,
     )
 
-    return _factory()
+    return _factory(working_dir=working_dir)
 
 
-def _resolve_model_name() -> str:
+def _resolve_model_name(working_dir: str | None = None) -> str:
     """Return the configured model identifier (value, not a source literal).
 
     Lazy import keeps the adapter/config dependency out of module-load scope
     (DIP) and keeps any provider/model *literal* out of this file's source
     (PROD::I3) — the model name is a runtime value resolved below the port.
+    ``working_dir`` (issue #106) enables the caller-repo opt-in.
     """
     from hestai_context_mcp.adapters import ai_config
 
-    return ai_config.resolve_model()
+    return ai_config.resolve_model(working_dir=working_dir)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -224,6 +229,7 @@ async def compile_prose_to_octave(
     *,
     max_output_tokens: int | None = None,
     max_cost_usd: float | None = None,
+    working_dir: str | None = None,
 ) -> CompileResult:
     """Transduce prose into a raw OCTAVE string over the AIClient port.
 
@@ -251,7 +257,7 @@ async def compile_prose_to_octave(
     )
     price_per_1k = _env_float("HESTAI_INTAKE_USD_PER_1K_TOKENS", _DEFAULT_USD_PER_1K_TOKENS)
 
-    model = _resolve_model_name()
+    model = _resolve_model_name(working_dir)
 
     # --- Cost cap: project BEFORE the call; abort on breach (no truncation). ---
     projected_tokens = _project_tokens(intake_context, out_cap)
@@ -267,7 +273,7 @@ async def compile_prose_to_octave(
             tokens=projected_tokens,
         )
 
-    client = build_default_ai_client()
+    client = build_default_ai_client(working_dir)
     if client is None:
         # Issue #99 (Finding 2): no credential → definitively $0; the provider
         # was never called so cost_is_estimate=False (not an approximation).

--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -145,7 +145,10 @@ async def run_intake_pipeline(
 
     for attempt in range(1, _MAX_ATTEMPTS + 1):
         compiled = await compile_prose_to_octave(
-            ctx, max_output_tokens=max_output_tokens, max_cost_usd=max_cost_usd
+            ctx,
+            max_output_tokens=max_output_tokens,
+            max_cost_usd=max_cost_usd,
+            working_dir=str(working_dir),
         )
         last_metrics = compiled["metrics"]
 

--- a/src/hestai_context_mcp/core/synthesis.py
+++ b/src/hestai_context_mcp/core/synthesis.py
@@ -28,7 +28,7 @@ from hestai_context_mcp.ports.ai_client import (
 logger = logging.getLogger(__name__)
 
 
-def build_default_ai_client() -> AIClient | None:
+def build_default_ai_client(working_dir: str | None = None) -> AIClient | None:
     """Return the default :class:`AIClient`, or ``None`` if none available.
 
     This is the *composition-root seam* for the AI synthesis path. It
@@ -42,6 +42,10 @@ def build_default_ai_client() -> AIClient | None:
     to inject stubs; that pattern is honoured because
     :func:`synthesize_ai_context` resolves this symbol via the module
     (not a direct name binding) on each call.
+
+    ``working_dir`` (issue #106) is forwarded to the adapter so a caller
+    repo that sets ``PER_REPO_OVERRIDE`` selects its own model; ``None``
+    keeps centralized (process-env) resolution.
     """
     # Lazy import: breaks the structural adapter-import coupling at
     # module-load time, preserving the ports-only dependency of core.
@@ -51,7 +55,7 @@ def build_default_ai_client() -> AIClient | None:
         build_default_ai_client as _factory,
     )
 
-    return _factory()
+    return _factory(working_dir=working_dir)
 
 
 # Valid values for the ``source`` discriminator. Anything else must be
@@ -104,6 +108,7 @@ def synthesize_ai_context(
     focus: str,
     phase: str,
     context_summary: str,
+    working_dir: str | None = None,
 ) -> AiSynthesisResult | None:
     """Attempt AI-backed synthesis of the clock-in context.
 
@@ -125,12 +130,14 @@ def synthesize_ai_context(
         focus: Resolved focus string.
         phase: Full phase identifier (e.g. ``"B1_FOUNDATION_COMPLETE"``).
         context_summary: Pre-built context summary for the AI to synthesise.
+        working_dir: Optional caller project root (issue #106) forwarded to
+            the client factory for the caller-repo model opt-in.
 
     Returns:
         :class:`AiSynthesisResult` with ``source == "ai"`` on success,
         otherwise ``None``.
     """
-    client = build_default_ai_client()
+    client = build_default_ai_client(working_dir=working_dir)
     if client is None:
         logger.debug("No AIClient available; seam returns None")
         return None
@@ -377,6 +384,7 @@ def resolve_ai_synthesis(
     focus: str,
     phase: str,
     context_summary: str,
+    working_dir: str | None = None,
 ) -> AiSynthesisResult:
     """Return an :class:`AiSynthesisResult`; never ``None``.
 
@@ -389,6 +397,8 @@ def resolve_ai_synthesis(
         focus: Resolved focus string.
         phase: Full phase identifier.
         context_summary: Pre-built context summary (passed through to seam).
+        working_dir: Optional caller project root (issue #106) forwarded to
+            the synthesis seam for the caller-repo model opt-in.
 
     Returns:
         Always a populated :class:`AiSynthesisResult`.
@@ -403,6 +413,7 @@ def resolve_ai_synthesis(
             focus=focus,
             phase=phase,
             context_summary=context_summary,
+            working_dir=working_dir,
         )
     except Exception as exc:  # noqa: BLE001 — seam must be total; fall back on any failure.
         # Observable degradation — log at warning so issue #5 provider failures

--- a/src/hestai_context_mcp/tools/clock_in.py
+++ b/src/hestai_context_mcp/tools/clock_in.py
@@ -235,6 +235,7 @@ def clock_in(
         focus=focus_resolved["value"],
         phase=phase,
         context_summary=context_summary,
+        working_dir=str(working_dir_path),
     )
 
     # ADR-0013 PSS: restore Portable Memory Artifacts and write a named

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -102,7 +102,9 @@ def _compose_sr_assessment(assessment: str, concerns: list[str]) -> str:
     return body
 
 
-async def _run_semantic_review(octave_content: str, pr_url: str) -> dict[str, Any]:
+async def _run_semantic_review(
+    octave_content: str, pr_url: str, working_dir: str | None = None
+) -> dict[str, Any]:
     """Stage 5: analysis-tier scoped-semantic review + SR post (issue #77).
 
     Runs ``review_governance(octave_content, tier="analysis")`` over the authored
@@ -120,7 +122,7 @@ async def _run_semantic_review(octave_content: str, pr_url: str) -> dict[str, An
     Returns the structured ``semantic_review`` block (PROD::I4).
     """
     try:
-        review = await review_governance(octave_content, tier="analysis")
+        review = await review_governance(octave_content, tier="analysis", working_dir=working_dir)
     except Exception as exc:  # noqa: BLE001 — fail-soft: any reviewer error is recorded.
         return {"posted": False, "error": f"semantic review failed: {exc}"}
 
@@ -234,6 +236,7 @@ async def _maybe_review(
     octave_content: str | None,
     dry_run: bool,
     review: bool,
+    working_dir: str | None = None,
 ) -> dict[str, Any]:
     """Run Stage 5 over a successful real PR, attaching ``semantic_review``.
 
@@ -250,7 +253,9 @@ async def _maybe_review(
     if not result.get("success") or not pr_url or not octave_content:
         return result
 
-    result["semantic_review"] = await _run_semantic_review(octave_content, pr_url)
+    result["semantic_review"] = await _run_semantic_review(
+        octave_content, pr_url, working_dir=working_dir
+    )
     return result
 
 
@@ -276,7 +281,7 @@ async def _submit_prose_input(
 
     intake_context = await loop.run_in_executor(None, assemble_intake_context, wd, prose_input)
     result = await run_intake_to_pr(wd, intake_context, dry_run=dry_run)
-    return await _maybe_review(result, result.get("octave"), dry_run, review)
+    return await _maybe_review(result, result.get("octave"), dry_run, review, working_dir=str(wd))
 
 
 async def _submit_octave_content(
@@ -359,4 +364,4 @@ async def _submit_octave_content(
         "octave_validation": octave_validation,
         "dry_run": dry_run,
     }
-    return await _maybe_review(result, octave_content, dry_run, review)
+    return await _maybe_review(result, octave_content, dry_run, review, working_dir=str(wd))

--- a/tests/integration/test_clock_in_ai_synthesis.py
+++ b/tests/integration/test_clock_in_ai_synthesis.py
@@ -65,7 +65,7 @@ class TestClockInAiSynthesisIntegration:
         monkeypatch.setattr(
             synth_mod,
             "build_default_ai_client",
-            lambda: _Stub(text=_valid_octave()),
+            lambda working_dir=None: _Stub(text=_valid_octave()),
             raising=True,
         )
 
@@ -90,7 +90,7 @@ class TestClockInAiSynthesisIntegration:
         monkeypatch.setattr(
             synth_mod,
             "build_default_ai_client",
-            lambda: _Stub(raises=port_mod.AIClientTransportError("net")),
+            lambda working_dir=None: _Stub(raises=port_mod.AIClientTransportError("net")),
             raising=True,
         )
 

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -20,6 +20,7 @@ binding invariants tested here.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import pytest
@@ -451,6 +452,103 @@ class TestResolveProviderPayload:
         # An explicitly empty / whitespace order list means "no preference".
         monkeypatch.setenv("HESTAI_AI_PROVIDER_ORDER", "   ,  ")
         assert resolve_provider_payload("openrouter") is None
+
+
+class TestResolveModelPerRepoOverride:
+    """Issue #106 / HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED-20260620.
+
+    Model selection is centralized-by-default (the process environment wins,
+    so every caller repo gets the same model) with an explicit per-repo
+    opt-in: only when the caller's ``working_dir/.env`` sets
+    ``PER_REPO_OVERRIDE`` truthy does that repo's own
+    ``HESTAI_AI_MODEL[_TIER]`` take effect. The caller ``.env`` is parsed for
+    those keys ONLY — never ``load_dotenv``'d into the shared process
+    (PROD::I2: zero caller-secret ingress).
+    """
+
+    @staticmethod
+    def _write_env(tmp_path, body: str) -> str:
+        (tmp_path / ".env").write_text(body, encoding="utf-8")
+        return str(tmp_path)
+
+    def test_working_dir_none_is_backcompat(self, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        assert resolve_model("default", working_dir=None) == "process/model"
+
+    def test_no_override_flag_ignores_repo_env(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        wd = self._write_env(tmp_path, "HESTAI_AI_MODEL=repo/model\n")
+        # No PER_REPO_OVERRIDE -> default behaviour: process env wins, repo .env ignored.
+        assert resolve_model("default", working_dir=wd) == "process/model"
+
+    def test_override_true_uses_repo_model(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        wd = self._write_env(tmp_path, "PER_REPO_OVERRIDE=true\nHESTAI_AI_MODEL=repo/model\n")
+        assert resolve_model("default", working_dir=wd) == "repo/model"
+
+    def test_override_true_is_tier_aware(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        wd = self._write_env(
+            tmp_path,
+            "PER_REPO_OVERRIDE=1\nHESTAI_AI_MODEL=repo/base\nHESTAI_AI_MODEL_ANALYSIS=repo/analysis\n",
+        )
+        assert resolve_model("analysis", working_dir=wd) == "repo/analysis"
+        assert resolve_model("default", working_dir=wd) == "repo/base"
+
+    def test_override_true_tier_falls_back_to_repo_base(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        wd = self._write_env(tmp_path, "PER_REPO_OVERRIDE=true\nHESTAI_AI_MODEL=repo/base\n")
+        # analysis var absent in the repo .env -> repo base.
+        assert resolve_model("analysis", working_dir=wd) == "repo/base"
+
+    def test_override_true_but_no_repo_model_falls_back_to_process(
+        self, tmp_path, monkeypatch, clean_env
+    ):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        wd = self._write_env(tmp_path, "PER_REPO_OVERRIDE=true\n")
+        assert resolve_model("default", working_dir=wd) == "process/model"
+
+    def test_override_true_no_model_anywhere_falls_back_to_default(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import DEFAULT_MODEL, resolve_model
+
+        wd = self._write_env(tmp_path, "PER_REPO_OVERRIDE=true\n")
+        assert resolve_model("default", working_dir=wd) == DEFAULT_MODEL
+
+    def test_override_falsey_values_do_not_trigger(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        for val in ("false", "0", "no", '""'):
+            wd = self._write_env(tmp_path, f"PER_REPO_OVERRIDE={val}\nHESTAI_AI_MODEL=repo/model\n")
+            assert resolve_model("default", working_dir=wd) == "process/model", val
+
+    def test_missing_env_file_is_backcompat(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        monkeypatch.setenv("HESTAI_AI_MODEL", "process/model")
+        # working_dir exists but has no .env file at all.
+        assert resolve_model("default", working_dir=str(tmp_path)) == "process/model"
+
+    def test_caller_env_not_loaded_into_process(self, tmp_path, clean_env):
+        """PROD::I2 — parsing the caller .env must NOT leak its secrets into os.environ."""
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        wd = self._write_env(
+            tmp_path,
+            "PER_REPO_OVERRIDE=true\nHESTAI_AI_MODEL=repo/model\nSECRET_TOKEN=supersecret\n",
+        )
+        assert resolve_model("default", working_dir=wd) == "repo/model"
+        assert "SECRET_TOKEN" not in os.environ
 
 
 # Dead-import helper so ``Any`` stays reachable by mypy when adding fields.

--- a/tests/unit/core/test_governance_reviewer.py
+++ b/tests/unit/core/test_governance_reviewer.py
@@ -121,8 +121,9 @@ def patch_client(monkeypatch: pytest.MonkeyPatch):
     def _install(client_or_none: Any) -> Any:
         captured: dict[str, Any] = {}
 
-        def _factory(*, tier: str = "default") -> Any:
+        def _factory(*, tier: str = "default", working_dir: Any = None) -> Any:
             captured["tier"] = tier
+            captured["working_dir"] = working_dir
             return client_or_none
 
         monkeypatch.setattr(mod, "build_default_ai_client", _factory, raising=True)

--- a/tests/unit/core/test_intake_compiler.py
+++ b/tests/unit/core/test_intake_compiler.py
@@ -99,7 +99,9 @@ def patch_client(monkeypatch: pytest.MonkeyPatch):
     """Patch the module-level AIClient factory to return a supplied stub."""
 
     def _install(client_or_none: Any) -> None:
-        monkeypatch.setattr(mod, "build_default_ai_client", lambda: client_or_none, raising=True)
+        monkeypatch.setattr(
+            mod, "build_default_ai_client", lambda working_dir=None: client_or_none, raising=True
+        )
 
     return _install
 

--- a/tests/unit/core/test_synthesis.py
+++ b/tests/unit/core/test_synthesis.py
@@ -28,7 +28,9 @@ class TestSynthesizeAiContextDefault:
     """
 
     def test_returns_none_when_factory_yields_no_client(self, monkeypatch):
-        monkeypatch.setattr(synthesis_mod, "build_default_ai_client", lambda: None, raising=True)
+        monkeypatch.setattr(
+            synthesis_mod, "build_default_ai_client", lambda working_dir=None: None, raising=True
+        )
         assert (
             synthesize_ai_context(
                 role="test-role",

--- a/tests/unit/core/test_synthesis_ai_path.py
+++ b/tests/unit/core/test_synthesis_ai_path.py
@@ -76,7 +76,7 @@ def patch_factory(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(
             mod,
             "build_default_ai_client",
-            lambda: client_or_none,
+            lambda working_dir=None: client_or_none,
             raising=True,
         )
 


### PR DESCRIPTION
## Summary

Implements **issue #106**: AI-model resolution is now **centralized-by-default with an explicit per-repo opt-in**, per the superseding decision **`HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED-20260620`** (AGR PR #119, supersedes `HO-INTAKE-MODEL-RESOLUTION-PER-REPO-20260619`).

Previously `resolve_model(tier)` read only `os.environ` (no `working_dir`), so the workbench launcher's injected `HESTAI_AI_MODEL` won everywhere and the model couldn't be controlled.

## Behaviour

- **Default (consistent across all repos):** `resolve_model` reads the process environment (`HESTAI_AI_MODEL[_TIER]`), falling back to `DEFAULT_MODEL`. Every caller repo gets the same model regardless of `working_dir`. Identical to pre-#106 behaviour — all existing zero-arg/tier-only calls unchanged.
- **Opt-in:** when a caller repo's `working_dir/.env` sets **`PER_REPO_OVERRIDE`** truthy (`true`/`1`/`yes`/`on`), `resolve_model` uses that repo's own `HESTAI_AI_MODEL[_TIER]` from its `.env` (tier → base → process → `DEFAULT_MODEL` fallback).

## Implementation

- `ai_config.resolve_model(tier, working_dir=None)` + `_read_caller_env_keys()` parser. The caller `.env` is parsed for **only** the `PER_REPO_OVERRIDE` flag + model keys — **never `load_dotenv`'d** → zero caller-secret ingress (**PROD I2**). Model IDs stay runtime values below the AIClient port (**PROD I3**). **10 new RED→GREEN unit tests.**
- `working_dir` threaded **additively** (default `None` = prior behaviour) through: `build_default_ai_client` (adapter composition root) → `synthesis` / `intake_compiler` / `governance_reviewer` → `compile_prose_to_octave` / `review_governance` / `run_intake_pipeline` → entry points `submit_governance` (`_maybe_review`/`_run_semantic_review`) and `clock_in` (`resolve_ai_synthesis`).
- Updated the AIClient-factory test stubs to the new seam signature; README documents `PER_REPO_OVERRIDE`.

## Verification

- `ruff` ✅ `black` ✅ `mypy src` ✅
- **1929 tests pass** (full suite). The one env-sensitive `clock_in` source-assertion is the pre-existing **issue #66** flake (assumes "no provider wired"); it passes when no API key is configured (e.g. CI) — **proven: 58/58 clock_in tests pass under a null keyring backend with no key**.

## Related
- AGR: **#119** (`HO-INTAKE-MODEL-RESOLUTION-CENTRALIZED-20260620`, PROPOSED — operator ratify/merge)
- Supersedes the per-repo decision from #106's original ratification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes model selection across repos by default, with an explicit per-repo opt-in via `PER_REPO_OVERRIDE` in a caller repo’s `.env`. Implements #106 and threads `working_dir` so per-repo models can apply to intake, review, and synthesis without changing defaults.

- **New Features**
  - Default: read `HESTAI_AI_MODEL[_TIER]` from the process env, fallback to `DEFAULT_MODEL`; same model across all repos.
  - Opt-in: if a caller repo’s `.env` sets `PER_REPO_OVERRIDE` to `true`/`1`/`yes`/`on`, use that repo’s `HESTAI_AI_MODEL[_TIER]` (tier → base → process → default).
  - Docs: README clarifies models also drive synthesis and mentions `HESTAI_AI_MODEL_ANALYSIS` / `HESTAI_AI_MODEL_CRITICAL`.

- **Refactors**
  - Added `working_dir` to `resolve_model` and threaded it through `build_default_ai_client`, synthesis, intake compiler/pipeline, governance reviewer, `submit_governance`, and `clock_in`.
  - Safety: parse the caller `.env` for only `PER_REPO_OVERRIDE` and model keys; never load it into the process env.
  - Tests: updated unit and integration stubs to accept `working_dir`.

<sup>Written for commit fc29339120a44ccab9fa441ec6805f606c32156c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

