### PR TITLE
feat(intake): fail-fast on context-window overflow + actionable truncation error (#108.1)

### DIFF
--- a/src/hestai_context_mcp/core/intake_compiler.py
+++ b/src/hestai_context_mcp/core/intake_compiler.py
@@ -17,6 +17,10 @@ Stage 3.
 Cost caps (operator-ratified, env-overridable):
     * ``HESTAI_INTAKE_MAX_OUTPUT_TOKENS`` — per-call output ceiling
       (default 8000). Passed as ``CompletionRequest.max_tokens``.
+    * ``HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS`` — pre-call fit ceiling for
+      ``estimated input + max_output_tokens`` (default 1048576). Aborts before
+      client construction when the request cannot fit the configured context
+      window.
     * ``HESTAI_INTAKE_MAX_COST_USD`` — abort *before* the call if the projected
       cost (input + max-output tokens, priced via
       ``HESTAI_INTAKE_USD_PER_1K_TOKENS``) exceeds this cap (default 0.50).
@@ -56,6 +60,7 @@ __all__ = [
 
 # Defaults for the operator-ratified cost caps. All env-overridable.
 _DEFAULT_MAX_OUTPUT_TOKENS = 8000
+_DEFAULT_CONTEXT_WINDOW_TOKENS = 1_048_576
 _DEFAULT_MAX_COST_USD = 0.50
 # Default blended price used only for the *pre-call* cost projection. Sized so
 # the default 8000-token ceiling stays comfortably under the $0.50 abort cap for
@@ -255,12 +260,28 @@ async def compile_prose_to_octave(
         if max_cost_usd is not None
         else _env_float("HESTAI_INTAKE_MAX_COST_USD", _DEFAULT_MAX_COST_USD)
     )
+    context_window_tokens = _env_int(
+        "HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS", _DEFAULT_CONTEXT_WINDOW_TOKENS
+    )
     price_per_1k = _env_float("HESTAI_INTAKE_USD_PER_1K_TOKENS", _DEFAULT_USD_PER_1K_TOKENS)
 
     model = _resolve_model_name(working_dir)
 
-    # --- Cost cap: project BEFORE the call; abort on breach (no truncation). ---
+    # --- Pre-call fit/cost guards: abort BEFORE client construction/billing. ---
+    estimated_input_tokens = _estimate_input_tokens(intake_context)
     projected_tokens = _project_tokens(intake_context, out_cap)
+    if projected_tokens > context_window_tokens:
+        return _failure(
+            model,
+            (
+                f"Projected request size {projected_tokens} tokens exceeds context window "
+                f"ceiling {context_window_tokens} (estimated input {estimated_input_tokens} "
+                f"+ max output {out_cap}). Aborted before backend call; no output produced."
+            ),
+            tokens=projected_tokens,
+            cost_is_estimate=False,
+        )
+
     projected_cost = (projected_tokens / 1000.0) * price_per_1k
     if projected_cost > cost_cap:
         return _failure(
@@ -312,7 +333,11 @@ async def compile_prose_to_octave(
             model,
             (
                 "AIClient truncation error (output hit the token cap; not retried): "
-                f"{exc}. Consumed {consumed} tokens."
+                f"{exc}. The provider consumed {consumed} tokens before truncation. "
+                "This was an output-cap failure, not user-input size. "
+                "Remediation: reduce record scope; context-assembly compression is tracked "
+                "in #111; and lower HESTAI_INTAKE_MAX_OUTPUT_TOKENS if the current max "
+                "output tokens budget is higher than needed."
             ),
             tokens=consumed,
             cost=billed_cost,

--- a/tests/unit/core/test_intake_compiler.py
+++ b/tests/unit/core/test_intake_compiler.py
@@ -395,6 +395,36 @@ class TestCostCaps:
         assert stub.entered is False
         assert stub.request is None
 
+    async def test_aborts_when_projected_tokens_exceed_context_window(
+        self, patch_client, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS", "1000")
+        stub = _StubClient(text="should never be returned")
+        patch_client(stub)
+
+        result = await compile_prose_to_octave(_ctx("x" * 3000), max_output_tokens=800)
+
+        assert result["ok"] is False
+        assert result["octave"] is None
+        assert "context window" in result["error"].lower()
+        assert "aborted before backend call" in result["error"].lower()
+        assert result["metrics"]["cost"] == pytest.approx(0.0)
+        assert stub.entered is False
+        assert stub.request is None
+
+    async def test_in_budget_request_still_proceeds_with_context_window_guard(
+        self, patch_client, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS", "5000")
+        stub = _StubClient(text="===DECISION_RECORD===\n===END===")
+        patch_client(stub)
+
+        result = await compile_prose_to_octave(_ctx("x" * 400), max_output_tokens=800)
+
+        assert result["ok"] is True
+        assert stub.entered is True
+        assert stub.request is not None
+
     async def test_env_override_for_output_cap(self, patch_client, monkeypatch) -> None:
         monkeypatch.setenv("HESTAI_INTAKE_MAX_OUTPUT_TOKENS", "256")
         stub = _StubClient(text="===DECISION_RECORD===\n===END===")
@@ -452,3 +482,26 @@ class TestMetricsAccounting:
             len(ctx.prompt) + len(ctx.prose_input) + _CHARS_PER_TOKEN - 1
         ) // _CHARS_PER_TOKEN
         assert _estimate_input_tokens(ctx) == expected
+
+
+class TestTruncationMessageContract:
+    async def test_truncation_error_message_is_actionable(self, patch_client, monkeypatch) -> None:
+        monkeypatch.setenv("HESTAI_INTAKE_MAX_COST_USD", "1000000")
+        consumed_tokens = 15523
+        stub = _StubClient(
+            raises=AIClientTruncationError(
+                "finish_reason='length'", consumed_tokens=consumed_tokens
+            )
+        )
+        patch_client(stub)
+
+        result = await compile_prose_to_octave(_ctx())
+
+        assert result["ok"] is False
+        assert result["error"] is not None
+        assert str(consumed_tokens) in result["error"]
+        assert "output hit the token cap" in result["error"].lower()
+        assert "not user-input size" in result["error"].lower()
+        assert "reduce record scope" in result["error"].lower()
+        assert "#111" in result["error"]
+        assert "max output tokens" in result["error"].lower()


### PR DESCRIPTION
## feat(intake): fail-fast on context-window overflow + actionable truncation error (#108.1)

Closes #108 item 1. Authoring an AGR via `prose_input` failed with **terminal, billed** truncation (provider hit the output-token cap → `AIClientTruncationError`, ~$0.08/attempt), and trimming user prose didn't help because consumption is dominated by Stage-1/2 **context assembly**. This adds the two failure-handling levers (per the HO decision: fail-fast + message only — corpus/output *prevention* is deferred to #111; no streaming/continuation/auto-retry/cap-raise).

### Changes (blast radius: `intake_compiler.py` + tests)
1. **Pre-call token-fit fail-fast.** New env-overridable ceiling `HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS` (default `1048576`). Before constructing the AI client / making any billed call, if `estimated_input_tokens + max_output_tokens > ceiling`, abort with the existing structured Stage-2 failure shape (`ok=False`, PROD-I4 error, **no billed call**). Rationale: when input + the full output budget can't fit the model's context window, the output cap can never be honored — so the request is structurally doomed; fail fast rather than pay to discover it.
2. **Actionable truncation message.** When `AIClientTruncationError` *is* caught (output genuinely hit the cap mid-generation — not predictable pre-call), the surfaced `validation_errors` message now includes the real consumed token count, states the **output** hit the cap (not user-input size), and gives remediation: reduce record scope; context-assembly compression is tracked in #111; the `HESTAI_INTAKE_MAX_OUTPUT_TOKENS` knob. No-re-issue behavior (#96) and real-token metrics (#98) unchanged.

### Transparency
The fail-fast guard will rarely fire on the currently-configured `google/gemini-3.5-flash` (1M context window = the chosen default), by design — it's a structural safety net for unusually large Stage-1 assemblies or operators who override the ceiling down for smaller-window models. The **message** is what handles the actual #108 output-truncation case; the *prevention* (shrinking the Stage-1/2 corpus) is #111.

### Verification
- RED→GREEN: context-window-overflow test (asserts no AI client / billed call) + truncation-message contract test, both RED pre-fix. Targeted intake/compiler/pipeline suites 40 passed; full suite 2007 passed (the only 2 failures are the pre-existing #66 `clock_in` AI-env flake — no `clock_in` code in this diff). ruff/mypy/black clean.
- Review gate (CE/CRS/TMG) recorded on the PR.

Refs: #108 (item 1). Prevention/compression follow-up: #111.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fail-fast context-window check to prevent billed calls when a request can’t fit, and make truncation errors actionable with real token usage and clear next steps. Addresses #108 item 1.

- **New Features**
  - Pre-call token-fit guard using `HESTAI_INTAKE_CONTEXT_WINDOW_TOKENS` (default 1,048,576). If estimated input + max output exceeds this ceiling, abort with a structured Stage-2 failure (no client construction, no cost).
  - Clearer truncation error on `AIClientTruncationError`: shows consumed token count, states the output hit the cap (not user input), and suggests reducing record scope, tracking compression in #111, and adjusting `HESTAI_INTAKE_MAX_OUTPUT_TOKENS`.

<sup>Written for commit 292e1e8463de00d69aabdc9a1af29768606ad1ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

