### PR TITLE
fix(governance): fail-fast pre-flight on worktree-discipline main tree (#108.3)

### DIFF
--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -95,6 +95,76 @@ def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
         return 1, "", str(exc)
 
 
+# Branches the global worktree-discipline pre-commit hook protects. A commit on
+# one of these, from a MAIN working tree (not a worktree), is blocked.
+_PROTECTED_BRANCHES = frozenset({"main", "master"})
+
+
+def _preflight_commit_safety(working_dir: Path) -> str | None:
+    """Return a recovery error iff committing here would be blocked, else None.
+
+    #108.3: the global worktree-discipline pre-commit hook
+    (``~/.githooks/pre-commit``) blocks a commit when ALL of the following hold:
+
+      1. ``working_dir`` is a MAIN working tree -- NOT a linked worktree. Git
+         reports the same path for ``--git-dir`` and ``--git-common-dir`` in a
+         main tree; a linked worktree's ``--git-dir`` is ``.git/worktrees/<name>``
+         and differs from the common dir.
+      2. the current branch is a protected branch (``main``/``master``).
+      3. an executable ``pre-commit`` hook is actually installed at the repo's
+         effective ``core.hooksPath`` (so a repo with hooks disabled -- e.g. the
+         isolated test fixture -- does NOT trip this guard).
+
+    The hook also auto-reverts a ``git checkout -b`` back to the protected branch
+    (a companion ``post-checkout`` hook), so the linker's own branch creation
+    cannot escape the block from a main tree -- hence we MUST fail fast *before*
+    creating a branch rather than relying on the checkout to move us off main.
+
+    When this returns a non-None error the linker aborts before touching git, so
+    no branch is created and nothing is staged (PROD::I4 structured failure with
+    explicit recovery guidance). Returns ``None`` (proceed) whenever the path is
+    not a git repo or any of conditions 1-3 do not hold -- including every linked
+    worktree, which is the supported authoring location.
+    """
+    # Not a git repo (or git unavailable) -> cannot be a blocked main tree.
+    code, git_dir, _ = _run_git(["rev-parse", "--absolute-git-dir"], working_dir)
+    if code != 0 or not git_dir:
+        return None
+    code, common_dir, _ = _run_git(
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"], working_dir
+    )
+    if code != 0 or not common_dir:
+        return None
+
+    # (1) MAIN tree iff the per-worktree git-dir IS the common dir.
+    if Path(git_dir).resolve() != Path(common_dir).resolve():
+        return None  # linked worktree -> supported, never blocked.
+
+    # (2) Protected branch only. A main tree on a feature branch commits fine.
+    code, branch, _ = _run_git(["branch", "--show-current"], working_dir)
+    if code != 0 or branch not in _PROTECTED_BRANCHES:
+        return None
+
+    # (3) An executable pre-commit hook must actually be installed at the repo's
+    #     effective hooks path; a repo with hooks disabled does not block.
+    code, hooks_dir, _ = _run_git(["rev-parse", "--git-path", "hooks"], working_dir)
+    if code != 0 or not hooks_dir:
+        return None
+    hook_path = (working_dir / hooks_dir / "pre-commit").resolve()
+    if not (hook_path.is_file() and os.access(hook_path, os.X_OK)):
+        return None
+
+    return (
+        f"BLOCKED: cannot author governance from the main working tree on "
+        f"'{branch}' -- the worktree-discipline pre-commit hook blocks commits "
+        f"here. Author from a git worktree instead:\n"
+        f"  git worktree add -b governance/your-record ../<repo>-governance main\n"
+        f"  # then re-run submit_governance with working_dir pointed at that "
+        f"worktree.\n"
+        f"No branch was created and nothing was staged."
+    )
+
+
 def _create_branch(working_dir: Path, branch_name: str) -> str | None:
     """Create and checkout a new git branch.
 
@@ -267,15 +337,35 @@ def run_linker(
             "branch": branch_name,
             "pr_url": None,
             "error": None,
+            "staged_uncommitted": False,
             "dry_run": True,
         }
 
     # --- Live path: git operations ---
     errors: list[str] = []
 
+    # 0. Pre-flight (#108.3): if committing here would be blocked by the
+    #    worktree-discipline hook, fail fast BEFORE creating any branch so no
+    #    orphan branch and no staged state is ever produced. Honours a worktree
+    #    working_dir (which is the supported authoring location) unchanged.
+    preflight_err = _preflight_commit_safety(working_dir)
+    if preflight_err:
+        # Aborted before branch creation: no branch, nothing staged.
+        return {
+            "token": token,
+            "card_type": card_type,
+            "target_path": target_path_str,
+            "branch": None,
+            "pr_url": None,
+            "error": preflight_err,
+            "staged_uncommitted": False,
+            "dry_run": False,
+        }
+
     # 1. Create branch
     err = _create_branch(working_dir, branch_name)
     if err:
+        # Branch creation itself failed: no branch, nothing staged.
         return {
             "token": token,
             "card_type": card_type,
@@ -283,11 +373,14 @@ def run_linker(
             "branch": branch_name,
             "pr_url": None,
             "error": err,
+            "staged_uncommitted": False,
             "dry_run": False,
         }
 
     # 2. Write OCTAVE content to target path
     if target_path is None:
+        # Branch WAS created but nothing was written/staged -- surface the
+        # partial state (branch exists) for recovery.
         return {
             "token": token,
             "card_type": card_type,
@@ -295,6 +388,7 @@ def run_linker(
             "branch": branch_name,
             "pr_url": None,
             "error": "target_path is None -- cannot write file",
+            "staged_uncommitted": True,
             "dry_run": False,
         }
 
@@ -302,6 +396,7 @@ def run_linker(
     try:
         target_path.resolve().relative_to(working_dir.resolve())
     except (ValueError, RuntimeError, OSError):
+        # Branch WAS created but the write was rejected -- partial state exists.
         return {
             "token": token,
             "card_type": card_type,
@@ -312,6 +407,7 @@ def run_linker(
                 f"target_path {target_path} is outside working_dir {working_dir} "
                 "-- path traversal rejected"
             ),
+            "staged_uncommitted": True,
             "dry_run": False,
         }
 
@@ -355,6 +451,14 @@ def run_linker(
 
     error_str = "; ".join(errors) if errors else None
 
+    # #108.3 orphan/partial-state surfacing: by this point the branch HAS been
+    # created (step 1 succeeded). If a later step failed, local state is left
+    # partially applied -- the branch exists and the record may be written/staged
+    # but not committed/pushed. Flag it so the operator can recover the branch
+    # rather than be handed a branch name that looks clean. On full success the
+    # state is committed (not "staged uncommitted"), so the flag is False.
+    staged_uncommitted = bool(errors)
+
     return {
         "token": token,
         "card_type": card_type,
@@ -362,5 +466,6 @@ def run_linker(
         "branch": branch_name,
         "pr_url": pr_url,
         "error": error_str,
+        "staged_uncommitted": staged_uncommitted,
         "dry_run": False,
     }

--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -332,6 +332,44 @@ class TestOpenPr:
 # ---------------------------------------------------------------------------
 
 
+# Repo-local git identity for the real-git fixtures. CI runners have NO global
+# user.name/user.email (and may set user.useConfigOnly), so any real commit MUST
+# carry an explicit identity or it aborts with exit 128 ("author identity
+# unknown"). These are passed both as repo config AND inline on every commit
+# (-c) so the fixtures are hermetic regardless of the runner's global git state.
+_GIT_IDENTITY = (
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run a git command in ``repo``, failing the test loudly on error."""
+    subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True)
+
+
+def _hermetic_seed_commit(repo: Path) -> None:
+    """Create a seed commit in ``repo`` that succeeds with NO global git config.
+
+    Identity is supplied inline (``-c user.*``) so the commit does not depend on
+    a global/system identity (absent on CI), and ``core.hooksPath`` is pointed at
+    a nonexistent dir so the seed itself is never gated by the discipline hook.
+    """
+    (repo / "seed.txt").write_text("seed")
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        *_GIT_IDENTITY,
+        "-c",
+        "core.hooksPath=/nonexistent",
+        "commit",
+        "-m",
+        "seed",
+    )
+
+
 def _git_init_main_tree(repo: Path, *, branch: str = "main", hooks: bool) -> None:
     """Initialise a real git repo as a MAIN tree on ``branch``.
 
@@ -340,6 +378,10 @@ def _git_init_main_tree(repo: Path, *, branch: str = "main", hooks: bool) -> Non
     points ``core.hooksPath`` at an empty dir with no ``pre-commit`` (simulating
     a repo where the branch-protection hook is NOT active), mirroring the
     isolated-repo fixture used by the submit_governance integration tests.
+
+    The repo is pinned onto ``branch`` via ``symbolic-ref`` (independent of the
+    runner's ``init.defaultBranch``) and given a repo-local identity so later
+    commits succeed even when the runner has no global git identity (CI).
     """
     subprocess.run(["git", "init"], cwd=str(repo), check=True, capture_output=True)
     subprocess.run(
@@ -348,6 +390,10 @@ def _git_init_main_tree(repo: Path, *, branch: str = "main", hooks: bool) -> Non
         check=True,
         capture_output=True,
     )
