### PR TITLE
feat(governance): auto-ratify decision records on human PR approval

### DIFF
--- a/.github/workflows/governance-ratify.yml
+++ b/.github/workflows/governance-ratify.yml
@@ -1,0 +1,75 @@
+name: Governance Auto-Ratify
+
+# When a human approves a governance/* PR, flip any DECISION_RECORD in the branch
+# that still carries STATUS::PROPOSED to STATUS::RATIFIED (stamping RATIFIED_BY +
+# RATIFIED_AT). The commit lands on the PR branch so the record is already
+# ratified by the time the operator merges.
+#
+# This is the sole CI workflow that mutates .hestai/decisions/ artifacts. It is a
+# mechanical reflection of a human approval event — the human PR approval is the
+# ratification act; the bot commit records it (PROD::I3 Human Primacy: no LLM
+# ratifies, no auto-merge). The mutation itself is performed by the stdlib-only
+# scripts/ratify_decision.py (unit-tested; whole-line anchored; idempotent).
+# Extending this mutation pattern requires a new governance decision.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: governance-ratify-${{ github.event.pull_request.number }}
+  # Queue, do not cancel — a mid-commit cancellation could leave the branch in a
+  # partially-ratified state.
+  cancel-in-progress: false
+
+jobs:
+  ratify:
+    name: Auto-ratify decision record
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Only fire on:
+    # - governance/* branches on this repo (not forks)
+    # - human approval from an owner, member, or collaborator (not bots)
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'governance/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.review.state == 'approved' &&
+      github.event.review.user.type == 'User' &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Ratify PROPOSED decision records
+        env:
+          REVIEWER: ${{ github.event.review.user.login }}
+        run: |
+          python3 scripts/ratify_decision.py .hestai/decisions
+
+      - name: Commit ratified files
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .hestai/decisions/
+          if git diff --cached --quiet; then
+            echo "No PROPOSED records to ratify; nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore(governance): auto-ratify on PR approval [DECISION_RECORD]"
+          git push || {
+            echo "::error::Failed to push ratification commit. Check branch protection rules." >&2
+            exit 1
+          }

