### PR TITLE
fix(governance): scope staged_uncommitted to commit-failure state (cubic P2)

### DIFF
--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -379,8 +379,8 @@ def run_linker(
 
     # 2. Write OCTAVE content to target path
     if target_path is None:
-        # Branch WAS created but nothing was written/staged -- surface the
-        # partial state (branch exists) for recovery.
+        # Branch WAS created (surfaced via ``branch`` for recovery) but no write
+        # or ``git add`` ran, so nothing is staged-uncommitted (contract: False).
         return {
             "token": token,
             "card_type": card_type,
@@ -388,7 +388,7 @@ def run_linker(
             "branch": branch_name,
             "pr_url": None,
             "error": "target_path is None -- cannot write file",
-            "staged_uncommitted": True,
+            "staged_uncommitted": False,
             "dry_run": False,
         }
 
@@ -396,7 +396,9 @@ def run_linker(
     try:
         target_path.resolve().relative_to(working_dir.resolve())
     except (ValueError, RuntimeError, OSError):
-        # Branch WAS created but the write was rejected -- partial state exists.
+        # Branch WAS created (surfaced via ``branch``) but the write was rejected
+        # before any ``git add``, so nothing is staged-uncommitted (contract:
+        # False); the branch-exists recovery is conveyed by ``branch`` + ``error``.
         return {
             "token": token,
             "card_type": card_type,
@@ -407,7 +409,7 @@ def run_linker(
                 f"target_path {target_path} is outside working_dir {working_dir} "
                 "-- path traversal rejected"
             ),
-            "staged_uncommitted": True,
+            "staged_uncommitted": False,
             "dry_run": False,
         }
 
@@ -428,10 +430,17 @@ def run_linker(
     commit_message = f"chore(governance): add {token} [{card_type}]"
     manifest_path = working_dir / ".hestai" / "MANIFEST.md"
 
+    # Track commit failure explicitly. ``_git_add_and_commit`` stages (git add)
+    # BEFORE committing, so a commit failure leaves changes staged-but-uncommitted
+    # -- the ONLY state where ``staged_uncommitted`` is True. A successful commit,
+    # or a step that never reached the commit (write/traversal failure: nothing
+    # staged), is NOT staged-uncommitted.
+    commit_failed = False
     if not errors:
         err = _git_add_and_commit(working_dir, target_path, manifest_path, commit_message)
         if err:
             errors.append(err)
+            commit_failed = True
 
     # 5. Push branch to origin (REQUIRED before gh pr create -- issue #73).
     #    gh aborts PR creation if the branch is not on a remote. A push
@@ -451,13 +460,14 @@ def run_linker(
 
     error_str = "; ".join(errors) if errors else None
 
-    # #108.3 orphan/partial-state surfacing: by this point the branch HAS been
-    # created (step 1 succeeded). If a later step failed, local state is left
-    # partially applied -- the branch exists and the record may be written/staged
-    # but not committed/pushed. Flag it so the operator can recover the branch
-    # rather than be handed a branch name that looks clean. On full success the
-    # state is committed (not "staged uncommitted"), so the flag is False.
-    staged_uncommitted = bool(errors)
+    # #108.3 orphan/partial-state surfacing (cubic P2 contract): the branch HAS
+    # been created (step 1 succeeded) by this point. ``staged_uncommitted`` is
+    # True IFF the commit itself failed -- i.e. changes were staged (git add) but
+    # not committed. It is False whenever the commit succeeded, INCLUDING when a
+    # later push (step 5) or PR-creation (step 6) failed: those are committed
+    # states with a different recovery, already described by ``error``. The flag
+    # stays literally "staged but not committed," matching its name.
+    staged_uncommitted = commit_failed
 
     return {
         "token": token,

--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -791,6 +791,106 @@ class TestRunLinkerLivePath:
         assert pr.call_args.args[-1] == "ghp_x" or pr.call_args.kwargs.get("gh_token") == "ghp_x"
 
 
+# ---------------------------------------------------------------------------
+# staged_uncommitted contract (cubic P2): True IFF the branch was created AND
+# the commit did NOT succeed (changes staged but not committed). MUST be False
+# whenever the commit succeeded -- including when a later push or PR step fails.
+# Fully mocked => hermetic (no real git).
+# ---------------------------------------------------------------------------
+
+
+class TestStagedUncommittedContract:
+    @staticmethod
+    def _run(tmp_path: Path, **overrides: object) -> dict[str, object]:
+        """Drive run_linker through the live path with all seams mocked.
+
+        ``overrides`` replaces individual seam return values (e.g.
+        ``commit="boom"``) so each test pins one outcome.
+        """
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        commit = overrides.get("commit")  # str error or None
+        push = overrides.get("push")  # str error or None
+        open_pr = overrides.get("open_pr", ("http://pr/1", None))  # (url, err)
+        with (
+            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
+            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._write_file", return_value=None),
+            patch(f"{_LINKER}.write_manifest"),
+            patch(f"{_LINKER}._git_add_and_commit", return_value=commit),
+            patch(f"{_LINKER}._push_branch", return_value=push),
+            patch(f"{_LINKER}._resolve_github_token", return_value=None),
+            patch(f"{_LINKER}._open_pr", return_value=open_pr),
+        ):
+            return run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+
+    @pytest.mark.unit
+    def test_commit_fails_is_staged_uncommitted(self, tmp_path: Path) -> None:
+        """Commit FAILED -> staged_uncommitted True (the genuine staged state)."""
+        out = self._run(tmp_path, commit="git commit failed: boom")
+        assert out["staged_uncommitted"] is True
+        assert out["error"] is not None and "git commit failed" in out["error"]
+        assert out["branch"] and str(out["branch"]).startswith("governance/")
+
+    @pytest.mark.unit
+    def test_push_fails_after_commit_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
+        """Commit OK + push FAILS -> staged_uncommitted False (it committed).
+
+        RED on the old ``bool(errors)`` flag: the push error made errors truthy
+        even though the commit landed, mislabelling a committed state as
+        staged-uncommitted. Recovery for a push failure is described by ``error``.
+        """
+        out = self._run(tmp_path, commit=None, push="push boom")
+        assert out["staged_uncommitted"] is False
+        assert out["error"] == "push boom"
+        assert out["branch"] and str(out["branch"]).startswith("governance/")
+
+    @pytest.mark.unit
+    def test_pr_fails_after_commit_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
+        """Commit OK + push OK + PR FAILS -> staged_uncommitted False (committed+pushed).
+
+        RED on the old ``bool(errors)`` flag.
+        """
+        out = self._run(tmp_path, commit=None, push=None, open_pr=(None, "pr boom"))
+        assert out["staged_uncommitted"] is False
+        assert out["error"] == "pr boom"
+
+    @pytest.mark.unit
+    def test_full_success_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
+        """Full success -> staged_uncommitted False (regression guard)."""
+        out = self._run(tmp_path, commit=None, push=None, open_pr=("http://pr/1", None))
+        assert out["staged_uncommitted"] is False
+        assert out["error"] is None
+
+    @pytest.mark.unit
+    def test_traversal_reject_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
+        """Path-traversal reject -> staged_uncommitted False: no `git add` ran yet.
+
+        The branch exists (surfaced via ``branch`` + ``error``) but nothing was
+        staged, so the literal "staged but not committed" flag is False.
+        """
+        # target_path OUTSIDE working_dir triggers the traversal guard, which
+        # returns before any write/add. ``_create_branch`` is stubbed so the
+        # branch-creation step "succeeds" and we reach the traversal guard.
+        outside = tmp_path.parent / "elsewhere" / "x.oct.md"
+        validation = ValidationResult(
+            valid=True,
+            errors=[],
+            token=_LIVE_RECORD_ID,
+            card_type="DECISION_RECORD",
+            target_path=outside,
+        )
+        with (
+            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
+            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._git_add_and_commit") as commit,
+        ):
+            out = run_linker(tmp_path, validation, "===DECISION_RECORD===\n", False)
+        assert "path traversal rejected" in out["error"]
+        assert out["staged_uncommitted"] is False
+        # The commit step was never reached.
+        commit.assert_not_called()
+
+
 @pytest.mark.unit
 def test_linker_module_exposes_run_linker() -> None:
     """Smoke: public entry point is importable and callable."""


### PR DESCRIPTION
## fix(governance): scope `staged_uncommitted` to the commit-failure state (cubic P2 on #123)

Follow-up to #123. cubic flagged that `linker.py`'s `staged_uncommitted` was computed as `bool(errors)` — but push (step 5) and PR-creation (step 6) each run only `if not errors`, i.e. **after a successful commit**. So a push- or PR-failure is a *committed* state, yet `bool(errors)` mislabelled it `staged_uncommitted=True`. A caller would pick the wrong recovery path (clean a "dirty" tree that is actually committed).

### Fix
- Track commit outcome explicitly: `commit_failed` (init `False`, set `True` only in the step-4 `_git_add_and_commit` error branch).
- Final return: `staged_uncommitted = commit_failed` (was `bool(errors)`).
- Aligned the two pre-commit early-returns (`target_path is None`, path-traversal reject) `True → False` — no `git add` has run at those points, so nothing is staged (branch-exists recovery is still conveyed by `branch` + `error`).

The flag now means exactly what its name says — **branch created ∧ record staged via `git add` ∧ commit did not land** — and is `False` for every committed state (success, push-fail, PR-fail) and every pre-staging abort.

### Verification
- 5 new contract tests (`TestStagedUncommittedContract`, fully mocked at the git seams): commit-fail→True, push-fail→False, PR-fail→False, full-success→False, traversal→False. The push/PR-fail tests are genuine RED on the old `bool(errors)`; two-direction mutation confirms every assertion is load-bearing (no always-green).
- Linker suite 46 passed; consumers 60 passed; ruff/mypy/black clean. Additive flag — both consumers read via `.get()`, no signature change.
- T2 review: **CRS GO** (AST-verified `commit_failed` cannot go stale; all 6 returns enumerated), **CE GO** (drove all 9 reachable outcomes; one non-blocking SOFT noted below), **TMG GO** (mutation-proven, correct seam targeting).

### Known non-blocking edge (CE SOFT)
`_git_add_and_commit` collapses `git add` failure (nothing staged) and `git commit` failure (staged) into one error, so the pathological `git add`-fail case (corrupt index / disk-full / fs-permission) over-reports `staged_uncommitted=True`. Benign — it points the operator to `git status` on a branch that exists anyway, with the precise cause in `error`; it does **not** reintroduce the false-clean deception the flag exists to prevent. Left as polish, not fixed here.

Refs: #108 (item 3 follow-up), cubic review on #123.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope `staged_uncommitted` to commit failures only, so push/PR errors no longer look like dirty working trees. Follow-up to #123; aligns with #108.3 contract.

- **Bug Fixes**
  - Track commit outcome via `commit_failed` and set `staged_uncommitted = commit_failed`.
  - Return `staged_uncommitted=False` for pre-commit early exits (`target_path is None`, path traversal reject).
  - Add 5 contract tests: commit-fail→True; push-fail/PR-fail/success/traversal→False.

<sup>Written for commit 200f05f1908b483504add4aa30d4d2e6d78b8d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