+    # Repo-local identity (belt-and-suspenders alongside the inline -c on commits)
+    # so this repo can commit on a CI runner with no global git identity.
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
     hooks_dir = repo / ".git" / ("real-hooks" if hooks else "no-hooks")
     hooks_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
@@ -410,18 +456,9 @@ class TestPreflightCommitSafety:
         main_repo.mkdir()
         _git_init_main_tree(main_repo, branch="main", hooks=True)
         # A repo needs at least one commit before a worktree can be added.
-        (main_repo / "seed.txt").write_text("seed")
-        env_args = {"cwd": str(main_repo), "check": True, "capture_output": True}
-        subprocess.run(["git", "add", "."], **env_args)  # type: ignore[arg-type]
-        subprocess.run(
-            ["git", "-c", "core.hooksPath=/nonexistent", "commit", "-m", "seed"],
-            **env_args,  # type: ignore[arg-type]
-        )
+        _hermetic_seed_commit(main_repo)
         wt = tmp_path / "wt"
-        subprocess.run(
-            ["git", "worktree", "add", "-b", "governance/x", str(wt), "main"],
-            **env_args,  # type: ignore[arg-type]
-        )
+        _git(main_repo, "worktree", "add", "-b", "governance/x", str(wt), "main")
         assert linker._preflight_commit_safety(wt) is None
 
     @pytest.mark.unit