--- a/scripts/ratify_decision.py
+++ b/scripts/ratify_decision.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Governance auto-ratify: flip merged-on-approval AGRs from PROPOSED to RATIFIED.
+
+When a human approves a ``governance/*`` PR, the Governance Auto-Ratify workflow
+runs this script over ``.hestai/decisions/``. Any DECISION_RECORD AGR carrying
+``STATUS::PROPOSED`` is flipped to ``STATUS::RATIFIED`` and stamped with
+``RATIFIED_BY`` + ``RATIFIED_AT`` injected directly after the ``AUTHORED_AT``
+line (this repo's META schema order — see existing RATIFIED records). The commit
+lands on the PR branch so the file is already ratified by the time the operator
+merges.
+
+This is a *mechanical reflection of a human approval event* — the human PR
+approval is the ratification act; this records it (PROD::I3 Human Primacy: no
+LLM ratifies, no auto-merge). It is the sole automation that mutates
+``.hestai/decisions/`` artifacts; extending this mutation pattern requires a new
+governance decision.
+
+Design:
+- Idempotent: a record already ``RATIFIED`` (or already carrying
+  ``RATIFIED_AT``) is left byte-for-byte untouched, so re-runs never churn or
+  duplicate fields.
+- Whole-line anchored: only the ``  STATUS::PROPOSED`` META field is rewritten,
+  never a ``PROPOSED`` substring appearing in prose.
+- Stdlib-only (no third-party imports, no package install) so it runs in CI the
+  same way scripts/validate_review.py does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Whole-line META field matches (two-space indent, exact value, line-anchored).
+_STATUS_PROPOSED_RE = re.compile(r"(?m)^  STATUS::PROPOSED[ \t]*$")
+_AUTHORED_AT_LINE_RE = re.compile(r"(?m)^  AUTHORED_AT::.*$")
+_RATIFIED_AT_PRESENT_RE = re.compile(r"(?m)^  RATIFIED_AT::")
+
+
+def ratify_text(text: str, *, reviewer: str, timestamp: str) -> tuple[str, bool]:
+    """Return ``(new_text, changed)`` for one AGR document.
+
+    Flips a whole-line ``  STATUS::PROPOSED`` to ``  STATUS::RATIFIED`` and, when
+    no ``RATIFIED_AT`` is already present, injects ``RATIFIED_BY`` then
+    ``RATIFIED_AT`` immediately after the ``AUTHORED_AT`` line. Returns
+    ``changed=False`` (and the text unmodified) when there is no PROPOSED status
+    line, making the operation idempotent.
+
+    Args:
+        text: The AGR document text.
+        reviewer: GitHub login of the approving human (for RATIFIED_BY trace).
+        timestamp: ISO-8601 UTC instant to stamp as RATIFIED_AT.
+    """
+    if not _STATUS_PROPOSED_RE.search(text):
+        return text, False
+
+    new_text = _STATUS_PROPOSED_RE.sub("  STATUS::RATIFIED", text, count=1)
+
+    if not _RATIFIED_AT_PRESENT_RE.search(new_text):
+        injection = (
+            f'\n  RATIFIED_BY::"human:operator<{reviewer}>"' f'\n  RATIFIED_AT::"{timestamp}"'
+        )
+        match = _AUTHORED_AT_LINE_RE.search(new_text)
+        if match is not None:
+            insert_at = match.end()
+        else:
+            # AUTHORED_AT is a required field, so this is a defensive fallback:
+            # anchor to the STATUS line we just wrote instead.
+            status_match = re.search(r"(?m)^  STATUS::RATIFIED[ \t]*$", new_text)
+            insert_at = status_match.end() if status_match else len(new_text)
+        new_text = new_text[:insert_at] + injection + new_text[insert_at:]
+
+    return new_text, True
+
+
+def ratify_directory(decisions_dir: Path, *, reviewer: str, timestamp: str) -> list[Path]:
+    """Ratify every PROPOSED AGR under ``decisions_dir``; return changed paths."""
+    changed: list[Path] = []
+    for path in sorted(decisions_dir.glob("*.oct.md")):
+        original = path.read_text(encoding="utf-8")
+        updated, was_changed = ratify_text(original, reviewer=reviewer, timestamp=timestamp)
+        if was_changed:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(path)
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Auto-ratify PROPOSED decision records.")
+    parser.add_argument(
+        "decisions_dir",
+        nargs="?",
+        default=".hestai/decisions",
+        help="Directory of *.oct.md AGRs (default: .hestai/decisions).",
+    )
+    parser.add_argument(
+        "--reviewer",
+        default=os.environ.get("REVIEWER", "unknown"),
+        help="Approving GitHub login (default: $REVIEWER).",
+    )
+    args = parser.parse_args(argv)
+
+    decisions_dir = Path(args.decisions_dir)
+    if not decisions_dir.is_dir():
+        print(f"No decisions directory at {decisions_dir}; nothing to ratify.")
+        print("changed=0")
+        return 0
+
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    changed = ratify_directory(decisions_dir, reviewer=args.reviewer, timestamp=timestamp)
+
+    for path in changed:
+        print(f"Ratified: {path}")
+    print(f"changed={len(changed)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_ratify_decision.py
+++ b/tests/unit/scripts/test_ratify_decision.py
@@ -1,0 +1,127 @@
+"""Unit tests for scripts/ratify_decision.py — governance auto-ratify logic.
+
+The script flips DECISION_RECORD AGRs carrying ``STATUS::PROPOSED`` to
+``STATUS::RATIFIED`` and injects ``RATIFIED_BY`` + ``RATIFIED_AT`` after the
+``AUTHORED_AT`` line (this repo's META schema). It is the mechanical reflection
+of a human PR-approval event. Stdlib-only, like scripts/validate_review.py.
+
+Binding properties:
+- PROPOSED -> RATIFIED with the two metadata fields injected in schema order.
+- Idempotent: a second run is a no-op (no duplicate fields, no churn).
+- Non-PROPOSED records are never touched.
+- Output remains a schema-valid AGR (asserted via the real Gate A validator).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+import ratify_decision  # noqa: E402
+
+_PROPOSED = (
+    "===DECISION_RECORD===\n"
+    "META:\n"
+    "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
+    "  TOKEN::HO-TEST-EXAMPLE-20260622\n"
+    "  STATUS::PROPOSED\n"
+    "  TIER::STRATEGIC\n"
+    '  AUTHORED_AT::"2026-06-22T00:00:00Z"\n'
+    '  SCOPE::"hestai-context-mcp"\n'
+    '  DECISION::"Test decision."\n'
+    '  BECAUSE::"Test rationale."\n'
+    "===END===\n"
+)
+
+
+class TestRatifyText:
+    def test_proposed_is_flipped_and_fields_injected(self):
+        out, changed = ratify_decision.ratify_text(
+            _PROPOSED, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        assert changed is True
+        assert "  STATUS::RATIFIED\n" in out
+        assert "  STATUS::PROPOSED" not in out
+        assert '  RATIFIED_BY::"human:operator<alice>"\n' in out
+        assert '  RATIFIED_AT::"2026-06-22T12:00:00Z"\n' in out
+
+    def test_injection_order_authored_then_by_then_at(self):
+        out, _ = ratify_decision.ratify_text(
+            _PROPOSED, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        i_auth = out.index("AUTHORED_AT::")
+        i_by = out.index("RATIFIED_BY::")
+        i_at = out.index("RATIFIED_AT::")
+        assert i_auth < i_by < i_at
+
+    def test_idempotent_second_run_is_noop(self):
+        once, _ = ratify_decision.ratify_text(
+            _PROPOSED, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        twice, changed = ratify_decision.ratify_text(
+            once, reviewer="bob", timestamp="2026-06-23T00:00:00Z"
+        )
+        assert changed is False
+        assert twice == once
+        # No duplicate metadata fields.
+        assert once.count("RATIFIED_BY::") == 1
+        assert once.count("RATIFIED_AT::") == 1
+
+    def test_already_ratified_untouched(self):
+        ratified = _PROPOSED.replace("STATUS::PROPOSED", "STATUS::RATIFIED")
+        out, changed = ratify_decision.ratify_text(
+            ratified, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        assert changed is False
+        assert out == ratified
+
+    def test_other_status_untouched(self):
+        voided = _PROPOSED.replace("STATUS::PROPOSED", "STATUS::VOID")
+        out, changed = ratify_decision.ratify_text(
+            voided, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        assert changed is False
+        assert out == voided
+
+    def test_status_substring_not_corrupted(self):
+        # A PROPOSED token inside prose must NOT be rewritten — only the
+        # whole-line META field.
+        text = _PROPOSED.replace(
+            '  DECISION::"Test decision."',
+            '  DECISION::"We rejected the PROPOSED alternative."',
+        )
+        out, _ = ratify_decision.ratify_text(
+            text, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        assert "PROPOSED alternative" in out  # prose preserved
+        assert "  STATUS::RATIFIED\n" in out
+
+    def test_output_passes_gate_a(self):
+        from hestai_context_mcp.tools.governance.type_checker import validate_octave_content
+
+        out, _ = ratify_decision.ratify_text(
+            _PROPOSED, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        result = validate_octave_content(Path("/tmp"), out)
+        assert result.valid, result.errors
+
+
+class TestRatifyDirectory:
+    def test_ratifies_proposed_files_and_reports(self, tmp_path):
+        d = tmp_path / ".hestai" / "decisions"
+        d.mkdir(parents=True)
+        (d / "a.oct.md").write_text(_PROPOSED, encoding="utf-8")
+        (d / "b.oct.md").write_text(
+            _PROPOSED.replace("STATUS::PROPOSED", "STATUS::RATIFIED"), encoding="utf-8"
+        )
+
+        changed = ratify_decision.ratify_directory(
+            d, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+
+        assert changed == [d / "a.oct.md"]
+        assert "STATUS::RATIFIED" in (d / "a.oct.md").read_text()
+        # b was already ratified -> not rewritten.
+        assert (d / "b.oct.md").read_text().count("RATIFIED_BY::") == 0

--- a/tests/unit/scripts/test_ratify_decision.py
+++ b/tests/unit/scripts/test_ratify_decision.py
@@ -107,6 +107,23 @@ class TestRatifyText:
         result = validate_octave_content(Path("/tmp"), out)
         assert result.valid, result.errors
 
+    def test_fallback_injects_after_status_when_authored_at_absent(self):
+        # Defensive branch: AUTHORED_AT is a required field, but if a malformed
+        # record lacks it the injection anchors to the flipped STATUS line
+        # instead of silently dropping the metadata.
+        no_authored = _PROPOSED.replace('  AUTHORED_AT::"2026-06-22T00:00:00Z"\n', "")
+        out, changed = ratify_decision.ratify_text(
+            no_authored, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+        assert changed is True
+        assert "  STATUS::RATIFIED\n" in out
+        assert '  RATIFIED_BY::"human:operator<alice>"\n' in out
+        assert '  RATIFIED_AT::"2026-06-22T12:00:00Z"\n' in out
+        # The fields land immediately after the STATUS line (the fallback anchor).
+        i_status = out.index("  STATUS::RATIFIED")
+        i_by = out.index("RATIFIED_BY::")
+        assert i_status < i_by
+
 
 class TestRatifyDirectory:
     def test_ratifies_proposed_files_and_reports(self, tmp_path):
@@ -125,3 +142,31 @@ class TestRatifyDirectory:
         assert "STATUS::RATIFIED" in (d / "a.oct.md").read_text()
         # b was already ratified -> not rewritten.
         assert (d / "b.oct.md").read_text().count("RATIFIED_BY::") == 0
+
+    def test_ratifies_multiple_proposed_files_sorted(self, tmp_path):
+        d = tmp_path / ".hestai" / "decisions"
+        d.mkdir(parents=True)
+        # Two PROPOSED records (distinct tokens) + one already RATIFIED.
+        (d / "two.oct.md").write_text(
+            _PROPOSED.replace("HO-TEST-EXAMPLE-20260622", "HO-TEST-TWO-20260622"),
+            encoding="utf-8",
+        )
+        (d / "one.oct.md").write_text(
+            _PROPOSED.replace("HO-TEST-EXAMPLE-20260622", "HO-TEST-ONE-20260622"),
+            encoding="utf-8",
+        )
+        (d / "done.oct.md").write_text(
+            _PROPOSED.replace("STATUS::PROPOSED", "STATUS::RATIFIED"), encoding="utf-8"
+        )
+
+        changed = ratify_decision.ratify_directory(
+            d, reviewer="alice", timestamp="2026-06-22T12:00:00Z"
+        )
+
+        # Both PROPOSED files ratified, returned in sorted order; the
+        # already-RATIFIED file is untouched.
+        assert changed == [d / "one.oct.md", d / "two.oct.md"]
+        for name in ("one.oct.md", "two.oct.md"):
+            body = (d / name).read_text()
+            assert "  STATUS::RATIFIED\n" in body
+            assert body.count("RATIFIED_BY::") == 1


### PR DESCRIPTION
## Summary

Ports + refactors hestai-workbench's `governance-ratify.yml` into hestai-context-mcp (now the host of the governance/review infrastructure), **closing the gap where merged AGRs stayed `STATUS::PROPOSED` forever** (e.g. the merged-as-PROPOSED #117 and #119).

When a human **approves** a `governance/*` PR — the ratification act (**PROD I3 Human Primacy**: no LLM ratifies, no auto-merge) — the workflow flips any `DECISION_RECORD` carrying `STATUS::PROPOSED` to `STATUS::RATIFIED`, stamps `RATIFIED_BY` + `RATIFIED_AT`, and commits onto the PR branch so the record is ratified **before** the operator merges.

## Refactor vs the workbench original (inline GNU `sed`)
- **Logic extracted to stdlib-only `scripts/ratify_decision.py`** (mirrors `scripts/validate_review.py` — runs in CI with no install): unit-tested, idempotent, cross-platform (no GNU/BSD `sed` divergence).
- **Schema adapted** to this repo's bytecode AGR META: inject `RATIFIED_BY` then `RATIFIED_AT` after `AUTHORED_AT` (matching existing RATIFIED records' order), full ISO-8601 `RATIFIED_AT`; dropped the workbench `STATUS_FINAL` line (not in this schema). `RATIFIED_BY = "human:operator<approver-login>"`.
- **Whole-line anchored** (only the META `STATUS` field — never a `PROPOSED` substring in prose); **idempotent** (already-RATIFIED records left byte-for-byte untouched).

## Tests
8 unit tests: flip+inject, injection order, idempotency, already-ratified/other-status no-ops, prose-substring safety, and that the ratified output **still passes the real Gate A validator**. `ruff`/`black`/`mypy` green. CLI smoke test: `changed=1` then idempotent `changed=0`.

## Design notes
- Trigger/guards unchanged from the proven workbench design: `pull_request_review` approved, `governance/*` branch, same-repo (no forks), human `User` reviewer with `OWNER`/`MEMBER`/`COLLABORATOR` association; queue-don't-cancel concurrency.
- Sole automation that mutates `.hestai/decisions/`; extending the pattern requires a new governance decision (carried forward from the workbench doctrine).

## Operator note
Once merged, approving a future `governance/*` PR auto-ratifies it. Already-merged-as-PROPOSED records (#117, #119) can be retro-ratified separately if you want their `STATUS` to reflect reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-ratifies governance decision records when a human approves a `governance/*` PR. Flips any `STATUS::PROPOSED` AGR to `STATUS::RATIFIED` on the PR branch before merge.

- **New Features**
  - GitHub Actions workflow runs on approved reviews for `governance/*` branches (same-repo, human `OWNER`/`MEMBER`/`COLLABORATOR`) and commits the ratification to the PR branch.
  - Added `scripts/ratify_decision.py` to flip status and inject `RATIFIED_BY` and `RATIFIED_AT` after `AUTHORED_AT`; whole-line anchored, idempotent, stdlib-only, with unit tests (now covering fallback inject-after-`STATUS` when `AUTHORED_AT` is missing and multi-file ratification in sorted order).

- **Migration**
  - No action needed; approving future `governance/*` PRs auto-ratifies.
  - Records merged as `PROPOSED` (e.g., #117, #119) need manual retro‑ratification.

<sup>Written for commit ccaaeb385d915d58b0b87d15476e572406d6c47f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

