### PR TITLE
feat(governance): loud + opt-in fail-closed Gate-B validation (#108.4)

### DIFF
--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -44,6 +44,7 @@ __all__ = [
     "DEFAULT_MODEL",
     "resolve_provider",
     "resolve_model",
+    "resolve_require_real_validation",
     "resolve_api_key",
     "get_provider_base_url",
     "resolve_provider_payload",
@@ -63,6 +64,15 @@ DEFAULT_MODEL: str = "google/gemini-2.0-flash-lite"
 # by setting this key truthy in its ``working_dir/.env``.
 _PER_REPO_OVERRIDE_KEY: str = "PER_REPO_OVERRIDE"
 _TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+
+# Issue #108.4 — opt-in fail-closed flag for Gate-B real OCTAVE validation.
+# Default OFF: Gate B is fail-soft-but-loud (a missing ``validation`` extra
+# degrades to regex-only with an explicit signal). A deployment opts INTO strict
+# fail-closed validation by setting this key truthy. Resolved per-repo from
+# ``working_dir/.env`` in isolation (parse this key only, never load_dotenv), with
+# process-env as the launcher fallback — mirroring ``resolve_model`` per-repo
+# isolation (HO-INTAKE-MODEL-RESOLUTION-PER-REPO). A boolean is not a secret.
+_REQUIRE_REAL_VALIDATION_KEY: str = "HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION"
 
 # Tier -> env-var name for that tier's model. The ``default`` tier reads the
 # base ``HESTAI_AI_MODEL``; richer tiers read their own var and fall back to
@@ -199,6 +209,37 @@ def resolve_model(tier: str = "default", working_dir: str | None = None) -> str:
     if tier_value:
         return tier_value
     return os.environ.get("HESTAI_AI_MODEL", DEFAULT_MODEL)
+
+
+def resolve_require_real_validation(working_dir: str | None = None) -> bool:
+    """Return whether Gate-B real OCTAVE validation is REQUIRED (fail-closed).
+
+    Issue #108.4 (Option C). Default is ``False`` — Gate B is fail-soft-but-loud
+    (a missing ``validation`` extra degrades to regex-only with an explicit
+    top-level signal). When this returns ``True`` the caller turns an
+    ``available=False`` Gate-B result into a HARD block (no linker / no PR).
+
+    Resolution, mirroring :func:`resolve_model` per-repo isolation
+    (HO-INTAKE-MODEL-RESOLUTION-PER-REPO):
+
+        1. ``working_dir/.env`` — parsed for THIS key ONLY (never ``load_dotenv``,
+           so no caller secret enters the process; PROD::I2). If present, it is
+           the per-call source of truth (a governance repo can demand strict
+           validation regardless of the launcher).
+        2. process env (launcher fallback) — ``HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION``.
+        3. default ``False``.
+
+    Args:
+        working_dir: Optional caller project root. When ``None`` only the process
+            env / default are consulted (no ``.env`` is read).
+    """
+    if working_dir is not None:
+        caller = _read_caller_env_keys(working_dir, (_REQUIRE_REAL_VALIDATION_KEY,))
+        repo_value = caller.get(_REQUIRE_REAL_VALIDATION_KEY)
+        if repo_value is not None:
+            return repo_value.strip().lower() in _TRUTHY_VALUES
+
+    return os.environ.get(_REQUIRE_REAL_VALIDATION_KEY, "").strip().lower() in _TRUTHY_VALUES
 
 
 def get_provider_base_url(provider: str) -> str:

--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -122,6 +122,27 @@ def resolve_provider() -> str:
     return os.environ.get("HESTAI_AI_PROVIDER", DEFAULT_PROVIDER)
 
 
+def _parse_env_value(raw_value: str) -> str:
+    """Parse one dotenv-style value conservatively.
+
+    Unquoted values treat the first ``" #"`` sequence as an inline comment
+    delimiter. Quoted values preserve ``#`` and ignore trailing content after
+    the closing quote.
+    """
+    value = raw_value.lstrip()
+    if not value:
+        return ""
+
+    quote = value[0]
+    if quote in {'"', "'"}:
+        end = value.find(quote, 1)
+        if end == -1:
+            return value[1:]
+        return value[1:end]
+
+    return value.split(" #", 1)[0].strip()
+
+
 def _read_caller_env_keys(working_dir: str, keys: tuple[str, ...]) -> dict[str, str]:
     """Parse ``{working_dir}/.env`` and return ONLY the requested keys.
 
@@ -146,7 +167,7 @@ def _read_caller_env_keys(working_dir: str, keys: tuple[str, ...]) -> dict[str, 
         if name.startswith("export "):
             name = name[len("export ") :].strip()
         if name in wanted:
-            found[name] = value.strip().strip('"').strip("'")
+            found[name] = _parse_env_value(value)
     return found
 
 

--- a/src/hestai_context_mcp/adapters/ai_config.py
+++ b/src/hestai_context_mcp/adapters/ai_config.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 
 import keyring
@@ -125,9 +126,9 @@ def resolve_provider() -> str:
 def _parse_env_value(raw_value: str) -> str:
     """Parse one dotenv-style value conservatively.
 
-    Unquoted values treat the first ``" #"`` sequence as an inline comment
-    delimiter. Quoted values preserve ``#`` and ignore trailing content after
-    the closing quote.
+    Unquoted values treat the first whitespace+``#`` sequence as an inline
+    comment delimiter. Quoted values preserve ``#`` and ignore trailing content
+    after the closing quote.
     """
     value = raw_value.lstrip()
     if not value:
@@ -140,7 +141,7 @@ def _parse_env_value(raw_value: str) -> str:
             return value[1:]
         return value[1:end]
 
-    return value.split(" #", 1)[0].strip()
+    return re.split(r"\s#", value, maxsplit=1)[0].strip()
 
 
 def _read_caller_env_keys(working_dir: str, keys: tuple[str, ...]) -> dict[str, str]:

--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 from functools import partial
 from pathlib import Path
 from typing import Any, TypedDict
@@ -34,13 +35,36 @@ from hestai_context_mcp.core.intake_compiler import (
     CompileMetrics,
     compile_prose_to_octave,
 )
-from hestai_context_mcp.ports.octave_validator import get_octave_validator
+from hestai_context_mcp.ports.octave_validator import (
+    fail_closed_error_message,
+    get_octave_validator,
+)
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
 from hestai_context_mcp.tools.governance.linker import run_linker
 from hestai_context_mcp.tools.governance.type_checker import (
     ValidationResult,
     validate_octave_content,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_require_real_validation(working_dir: str | None = None) -> bool:
+    """Module-level seam over the adapter's fail-closed flag resolver (#108.4).
+
+    DIP boundary (enforced by ``tests/unit/test_source_invariants.py``): this
+    ``core`` module must not import ``adapters`` at module load. The adapter is
+    reached via a LAZY import inside this wrapper (composition-root pattern,
+    mirroring ``intake_compiler.build_default_ai_client``). Tests monkeypatch
+    this symbol on the module to inject the policy; production resolves it via
+    the lazy import on each call.
+    """
+    from hestai_context_mcp.adapters.ai_config import (
+        resolve_require_real_validation as _resolve,
+    )
+
+    return _resolve(working_dir)
+
 
 __all__ = ["PipelineResult", "run_intake_pipeline", "run_intake_to_pr"]
 
@@ -58,6 +82,10 @@ class PipelineResult(TypedDict):
         validation_errors: Flattened error strings (empty on success).
         metrics: Stage-2 metrics from the *last* compile attempt.
         attempts: Number of backend compile attempts performed (1 or 2).
+        real_validation_available: #108.4 — whether Gate B's real OCTAVE
+            validator actually ran (False when the ``validation`` extra is
+            absent and the pass degraded to regex-only). Surfaced so the Stage-4
+            seam can apply the loud signal + opt-in fail-closed policy.
     """
 
     ok: bool
@@ -66,14 +94,16 @@ class PipelineResult(TypedDict):
     validation_errors: list[str]
     metrics: CompileMetrics
     attempts: int
+    real_validation_available: bool
 
 
-def _gate(working_dir: Path, octave: str) -> tuple[bool, ValidationResult, list[str]]:
-    """Run the existing two-stage gate. Returns (passed, regex_result, errors).
+def _gate(working_dir: Path, octave: str) -> tuple[bool, ValidationResult, list[str], bool]:
+    """Run the existing two-stage gate.
 
-    Regex Gate A runs first (it also extracts token/card_type/target_path for
-    Stage 4). The real Gate B validator runs additively; its structured errors
-    are flattened into the error list. The pass requires BOTH to be clean.
+    Returns ``(passed, regex_result, errors, real_validation_available)``. The
+    last element (#108.4) reports whether Gate B's real validator actually ran;
+    it is ``True`` until Gate B is reached (regex-fail short-circuits before
+    Gate B, so availability is unknown -> reported True, no degrade observed).
     """
     # Gate A (regex) carries the §4.1 #13 reasoning-density guard (≤40 words,
     # no newline on DECISION/BECAUSE), so the verbosity rule is enforced HERE,
@@ -83,16 +113,16 @@ def _gate(working_dir: Path, octave: str) -> tuple[bool, ValidationResult, list[
     # informed-retry/abort path as any schema failure (no separate Gate-C lint).
     regex_result = validate_octave_content(working_dir, octave)
     if not regex_result.valid:
-        return False, regex_result, list(regex_result.errors)
+        return False, regex_result, list(regex_result.errors), True
 
     octave_result = get_octave_validator().validate(octave)
     if not octave_result.ok:
         errors = [
             f"[{e.get('code', '')}] {e.get('message', '')}".strip() for e in octave_result.errors
         ]
-        return False, regex_result, errors
+        return False, regex_result, errors, octave_result.available
 
-    return True, regex_result, []
+    return True, regex_result, [], octave_result.available
 
 
 def _augment_prompt_with_errors(ctx: IntakeContext, errors: list[str]) -> IntakeContext:
@@ -142,6 +172,10 @@ async def run_intake_pipeline(
         "cost_is_estimate": True,
     }
     last_errors: list[str] = []
+    # #108.4: carry Gate-B availability from the last attempt that reached Gate B.
+    # Defaults True (no degrade observed) for compile-fail aborts that never
+    # reach the validator.
+    last_available = True
 
     for attempt in range(1, _MAX_ATTEMPTS + 1):
         compiled = await compile_prose_to_octave(
@@ -163,10 +197,11 @@ async def run_intake_pipeline(
                 "validation_errors": [err],
                 "metrics": last_metrics,
                 "attempts": attempt,
+                "real_validation_available": last_available,
             }
 
         octave = compiled["octave"]
-        passed, regex_result, errors = _gate(working_dir, octave)
+        passed, regex_result, errors, last_available = _gate(working_dir, octave)
         if passed:
             return {
                 "ok": True,
@@ -175,6 +210,7 @@ async def run_intake_pipeline(
                 "validation_errors": [],
                 "metrics": last_metrics,
                 "attempts": attempt,
+                "real_validation_available": last_available,
             }
 
         last_errors = errors
@@ -190,6 +226,7 @@ async def run_intake_pipeline(
         "validation_errors": last_errors,
         "metrics": last_metrics,
         "attempts": _MAX_ATTEMPTS,
+        "real_validation_available": last_available,
     }
 
 
@@ -204,6 +241,30 @@ def _intake_failure_result(pipeline: PipelineResult, dry_run: bool) -> dict[str,
         "pr_url": None,
         "validation_errors": pipeline["validation_errors"],
         "octave_validation": None,
+        "real_validation_available": pipeline["real_validation_available"],
+        "metrics": pipeline["metrics"],
+        "dry_run": dry_run,
+    }
+
+
+def _fail_closed_result(pipeline: PipelineResult, dry_run: bool) -> dict[str, Any]:
+    """#108.4 Option C: hard-block shape when real validation is required but absent.
+
+    Mirrors the abort shape (no token/branch/pr_url, NEVER calls the linker) with
+    the structured fail-closed error and the loud ``real_validation_available``
+    signal. The authored OCTAVE is surfaced for parity with the success path.
+    """
+    return {
+        "success": False,
+        "token": None,
+        "card_type": None,
+        "target_path": None,
+        "branch": None,
+        "pr_url": None,
+        "validation_errors": [fail_closed_error_message()],
+        "octave_validation": None,
+        "real_validation_available": False,
+        "octave": pipeline["octave"],
         "metrics": pipeline["metrics"],
         "dry_run": dry_run,
     }
@@ -246,6 +307,21 @@ async def run_intake_to_pr(
     if not pipeline["ok"] or pipeline["octave"] is None or pipeline["validation"] is None:
         return _intake_failure_result(pipeline, dry_run)
 
+    # --- #108.4: Gate-B availability policy on the PROSE path (shared Gate B) ---
+    # Option L (unconditional): surface ``real_validation_available`` top-level
+    # (below) and log at WARNING when degraded. Option C (opt-in, default OFF):
+    # when real validation is REQUIRED but Gate B was unavailable, hard-block
+    # BEFORE the linker (no branch, no PR), mirroring the octave_content path.
+    real_validation_available = pipeline["real_validation_available"]
+    if not real_validation_available:
+        logger.warning(
+            "Gate B real OCTAVE validation unavailable (the 'validation' extra is "
+            "not installed); proceeding on regex Gate A only unless fail-closed is "
+            "required."
+        )
+        if resolve_require_real_validation(working_dir=str(working_dir)):
+            return _fail_closed_result(pipeline, dry_run)
+
     loop = asyncio.get_running_loop()
     linker_fn = partial(
         run_linker,
@@ -266,6 +342,7 @@ async def run_intake_to_pr(
         "pr_url": linker_output.get("pr_url"),
         "validation_errors": [linker_error] if linker_error else [],
         "octave_validation": None,
+        "real_validation_available": real_validation_available,
         # Surface the authored OCTAVE so the Stage-5 reviewer can read the exact
         # record that was PR'd (issue #77). Additive; ``None`` on the abort path.
         "octave": pipeline["octave"],

--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -325,7 +325,12 @@ async def run_intake_to_pr(
             "not installed); proceeding on regex Gate A only unless fail-closed is "
             "required."
         )
-        if resolve_require_real_validation(working_dir=str(working_dir)):
+        loop = asyncio.get_running_loop()
+        require_real_validation = await loop.run_in_executor(
+            None,
+            partial(resolve_require_real_validation, working_dir=str(working_dir)),
+        )
+        if require_real_validation:
             return _fail_closed_result(pipeline, dry_run)
 
     loop = asyncio.get_running_loop()

--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -36,6 +36,7 @@ from hestai_context_mcp.core.intake_compiler import (
     compile_prose_to_octave,
 )
 from hestai_context_mcp.ports.octave_validator import (
+    UnavailableOctaveValidator,
     fail_closed_error_message,
     get_octave_validator,
 )
@@ -101,9 +102,9 @@ def _gate(working_dir: Path, octave: str) -> tuple[bool, ValidationResult, list[
     """Run the existing two-stage gate.
 
     Returns ``(passed, regex_result, errors, real_validation_available)``. The
-    last element (#108.4) reports whether Gate B's real validator actually ran;
-    it is ``True`` until Gate B is reached (regex-fail short-circuits before
-    Gate B, so availability is unknown -> reported True, no degrade observed).
+    last element (#108.4) reports whether Gate B's real validator is actually
+    available. A regex-fail short-circuit still reports backend availability
+    accurately without running full validation.
     """
     # Gate A (regex) carries the §4.1 #13 reasoning-density guard (≤40 words,
     # no newline on DECISION/BECAUSE), so the verbosity rule is enforced HERE,
@@ -112,10 +113,15 @@ def _gate(working_dir: Path, octave: str) -> tuple[bool, ValidationResult, list[
     # record therefore fails Gate A directly; the failure flows through the same
     # informed-retry/abort path as any schema failure (no separate Gate-C lint).
     regex_result = validate_octave_content(working_dir, octave)
+    octave_validator = get_octave_validator()
+    real_validation_available = not isinstance(
+        octave_validator,
+        UnavailableOctaveValidator,
+    )
     if not regex_result.valid:
-        return False, regex_result, list(regex_result.errors), True
+        return False, regex_result, list(regex_result.errors), real_validation_available
 
-    octave_result = get_octave_validator().validate(octave)
+    octave_result = octave_validator.validate(octave)
     if not octave_result.ok:
         errors = [
             f"[{e.get('code', '')}] {e.get('message', '')}".strip() for e in octave_result.errors

--- a/src/hestai_context_mcp/ports/octave_validator.py
+++ b/src/hestai_context_mcp/ports/octave_validator.py
@@ -47,10 +47,29 @@ __all__ = [
     "RealOctaveValidator",
     "UnavailableOctaveValidator",
     "get_octave_validator",
+    "fail_closed_error_message",
 ]
 
 # Stable warning code surfaced when the optional ``validation`` extra is absent.
 REAL_VALIDATION_UNAVAILABLE = "REAL_VALIDATION_UNAVAILABLE"
+
+
+def fail_closed_error_message() -> str:
+    """Return the structured error used when fail-closed validation blocks (#108.4).
+
+    Single source of truth for the Option-C block message across both submission
+    paths (octave_content and prose). Names the missing ``validation`` extra and
+    how to install it, plus the escape hatch (unset the flag), so a blocked
+    operator has a clear recovery path (PROD::I4).
+    """
+    return (
+        f"{REAL_VALIDATION_UNAVAILABLE}: real OCTAVE validation is REQUIRED "
+        "(HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION is set) but the optional "
+        "'validation' extra (octave-mcp) is not installed, so only regex Gate A "
+        "could run. Refusing to author governance without full AST validation. "
+        "Install it with 'pip install hestai-context-mcp[validation]', or unset "
+        "the flag to fall back to fail-soft (regex-only) authoring."
+    )
 
 
 @dataclass(frozen=True)

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -368,7 +368,11 @@ async def _submit_octave_content(
             "not installed); proceeding on regex Gate A only unless fail-closed is "
             "required."
         )
-        if resolve_require_real_validation(working_dir=str(wd)):
+        require_real_validation = await loop.run_in_executor(
+            None,
+            partial(resolve_require_real_validation, working_dir=str(wd)),
+        )
+        if require_real_validation:
             return _empty_result(
                 dry_run,
                 [fail_closed_error_message()],

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -24,14 +24,17 @@ structured "real-validation unavailable" signal and the regex Gate A still runs.
 """
 
 import asyncio
+import logging
 import re
 from functools import partial
 from typing import Any
 
+from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
 from hestai_context_mcp.core.governance_reviewer import review_governance
 from hestai_context_mcp.core.intake_pipeline import run_intake_to_pr
 from hestai_context_mcp.ports.octave_validator import (
     OctaveValidationResult,
+    fail_closed_error_message,
     get_octave_validator,
 )
 from hestai_context_mcp.tools.clock_in import validate_working_dir
@@ -39,6 +42,8 @@ from hestai_context_mcp.tools.governance.intake_context import assemble_intake_c
 from hestai_context_mcp.tools.governance.linker import run_linker
 from hestai_context_mcp.tools.governance.type_checker import validate_octave_content
 from hestai_context_mcp.tools.submit_review import submit_review
+
+logger = logging.getLogger(__name__)
 
 # review_governance and submit_review are imported as module globals (not via
 # attribute paths) so the Stage-5 seam is monkeypatchable in tests, mirroring
@@ -59,8 +64,16 @@ def _empty_result(
     dry_run: bool,
     errors: list[str],
     octave_validation: dict[str, Any] | None = None,
+    *,
+    real_validation_available: bool = True,
 ) -> dict[str, Any]:
-    """Return the I4-conformant failure shape with all fields present."""
+    """Return the I4-conformant failure shape with all fields present.
+
+    ``real_validation_available`` (#108.4 Option L) is an EXPLICIT top-level
+    signal so a fail-soft Gate-B degrade is never hidden inside
+    ``octave_validation.warnings``. It defaults True because most failures are
+    unrelated to Gate-B availability; the Gate-B paths pass it explicitly.
+    """
     return {
         "success": False,
         "token": None,
@@ -70,6 +83,7 @@ def _empty_result(
         "pr_url": None,
         "validation_errors": errors,
         "octave_validation": octave_validation,
+        "real_validation_available": real_validation_available,
         "dry_run": dry_run,
     }
 
@@ -329,6 +343,7 @@ async def _submit_octave_content(
         octave_content,
     )
     octave_validation = octave_result.to_dict()
+    real_validation_available = octave_result.available
 
     if not octave_result.ok:
         # Real validation failed: structured error, no PR / no write.
@@ -336,7 +351,30 @@ async def _submit_octave_content(
             dry_run,
             _octave_errors_to_strings(octave_result),
             octave_validation=octave_validation,
+            real_validation_available=real_validation_available,
         )
+
+    # --- #108.4: Gate-B availability policy (Option L loud + Option C opt-in) ---
+    # Option L (unconditional): the degrade is surfaced as the top-level
+    # ``real_validation_available`` signal below, and logged at WARNING here, so
+    # it can never hide inside ``octave_validation.warnings``.
+    # Option C (opt-in, default OFF): when the deployment REQUIRES real validation
+    # and it is unavailable, hard-block (no linker / no PR) with a structured
+    # PROD-I4 error naming the missing extra. Default OFF keeps the octave_content
+    # path byte-stable apart from the additive signal.
+    if not real_validation_available:
+        logger.warning(
+            "Gate B real OCTAVE validation unavailable (the 'validation' extra is "
+            "not installed); proceeding on regex Gate A only unless fail-closed is "
+            "required."
+        )
+        if resolve_require_real_validation(working_dir=str(wd)):
+            return _empty_result(
+                dry_run,
+                [fail_closed_error_message()],
+                octave_validation=octave_validation,
+                real_validation_available=False,
+            )
 
     # --- Linker (blocking: git subprocess + file writes) ---
     linker_fn = partial(
@@ -362,6 +400,7 @@ async def _submit_octave_content(
         "pr_url": linker_output.get("pr_url"),
         "validation_errors": errors,
         "octave_validation": octave_validation,
+        "real_validation_available": real_validation_available,
         "dry_run": dry_run,
     }
     return await _maybe_review(result, octave_content, dry_run, review, working_dir=str(wd))

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -71,6 +71,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "HESTAI_AI_MODEL_CRITICAL",
         "HESTAI_AI_PROVIDER_ROUTING",
         "HESTAI_AI_PROVIDER_ORDER",
+        "HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
     ):
@@ -548,6 +549,84 @@ class TestResolveModelPerRepoOverride:
             "PER_REPO_OVERRIDE=true\nHESTAI_AI_MODEL=repo/model\nSECRET_TOKEN=supersecret\n",
         )
         assert resolve_model("default", working_dir=wd) == "repo/model"
+        assert "SECRET_TOKEN" not in os.environ
+
+
+class TestResolveRequireRealValidation:
+    """#108.4 Option C: opt-in fail-closed flag for Gate-B real OCTAVE validation.
+
+    Default OFF (fail-soft-but-loud). Resolved per-repo from ``working_dir/.env``
+    in ISOLATION (the flag key only, never ``load_dotenv``), with process-env as
+    the launcher fallback — mirroring ``resolve_model``'s per-repo isolation
+    (HO-INTAKE-MODEL-RESOLUTION-PER-REPO). A boolean is not a secret, so a
+    per-repo flag lets a governance repo demand strict AST validation.
+    """
+
+    _KEY = "HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION"
+
+    @staticmethod
+    def _write_env(tmp_path, body: str) -> str:
+        (tmp_path / ".env").write_text(body, encoding="utf-8")
+        return str(tmp_path)
+
+    def test_default_is_false(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        # No process env, no .env -> default OFF.
+        assert resolve_require_real_validation(working_dir=str(tmp_path)) is False
+
+    def test_working_dir_none_reads_process_env_only(self, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        assert resolve_require_real_validation(working_dir=None) is False
+        monkeypatch.setenv(self._KEY, "true")
+        assert resolve_require_real_validation(working_dir=None) is True
+
+    def test_process_env_launcher_fallback(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        monkeypatch.setenv(self._KEY, "1")
+        # No .env in the repo -> the process env (launcher) supplies the flag.
+        assert resolve_require_real_validation(working_dir=str(tmp_path)) is True
+
+    def test_repo_env_enables_when_process_off(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=true\n")
+        # Per-repo opt-in: a governance repo demands strict validation.
+        assert resolve_require_real_validation(working_dir=wd) is True
+
+    def test_repo_env_takes_precedence_over_process(self, tmp_path, monkeypatch, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        # Repo .env is the per-call source of truth; if present it wins.
+        monkeypatch.setenv(self._KEY, "false")
+        wd = self._write_env(tmp_path, f"{self._KEY}=true\n")
+        assert resolve_require_real_validation(working_dir=wd) is True
+
+    def test_truthy_variants(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        for val in ("1", "true", "TRUE", "yes", "on"):
+            wd = self._write_env(tmp_path, f"{self._KEY}={val}\n")
+            assert resolve_require_real_validation(working_dir=wd) is True, val
+
+    def test_falsey_variants(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        for val in ("0", "false", "no", "off", ""):
+            wd = self._write_env(tmp_path, f"{self._KEY}={val}\n")
+            assert resolve_require_real_validation(working_dir=wd) is False, val
+
+    def test_caller_env_not_loaded_into_process(self, tmp_path, clean_env):
+        """PROD::I2 — parsing the caller .env must NOT leak its secrets into os.environ."""
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(
+            tmp_path,
+            f"{self._KEY}=true\nSECRET_TOKEN=supersecret\n",
+        )
+        assert resolve_require_real_validation(working_dir=wd) is True
         assert "SECRET_TOKEN" not in os.environ
 
 

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -644,6 +644,12 @@ class TestResolveRequireRealValidation:
         wd = self._write_env(tmp_path, f"{self._KEY}=true # enforce strict\n")
         assert resolve_require_real_validation(working_dir=wd) is True
 
+    def test_tab_prefixed_inline_comment_is_stripped_before_truthy_parse(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=true\t# enforce strict\n")
+        assert resolve_require_real_validation(working_dir=wd) is True
+
     def test_quoted_hash_is_preserved_not_treated_as_comment(self, tmp_path, clean_env):
         from hestai_context_mcp.adapters.ai_config import _read_caller_env_keys
 
@@ -661,6 +667,18 @@ class TestResolveRequireRealValidation:
 
         wd = self._write_env(tmp_path, f"{self._KEY}=false # explicit off\n")
         assert resolve_require_real_validation(working_dir=wd) is False
+
+    def test_false_value_with_tab_prefixed_inline_comment_stays_false(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=false\t# explicit off\n")
+        assert resolve_require_real_validation(working_dir=wd) is False
+
+    def test_unquoted_hash_without_leading_whitespace_is_preserved(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import _read_caller_env_keys
+
+        wd = self._write_env(tmp_path, "TOKEN=token#fragment\n")
+        assert _read_caller_env_keys(wd, ("TOKEN",)) == {"TOKEN": "token#fragment"}
 
 
 # Dead-import helper so ``Any`` stays reachable by mypy when adding fields.

--- a/tests/unit/adapters/test_ai_config.py
+++ b/tests/unit/adapters/test_ai_config.py
@@ -551,6 +551,15 @@ class TestResolveModelPerRepoOverride:
         assert resolve_model("default", working_dir=wd) == "repo/model"
         assert "SECRET_TOKEN" not in os.environ
 
+    def test_unquoted_inline_comment_is_stripped_from_model(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_model
+
+        wd = self._write_env(
+            tmp_path,
+            "PER_REPO_OVERRIDE=true\nHESTAI_AI_MODEL=gpt-4 # default\n",
+        )
+        assert resolve_model("default", working_dir=wd) == "gpt-4"
+
 
 class TestResolveRequireRealValidation:
     """#108.4 Option C: opt-in fail-closed flag for Gate-B real OCTAVE validation.
@@ -628,6 +637,30 @@ class TestResolveRequireRealValidation:
         )
         assert resolve_require_real_validation(working_dir=wd) is True
         assert "SECRET_TOKEN" not in os.environ
+
+    def test_unquoted_inline_comment_is_stripped_before_truthy_parse(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=true # enforce strict\n")
+        assert resolve_require_real_validation(working_dir=wd) is True
+
+    def test_quoted_hash_is_preserved_not_treated_as_comment(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import _read_caller_env_keys
+
+        wd = self._write_env(tmp_path, f'{self._KEY}="true # not a comment"\n')
+        assert _read_caller_env_keys(wd, (self._KEY,)) == {self._KEY: "true # not a comment"}
+
+    def test_unquoted_value_without_comment_still_reads_true(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=true\n")
+        assert resolve_require_real_validation(working_dir=wd) is True
+
+    def test_false_value_with_inline_comment_stays_false(self, tmp_path, clean_env):
+        from hestai_context_mcp.adapters.ai_config import resolve_require_real_validation
+
+        wd = self._write_env(tmp_path, f"{self._KEY}=false # explicit off\n")
+        assert resolve_require_real_validation(working_dir=wd) is False
 
 
 # Dead-import helper so ``Any`` stays reachable by mypy when adding fields.

--- a/tests/unit/core/test_intake_linker_wiring.py
+++ b/tests/unit/core/test_intake_linker_wiring.py
@@ -52,7 +52,7 @@ def _ctx() -> IntakeContext:
     return IntakeContext(prose_input="record a decision", corpus="", prompt="P", relevant_tokens=())
 
 
-def _pipeline_ok() -> dict[str, Any]:
+def _pipeline_ok(real_validation_available: bool = True) -> dict[str, Any]:
     return {
         "ok": True,
         "octave": _VALID_OCTAVE,
@@ -66,6 +66,7 @@ def _pipeline_ok() -> dict[str, Any]:
         "validation_errors": [],
         "metrics": {"tokens": 10, "cost": 0.01, "model": "test-model"},
         "attempts": 1,
+        "real_validation_available": real_validation_available,
     }
 
 
@@ -77,6 +78,7 @@ def _pipeline_abort() -> dict[str, Any]:
         "validation_errors": ["No OCTAVE sentinel found at document start."],
         "metrics": {"tokens": 10, "cost": 0.0, "model": "test-model"},
         "attempts": 2,
+        "real_validation_available": True,
     }
 
 
@@ -152,6 +154,53 @@ class TestAbortDoesNotWireLinker:
         assert result["pr_url"] is None
         # Hallucination immunity at the seam: linker NEVER invoked on abort.
         assert spy_linker.calls == []
+
+
+class TestRealValidationSignalAndFailClosed:
+    """#108.4 on the PROSE path (shared Gate B): top-level signal + opt-in block."""
+
+    async def test_available_surfaces_top_level_signal(
+        self, tmp_path: Path, stub_pipeline, spy_linker
+    ) -> None:
+        stub_pipeline(_pipeline_ok(real_validation_available=True))
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=True)
+        assert result["success"] is True
+        assert result["real_validation_available"] is True
+
+    async def test_unavailable_flag_off_proceeds_with_loud_signal(
+        self, tmp_path: Path, stub_pipeline, spy_linker, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: False)
+        stub_pipeline(_pipeline_ok(real_validation_available=False))
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=True)
+        # Fail-soft default: proceeds, but the degrade is surfaced top-level.
+        assert result["success"] is True
+        assert result["real_validation_available"] is False
+        assert len(spy_linker.calls) == 1
+
+    async def test_unavailable_flag_on_hard_blocks_no_linker(
+        self, tmp_path: Path, stub_pipeline, spy_linker, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+        stub_pipeline(_pipeline_ok(real_validation_available=False))
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=False)
+        assert result["success"] is False
+        assert result["pr_url"] is None
+        assert result["real_validation_available"] is False
+        # Fail-closed must NOT invoke the linker.
+        assert spy_linker.calls == []
+        joined = " ".join(result["validation_errors"]).lower()
+        assert "validation" in joined and ("install" in joined or "extra" in joined)
+
+    async def test_unavailable_flag_on_but_available_proceeds(
+        self, tmp_path: Path, stub_pipeline, spy_linker, monkeypatch
+    ) -> None:
+        """Flag ON but Gate B available -> normal proceed (block only on unavailable)."""
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+        stub_pipeline(_pipeline_ok(real_validation_available=True))
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=True)
+        assert result["success"] is True
+        assert len(spy_linker.calls) == 1
 
 
 class TestHumanPrimacy:

--- a/tests/unit/core/test_intake_linker_wiring.py
+++ b/tests/unit/core/test_intake_linker_wiring.py
@@ -192,6 +192,29 @@ class TestRealValidationSignalAndFailClosed:
         joined = " ".join(result["validation_errors"]).lower()
         assert "validation" in joined and ("install" in joined or "extra" in joined)
 
+    async def test_unavailable_flag_resolution_is_offloaded_to_executor(
+        self, tmp_path: Path, stub_pipeline, spy_linker, monkeypatch
+    ) -> None:
+        class _Loop:
+            def __init__(self) -> None:
+                self.calls: list[object] = []
+
+            async def run_in_executor(self, executor, func, *args):
+                self.calls.append(func)
+                return func(*args)
+
+        loop = _Loop()
+        monkeypatch.setattr(mod.asyncio, "get_running_loop", lambda: loop)
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+        stub_pipeline(_pipeline_ok(real_validation_available=False))
+
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=False)
+
+        assert result["success"] is False
+        assert result["real_validation_available"] is False
+        assert spy_linker.calls == []
+        assert len(loop.calls) == 1
+
     async def test_unavailable_flag_on_but_available_proceeds(
         self, tmp_path: Path, stub_pipeline, spy_linker, monkeypatch
     ) -> None:

--- a/tests/unit/core/test_intake_pipeline.py
+++ b/tests/unit/core/test_intake_pipeline.py
@@ -147,6 +147,33 @@ class TestRealValidationAvailabilitySurfaced:
         assert result["ok"] is True
         assert result["real_validation_available"] is False
 
+    async def test_gate_a_failure_reports_false_when_unavailable_validator_active(
+        self, tmp_path: Path, stub_backend, monkeypatch
+    ) -> None:
+        from hestai_context_mcp.ports.octave_validator import UnavailableOctaveValidator
+
+        monkeypatch.setattr(
+            mod,
+            "get_octave_validator",
+            lambda: UnavailableOctaveValidator(),
+            raising=True,
+        )
+        passed, _, _, available = mod._gate(tmp_path, _INVALID_OCTAVE)
+        assert passed is False
+        assert available is False
+
+    async def test_gate_a_failure_reports_true_when_real_validator_is_available(
+        self, tmp_path: Path, stub_backend, monkeypatch
+    ) -> None:
+        class _Available:
+            def validate(self, content: str):  # pragma: no cover - Gate A must short-circuit first.
+                raise AssertionError("Gate B must not run on a Gate-A failure")
+
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: _Available(), raising=True)
+        passed, _, _, available = mod._gate(tmp_path, _INVALID_OCTAVE)
+        assert passed is False
+        assert available is True
+
 
 class TestRetryOnce:
     async def test_invalid_then_valid_retries_once(self, tmp_path: Path, stub_backend) -> None:

--- a/tests/unit/core/test_intake_pipeline.py
+++ b/tests/unit/core/test_intake_pipeline.py
@@ -120,6 +120,34 @@ class TestHappyPath:
         assert len(stub_backend.calls) == 1
 
 
+class TestRealValidationAvailabilitySurfaced:
+    """#108.4: the pipeline surfaces Gate-B availability so callers can act on it."""
+
+    async def test_available_true_when_validator_available(
+        self, tmp_path: Path, stub_backend
+    ) -> None:
+        stub_backend.script([_compile_result(_VALID_OCTAVE)])
+        result = await run_intake_pipeline(tmp_path, _ctx())
+        assert result["ok"] is True
+        assert result["real_validation_available"] is True
+
+    async def test_available_false_when_extra_absent(
+        self, tmp_path: Path, stub_backend, monkeypatch
+    ) -> None:
+        from hestai_context_mcp.ports.octave_validator import OctaveValidationResult
+
+        class _Unavailable:
+            def validate(self, content: str) -> OctaveValidationResult:
+                return OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: _Unavailable(), raising=True)
+        stub_backend.script([_compile_result(_VALID_OCTAVE)])
+        result = await run_intake_pipeline(tmp_path, _ctx())
+        # Regex Gate A still gated -> a valid doc passes; availability is surfaced.
+        assert result["ok"] is True
+        assert result["real_validation_available"] is False
+
+
 class TestRetryOnce:
     async def test_invalid_then_valid_retries_once(self, tmp_path: Path, stub_backend) -> None:
         stub_backend.script([_compile_result(_INVALID_OCTAVE), _compile_result(_VALID_OCTAVE)])

--- a/tests/unit/tools/test_submit_governance_octave_validator.py
+++ b/tests/unit/tools/test_submit_governance_octave_validator.py
@@ -312,6 +312,53 @@ class TestFailClosedOptIn:
         assert result["success"] is True
         assert result["real_validation_available"] is False
 
+    @pytest.mark.unit
+    def test_unavailable_flag_resolution_is_offloaded_to_executor(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        class _Loop:
+            def __init__(self) -> None:
+                self.calls: list[object] = []
+
+            async def run_in_executor(self, executor, func, *args):
+                self.calls.append(func)
+                return func(*args)
+
+        loop = _Loop()
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+        )
+
+        monkeypatch.setattr(mod.asyncio, "get_running_loop", lambda: loop)
+        monkeypatch.setattr(mod, "validate_working_dir", lambda raw: Path(raw))
+        monkeypatch.setattr(
+            mod,
+            "validate_octave_content",
+            lambda wd, content: type("Validation", (), {"valid": True, "errors": []})(),
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+        monkeypatch.setattr(
+            mod,
+            "run_linker",
+            lambda **kwargs: pytest.fail("run_linker must not run when fail-closed blocks"),
+        )
+
+        result = asyncio.run(
+            mod._submit_octave_content(
+                str(tmp_path),
+                decision_record_octave,
+                True,
+                False,
+            )
+        )
+
+        assert result["success"] is False
+        assert result["real_validation_available"] is False
+        assert len(loop.calls) == 4
+
 
 class TestPublicContractUnchanged:
     @pytest.mark.unit

--- a/tests/unit/tools/test_submit_governance_octave_validator.py
+++ b/tests/unit/tools/test_submit_governance_octave_validator.py
@@ -201,6 +201,118 @@ class TestFailSoftDoesNotBlock:
         assert result["validation_errors"]
 
 
+class TestRealValidationTopLevelSignal:
+    """#108.4 Option L: the degrade must be an EXPLICIT top-level signal.
+
+    ``real_validation_available`` is surfaced at the TOP LEVEL of the result on
+    both submission paths so a fail-soft degrade cannot hide inside
+    ``octave_validation.warnings``.
+    """
+
+    @pytest.mark.unit
+    def test_available_true_surfaces_top_level_true(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=True)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is True
+        # Explicit, top-level (NOT buried in octave_validation).
+        assert result["real_validation_available"] is True
+
+    @pytest.mark.unit
+    def test_unavailable_surfaces_top_level_false_and_proceeds(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        # Flag OFF (default) -> proceeds (fail-soft), but the degrade is LOUD.
+        assert result["success"] is True
+        assert result["real_validation_available"] is False
+        # And it is a TOP-LEVEL key, not only inside octave_validation.warnings.
+        assert "real_validation_available" in result
+
+
+class TestFailClosedOptIn:
+    """#108.4 Option C: opt-in fail-closed flag (default OFF)."""
+
+    @pytest.mark.unit
+    def test_flag_on_unavailable_hard_blocks_no_linker(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+        # Force the fail-closed policy ON regardless of env/.env.
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must not be called
+            raise AssertionError("run_linker must not run when fail-closed blocks")
+
+        monkeypatch.setattr(mod, "run_linker", _boom)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is False
+        assert result["pr_url"] is None
+        assert result["real_validation_available"] is False
+        # Structured PROD-I4 error naming the missing extra + how to install.
+        joined = " ".join(result["validation_errors"]).lower()
+        assert "validation" in joined and ("install" in joined or "extra" in joined)
+
+    @pytest.mark.unit
+    def test_flag_on_but_available_proceeds(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        """Flag ON but the real validator IS available -> normal proceed (no block)."""
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=True)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: True)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is True
+        assert result["real_validation_available"] is True
+
+    @pytest.mark.unit
+    def test_flag_off_unavailable_is_byte_stable_proceed(
+        self, tmp_path: Path, decision_record_octave: str, monkeypatch
+    ) -> None:
+        """Flag OFF + unavailable -> proceeds (only the additive signal differs)."""
+        import hestai_context_mcp.tools.submit_governance as mod
+
+        stub = _StubValidator(
+            OctaveValidationResult(ok=True, errors=[], warnings=[], available=False)
+        )
+        monkeypatch.setattr(mod, "get_octave_validator", lambda: stub)
+        monkeypatch.setattr(mod, "resolve_require_real_validation", lambda working_dir: False)
+
+        result = _run(tmp_path, decision_record_octave)
+
+        assert result["success"] is True
+        assert result["real_validation_available"] is False
+
+
 class TestPublicContractUnchanged:
     @pytest.mark.unit
     def test_input_signature_adds_prose_input_back_compatibly(self) -> None:

--- a/tests/unit/tools/test_submit_governance_prose.py
+++ b/tests/unit/tools/test_submit_governance_prose.py
@@ -150,7 +150,9 @@ class TestProseMode:
 
 
 class TestOctaveContentBackCompat:
-    """The octave_content path must keep its EXACT post-#70 return shape."""
+    """The octave_content path keeps its post-#70 return shape, plus the single
+    additive #108.4 Option-L ``real_validation_available`` signal (no pre-existing
+    key removed/renamed, and still no ``metrics`` key on this path)."""
 
     _POST_70_KEYS = {
         "success",
@@ -161,6 +163,7 @@ class TestOctaveContentBackCompat:
         "pr_url",
         "validation_errors",
         "octave_validation",
+        "real_validation_available",
         "dry_run",
     }
 
@@ -172,7 +175,7 @@ class TestOctaveContentBackCompat:
                 dry_run=True,
             )
         )
-        # Byte-stable shape: EXACTLY the post-#70 keys, no extra "metrics" key.
+        # Byte-stable shape beyond the additive signal: no extra "metrics" key.
         assert set(result.keys()) == self._POST_70_KEYS
         assert result["success"] is True
         assert result["token"] == "HO-CONTEXT-MCP-PROSE-20260601"

--- a/tests/unit/tools/test_submit_governance_prose_review.py
+++ b/tests/unit/tools/test_submit_governance_prose_review.py
@@ -69,6 +69,7 @@ class TestRunIntakeToPrThreadsOctave:
                 "validation_errors": [],
                 "metrics": {"tokens": 10, "cost": 0.0, "model": "default-tier-model"},
                 "attempts": 1,
+                "real_validation_available": True,
             }
 
         def _fake_linker(**kw: Any) -> dict[str, Any]:
@@ -98,6 +99,7 @@ class TestRunIntakeToPrThreadsOctave:
                 "validation_errors": ["bad"],
                 "metrics": {"tokens": 0, "cost": 0.0, "model": ""},
                 "attempts": 2,
+                "real_validation_available": True,
             }
 
         monkeypatch.setattr(pipeline_mod, "run_intake_pipeline", _fake_pipeline, raising=True)

--- a/tests/unit/tools/test_submit_governance_semantic_review.py
+++ b/tests/unit/tools/test_submit_governance_semantic_review.py
@@ -92,6 +92,7 @@ def stub_octave_pr(monkeypatch: pytest.MonkeyPatch):
 
     class _OctaveResult:
         ok = True
+        available = True
 
         def to_dict(self) -> dict[str, Any]:
             return {"ok": True, "available": True, "errors": []}
@@ -215,8 +216,13 @@ class TestOctaveContentStage5:
             "octave_validation",
             "dry_run",
         }
-        # The ONLY new top-level key is the additive semantic_review.
-        assert set(result.keys()) == post_70_keys | {"semantic_review"}
+        # Additive top-level keys: semantic_review (#77) and the #108.4 Option-L
+        # real_validation_available signal. No pre-existing key is removed or
+        # renamed (byte-stable contract beyond purely additive fields).
+        assert set(result.keys()) == post_70_keys | {
+            "semantic_review",
+            "real_validation_available",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +259,7 @@ class TestStage5SkipConditions:
 
         class _OctaveResult:
             ok = True
+            available = True
 
             def to_dict(self) -> dict[str, Any]:
                 return {"ok": True, "available": True, "errors": []}
@@ -336,6 +343,7 @@ class TestStage5FailSoft:
 
         class _OctaveResult:
             ok = True
+            available = True
 
             def to_dict(self) -> dict[str, Any]:
                 return {"ok": True, "available": True, "errors": []}


### PR DESCRIPTION
## feat(governance): loud + opt-in fail-closed Gate-B validation (#108.4)

Closes #108 item 4. When the optional `octave-mcp` `[validation]` extra is absent, Gate B (real OCTAVE AST validation) silently degraded to regex-only and the submit still proceeded — the degrade was buried in `octave_validation.warnings`. This makes the degrade **loud** and adds an **opt-in fail-closed** posture.

### What it does
- **Option L (unconditional, both paths):** adds an explicit top-level `real_validation_available: bool` to the `submit_governance` result on both the `octave_content` and prose (`intake_pipeline`) paths — `False` when the real validator didn't run — and logs at WARNING on degrade. No longer hideable in a warnings list.
- **Option C (opt-in fail-closed), default OFF:** flag `HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION`. When set, an unavailable real validator becomes a hard block (`success=False`, **no linker / no PR**) with a single-source structured error naming the missing extra + `pip install …[validation]` + the unset-flag escape hatch.
- **Flag mechanism:** `resolve_require_real_validation(working_dir)` resolves per-call from `working_dir/.env` in isolation via the existing `_read_caller_env_keys` (read-only parse, never `load_dotenv` → zero caller-secret ingress, PROD I2), precedence `working_dir/.env → process-env → default False` — mirrors the ratified `resolve_model` (#106). Per-repo, so a governance repo can demand strict AST validation independent of the launcher.
- **DIP:** the prose path reaches the resolver via a lazy-import wrapper, keeping `core/` free of module-level `adapters/` imports (enforced by a CI invariant test).

### Posture decision
Operator chose **loud + opt-in fail-closed, default OFF** — byte-stable by default (no forced dependency), and reversible to fail-closed-by-default later by flipping the flag default.

### Verification
- 91 targeted tests + 934 across affected areas (tools/core/adapters) green; ruff/mypy/black clean.
- Flag isolation verified: a caller `.env` secret does **not** enter `os.environ`. Fail-closed tests assert `run_linker` is **never called** when blocking. Byte-stability: shape-assertion keysets remain exact/closed (only the additive `real_validation_available` key). DIP invariant passes. The one full-suite failure is the pre-existing #66 `clock_in` AI-env flake (diff touches no `clock_in` code).
- **Review note:** HO performed the independent verification above; the sub-agent T3 panel (CE/CRS/TMG) is temporarily session-limited and will post role verdicts on reset. Human merge remains the semantic gate.

Refs: #108 (item 4). Ratified bases: #106 (per-repo env resolution / PROD I2), PROD I3 (octave-mcp port, never reinvented).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OCTAVE Gate B validation loud and adds an opt‑in fail‑closed mode across both submission paths. Also hardens `.env` parsing and offloads env-flag reads on both paths.

- **New Features**
  - Added `real_validation_available: bool` at the top level of all `submit_governance` and prose results; logs WARNING when Gate B degrades to regex‑only.
  - Opt-in fail-closed via `HESTAI_GOVERNANCE_REQUIRE_REAL_VALIDATION`. If set and the real validator is unavailable, we block before the linker with a structured error suggesting `pip install hestai-context-mcp[validation]`. Applied to both `octave_content` and prose paths, with the prose path resolving the flag via a lazy import and running it in an executor.

- **Bug Fixes**
  - `.env` parsing now strips unquoted inline comments after whitespace or tabs and preserves quoted `#` in both `resolve_model` and `resolve_require_real_validation`.
  - Flag resolution is offloaded to an executor on the prose path (in addition to `octave_content`) to avoid blocking the event loop.
  - Gate A short-circuits still report `real_validation_available` correctly even when real validation does not run.

<sup>Written for commit beb8d3fa2bc7a71aeeae6ef003bcf1cd4288c15c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