@@ -439,25 +476,13 @@ class TestPreflightCommitSafety:
         main_repo = tmp_path / "main"
         main_repo.mkdir()
         _git_init_main_tree(main_repo, branch="main", hooks=True)
-        (main_repo / "seed.txt").write_text("seed")
-        env_args = {"cwd": str(main_repo), "check": True, "capture_output": True}
-        subprocess.run(["git", "add", "."], **env_args)  # type: ignore[arg-type]
-        subprocess.run(
-            ["git", "-c", "core.hooksPath=/nonexistent", "commit", "-m", "seed"],
-            **env_args,  # type: ignore[arg-type]
-        )
+        _hermetic_seed_commit(main_repo)
         # Free up ``main`` so a linked worktree can check it out: move the MAIN
         # tree onto a parking branch. The worktree then sits ON the protected
         # branch ``main`` while the main tree does not.
-        subprocess.run(
-            ["git", "-c", "core.hooksPath=/nonexistent", "checkout", "-b", "parking"],
-            **env_args,  # type: ignore[arg-type]
-        )
+        _git(main_repo, "-c", "core.hooksPath=/nonexistent", "checkout", "-b", "parking")
         wt = tmp_path / "wt-main"
-        subprocess.run(
-            ["git", "worktree", "add", str(wt), "main"],
-            **env_args,  # type: ignore[arg-type]
-        )
+        _git(main_repo, "worktree", "add", str(wt), "main")
 
         # Pre-conditions for the isolation claim: the worktree IS on the
         # protected branch, and the worktree's git-dir differs from the common

--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -328,6 +328,154 @@ class TestOpenPr:
 
 
 # ---------------------------------------------------------------------------
+# _preflight_commit_safety (#108.3 worktree-discipline guard)
+# ---------------------------------------------------------------------------
+
+
+def _git_init_main_tree(repo: Path, *, branch: str = "main", hooks: bool) -> None:
+    """Initialise a real git repo as a MAIN tree on ``branch``.
+
+    ``hooks=True`` installs an executable ``pre-commit`` at the repo's effective
+    hooks path (simulating a discipline-enforced main tree). ``hooks=False``
+    points ``core.hooksPath`` at an empty dir with no ``pre-commit`` (simulating
+    a repo where the branch-protection hook is NOT active), mirroring the
+    isolated-repo fixture used by the submit_governance integration tests.
+    """
+    subprocess.run(["git", "init"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "symbolic-ref", "HEAD", f"refs/heads/{branch}"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    hooks_dir = repo / ".git" / ("real-hooks" if hooks else "no-hooks")
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    if hooks:
+        pre_commit = hooks_dir / "pre-commit"
+        pre_commit.write_text("#!/bin/bash\nexit 1\n")
+        pre_commit.chmod(0o755)
+
+
+class TestPreflightCommitSafety:
+    @pytest.mark.unit
+    def test_non_repo_is_safe(self, tmp_path: Path) -> None:
+        """A path that is not a git repo cannot be a blocked main tree -> safe."""
+        assert linker._preflight_commit_safety(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_main_tree_on_main_with_active_hook_blocks(self, tmp_path: Path) -> None:
+        """Main tree + protected branch + active pre-commit hook -> structured block."""
+        _git_init_main_tree(tmp_path, branch="main", hooks=True)
+        err = linker._preflight_commit_safety(tmp_path)
+        assert err is not None
+        # Recovery guidance: tell the operator to author from a worktree.
+        assert "worktree" in err.lower()
+
+    @pytest.mark.unit
+    def test_main_tree_on_master_with_active_hook_blocks(self, tmp_path: Path) -> None:
+        """The protected-branch set includes 'master', not only 'main'."""
+        _git_init_main_tree(tmp_path, branch="master", hooks=True)
+        assert linker._preflight_commit_safety(tmp_path) is not None
+
+    @pytest.mark.unit
+    def test_main_tree_without_active_hook_is_safe(self, tmp_path: Path) -> None:
+        """A main tree whose hooks are disabled (no pre-commit) does NOT block.
+
+        This is the isolated-repo fixture shape used by the submit_governance
+        integration tests; the guard must NOT false-positive there.
+        """
+        _git_init_main_tree(tmp_path, branch="main", hooks=False)
+        assert linker._preflight_commit_safety(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_main_tree_on_feature_branch_is_safe(self, tmp_path: Path) -> None:
+        """A main tree sitting on a NON-protected branch would commit fine -> safe.
+
+        Guards against the false-positive HO flagged: detection must key on the
+        protected branch, not merely on 'this is a main tree'.
+        """
+        _git_init_main_tree(tmp_path, branch="feature/x", hooks=True)
+        assert linker._preflight_commit_safety(tmp_path) is None
+
+    @pytest.mark.unit
+    def test_real_worktree_is_safe(self, tmp_path: Path) -> None:
+        """A genuine git worktree (git-dir != git-common-dir) is never blocked."""
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        _git_init_main_tree(main_repo, branch="main", hooks=True)
+        # A repo needs at least one commit before a worktree can be added.
+        (main_repo / "seed.txt").write_text("seed")
+        env_args = {"cwd": str(main_repo), "check": True, "capture_output": True}
+        subprocess.run(["git", "add", "."], **env_args)  # type: ignore[arg-type]
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/nonexistent", "commit", "-m", "seed"],
+            **env_args,  # type: ignore[arg-type]
+        )
+        wt = tmp_path / "wt"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "governance/x", str(wt), "main"],
+            **env_args,  # type: ignore[arg-type]
+        )
+        assert linker._preflight_commit_safety(wt) is None
+
+    @pytest.mark.unit
+    def test_worktree_on_protected_branch_is_safe(self, tmp_path: Path) -> None:
+        """A linked worktree checked out ON ``main`` with the hook active is SAFE.
+
+        This is #108.3's core supported authoring path. Conditions (2) protected
+        branch and (3) active pre-commit hook BOTH hold here -- the ONLY thing
+        keeping the commit unblocked is condition (1), the git-dir != common-dir
+        worktree exemption. So this test isolates the worktree discriminator: if
+        the git-dir/common-dir comparison were blinded, this would flip to a
+        false-block (verified out-of-band). The other two discriminators are
+        pinned by the main-tree tests above.
+        """
+        main_repo = tmp_path / "main"
+        main_repo.mkdir()
+        _git_init_main_tree(main_repo, branch="main", hooks=True)
+        (main_repo / "seed.txt").write_text("seed")
+        env_args = {"cwd": str(main_repo), "check": True, "capture_output": True}
+        subprocess.run(["git", "add", "."], **env_args)  # type: ignore[arg-type]
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/nonexistent", "commit", "-m", "seed"],
+            **env_args,  # type: ignore[arg-type]
+        )
+        # Free up ``main`` so a linked worktree can check it out: move the MAIN
+        # tree onto a parking branch. The worktree then sits ON the protected
+        # branch ``main`` while the main tree does not.
+        subprocess.run(
+            ["git", "-c", "core.hooksPath=/nonexistent", "checkout", "-b", "parking"],
+            **env_args,  # type: ignore[arg-type]
+        )
+        wt = tmp_path / "wt-main"
+        subprocess.run(
+            ["git", "worktree", "add", str(wt), "main"],
+            **env_args,  # type: ignore[arg-type]
+        )
+
+        # Pre-conditions for the isolation claim: the worktree IS on the
+        # protected branch, and the worktree's git-dir differs from the common
+        # dir (the exemption). If git ever stopped distinguishing them, the
+        # branch+hook conditions would make this a false-block.
+        branch = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=str(wt),
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert branch == "main", "worktree must be ON the protected branch for this isolation"
+
+        assert linker._preflight_commit_safety(wt) is None
+
+
+# ---------------------------------------------------------------------------
 # run_linker live-path branches (subprocess + filesystem fully mocked)
 # ---------------------------------------------------------------------------
 
@@ -352,6 +500,89 @@ class TestRunLinkerLivePath:
         assert out["error"] == "branch boom"
         assert out["pr_url"] is None
         assert out["dry_run"] is False
+
+    @pytest.mark.unit
+    def test_preflight_block_aborts_before_branch_creation(self, tmp_path: Path) -> None:
+        """A discipline-enforced main tree aborts BEFORE any branch is created.
+
+        #108.3: when the pre-flight guard fires, run_linker must return a
+        structured failure (success-shape: error set, pr_url None) and must NOT
+        invoke ``_create_branch`` -- so no orphan branch and no staged state is
+        ever produced (the orphan-branch defect cannot occur).
+        """
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        with (
+            patch(f"{_LINKER}._preflight_commit_safety", return_value="BLOCKED: use a worktree"),
+            patch(f"{_LINKER}._create_branch") as create_branch,
+            patch(f"{_LINKER}._write_file") as write_file,
+            patch(f"{_LINKER}.subprocess.run") as run,
+        ):
+            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        assert out["error"] == "BLOCKED: use a worktree"
+        assert out["pr_url"] is None
+        assert out["dry_run"] is False
+        # No branch was created, nothing was written, no subprocess ran: zero
+        # partial state (no orphan branch, no staged changes).
+        assert out["branch"] is None
+        assert out["staged_uncommitted"] is False
+        create_branch.assert_not_called()
+        write_file.assert_not_called()
+        run.assert_not_called()
+
+    @pytest.mark.unit
+    def test_preflight_safe_proceeds_to_branch_creation(self, tmp_path: Path) -> None:
+        """When pre-flight returns safe (None), the existing happy path proceeds."""
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        with (
+            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
+            patch(f"{_LINKER}._create_branch", return_value=None) as create_branch,
+            patch(f"{_LINKER}._write_file", return_value=None),
+            patch(f"{_LINKER}.write_manifest"),
+            patch(f"{_LINKER}._git_add_and_commit", return_value=None),
+            patch(f"{_LINKER}._push_branch", return_value=None),
+            patch(f"{_LINKER}._resolve_github_token", return_value=None),
+            patch(f"{_LINKER}._open_pr", return_value=("http://pr/1", None)),
+        ):
+            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        assert out["error"] is None
+        assert out["pr_url"] == "http://pr/1"
+        create_branch.assert_called_once()
+
+    @pytest.mark.unit
+    def test_dry_run_skips_preflight(self, tmp_path: Path) -> None:
+        """dry_run must not invoke the pre-flight probe (no git side-channel work)."""
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        with patch(f"{_LINKER}._preflight_commit_safety") as preflight:
+            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", True)
+        assert out["dry_run"] is True
+        preflight.assert_not_called()
+
+    @pytest.mark.unit
+    def test_commit_failure_surfaces_branch_and_staged_state(self, tmp_path: Path) -> None:
+        """A post-branch commit failure must surface the created branch + staged state.
+
+        #108.3: when a step after branch creation fails, the result must make the
+        partial state explicit (the branch that WAS created, and that changes were
+        staged) so the operator can recover -- not silently return a branch name
+        that looks clean.
+        """
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        with (
+            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
+            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._write_file", return_value=None),
+            patch(f"{_LINKER}.write_manifest"),
+            patch(f"{_LINKER}._git_add_and_commit", return_value="git commit failed: boom"),
+            patch(f"{_LINKER}._open_pr") as pr,
+        ):
+            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        assert out["error"] is not None
+        assert "git commit failed" in out["error"]
+        # The created branch is surfaced (not None) so the operator can recover it.
+        assert out["branch"] and out["branch"].startswith("governance/")
+        # The result flags that local state was left partially applied.
+        assert out.get("staged_uncommitted") is True
+        pr.assert_not_called()
 
     @pytest.mark.unit
     def test_target_path_none_on_live_path_errors(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Wave B / PR-1 — #108.3: fail-fast pre-flight on the worktree-discipline main tree

Closes the blocking half of #108: authoring a governance record via `submit_governance` from a **discipline-enforced main working tree** silently stranded a commit on `main`.

### Root cause (two-hook interaction)
The linker runs all git ops with `cwd=working_dir` — it is **not** hardcoded to main. The failure surfaced because `working_dir` was a *main working tree*:
1. `_create_branch` runs `git checkout -b governance/…` → exit 0, BUT
2. the global `post-checkout` hook auto-reverts HEAD back to `main` and deletes the orphan branch (still exit 0), so
3. the linker writes + stages + commits **on `main`** → the `pre-commit` hook fires `BLOCKED: cannot commit to main` → the record is left staged-but-uncommitted, the returned branch never persisted.

So `checkout -b` cannot escape the block from a main tree — the guard must fail fast **before** branch creation.

### Fix
New `_preflight_commit_safety(working_dir)` runs as step 0 of `run_linker`. It returns a structured PROD-I4 recovery error (no branch created, nothing staged) **iff all three hold**:
1. main working tree — `git rev-parse --absolute-git-dir` == `--git-common-dir` (a linked worktree differs → exempt);
2. current branch ∈ {`main`, `master`};
3. an executable `pre-commit` hook is installed at the **effective** `core.hooksPath` (`git rev-parse --git-path hooks` — honors the global override).

Approach **(c) fail-fast + recovery** with **(b) honour a worktree `working_dir`** (already commit-safe); auto-worktree creation **(a) rejected** (MIP / Human-Primacy). Also adds `staged_uncommitted` to the linker result so a post-branch partial failure surfaces explicit recovery state instead of a clean-looking-but-abandoned branch. The recovery message gives the exact `git worktree add` command (verified rc=0).

Blast radius confined to `linker.py` (+105); both consumers read result keys via `.get()` — additive, no signature change.

### Verification (orchestration evidence — human merge is the semantic gate)
- Empirically: real main tree on `main` → BLOCK; this worktree → PROCEED; both confirmed against the live global `~/.githooks`.
- 12 new tests; the detection matrix pins all three discriminators independently (branch, hook, **and** worktree-exemption) — each mutation-isolated (blinding one flips exactly its test RED). Linker suite 41 passed; full local gate (ruff/mypy/black) clean.
- T3 review panel (independent, on this head): **CRS GO** (pure detection, fail-fast ordering, consumer-compatible), **CE GO** (full false-positive/negative matrix, injection-free, timeout-bounded; non-blocking note: graceful fail-open on git <2.31), **CIV GO** (fires in real scenario, both consumers propagate, recovery command works, happy-path no regression), **TMG GO** (mutation-proven non-theater, worktree-on-main isolation added).

Refs: #108 (item 3). Items 1 (truncation) and 4 (fail-soft validation) follow as separate PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail‑fast preflight in the governance linker to block authoring from a discipline‑enforced main working tree and prevent orphan branches and stranded commits. Addresses #108.3 and adds recovery guidance plus a new `staged_uncommitted` flag for partial failures.

- **Bug Fixes**
  - Before any branch creation, detect blocked commits only when all hold: main tree (git-dir == git-common-dir), on `main`/`master`, and an executable `pre-commit` at the effective hooks path; abort with a structured error and a suggested `git worktree add` command.
  - Worktrees remain green; dry runs skip the preflight.
  - Expose `staged_uncommitted` on post-branch failures; tests cover the detection matrix and live-path behavior and are now hermetic for CI (inline git identity, branch pinning).

<sup>Written for commit 272e6ecee5ab1a5d71e3fc1d335b84498862b40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

