### PR TITLE
feat(intake): complete #111 compression contract — ∴ operator + verbose→bytecode few-shot

### DIFF
--- a/src/hestai_context_mcp/tools/governance/intake_context.py
+++ b/src/hestai_context_mcp/tools/governance/intake_context.py
@@ -171,11 +171,31 @@ _COMPRESSION_CONTRACT = (
     "- DROP stopwords, repetition, narrative connectives.\n"
     "- Reasoning fields (DECISION, BECAUSE, RATIONALE, WHY) MUST be telegraphic phrases, "
     "NOT multi-sentence prose paragraphs. Let operators carry the connectives: "
-    "⊕ (synthesis), ⇌ (tension), → (causality/flow), ∧ (and), ∨ (or).\n"
+    "→ (causality/flow), ⇌ (tension), ∴ (therefore), ⊕ (synthesis), ∧ (and), ∨ (or).\n"
     "- NEVER emit an enumerated mega-string ('(1)... (2)... (3)...') inside one value; "
     "split enumerated points into BLOCK-structured keyed children.\n"
     "- Declare loss accounting in META: COMPRESSION_TIER::CONSERVATIVE and a "
     'LOSS_PROFILE::"[preserve:...,drop:...]" — loss is explicit, never hidden.\n'
+    # Worked few-shot: verbose operator prose -> flat bytecode. The BEFORE pole is
+    # genuinely guard-FAILING (>40-word multi-sentence prose value) so "REJECTED"
+    # is literally true under the Gate-A ≤40-word guard; the AFTER lines are
+    # themselves guard-passing (single quoted flat string, no newline, ≤40 words,
+    # operators carrying the connectives, no nested keys). The example is a SHAPE
+    # demonstration only — never copy its content into the output.
+    "EXAMPLE (verbose prose → flat bytecode) — transform the value form, do NOT "
+    "copy this content:\n"
+    "  BEFORE (verbose, REJECTED — >40-word multi-sentence prose value, fails the "
+    "Gate-A ≤40-word guard):\n"
+    '    DECISION::"We have decided that the archive write path should always redact '
+    "credentials in a strictly fail-closed manner, which means that whenever the "
+    "redaction regex does not match the expected pattern we will drop the entire "
+    "record rather than take any risk of persisting a secret, because we believe that "
+    'losing data is far more acceptable than ever exposing a credential."\n'
+    "  AFTER (flat bytecode, ACCEPTED — telegraphic, operators carry connectives):\n"
+    '    DECISION::"Adopt fail-closed redaction on archive write → drop record on '
+    'regex miss ∴ data-loss preferred over credential exposure ⊕ zero secrets persist"\n'
+    '    BECAUSE::"Single leaked credential ⇌ security incident → unacceptable blast '
+    'radius ∴ fail closed ⊕ redaction runs before persistence not after"\n'
     "METADATA FIDELITY — never fabricate governance provenance:\n"
     "- STATUS reflects the ACTUAL lifecycle. A newly authored record defaults to "
     "STATUS::PROPOSED. NEVER assert STATUS::RATIFIED — ratification is the human PR "

--- a/tests/unit/tools/governance/test_intake_context.py
+++ b/tests/unit/tools/governance/test_intake_context.py
@@ -201,6 +201,101 @@ class TestCompressionContract:
         assert marker not in ctx.prompt
 
 
+class TestBytecodeFewShotAndOperators:
+    """#111 residual: the contract must (a) name the full ratified operator set
+    (→ ⇌ ∴ ⊕) and (b) carry a telegraphic verbose→bytecode worked example.
+
+    GAP-A: the ``∴`` (therefore) operator was missing from the contract's
+    operator list while the Gate-A guard's own remediation text already cites it
+    (type_checker.py) — a contract/guard inconsistency.
+    GAP-B: the issue asked for a worked BEFORE (verbose prose) → AFTER (flat
+    ≤40-word compressed-OCTAVE) one-shot; the contract described the rules but
+    shipped no example. Both poles are test-verified against the real Gate-A
+    guard: the BEFORE DECISION genuinely FAILS the ≤40-word guard (the "REJECTED"
+    label is literally true), and the AFTER DECISION/BECAUSE genuinely PASS.
+    """
+
+    def test_prompt_names_therefore_operator(self, tmp_path: Path) -> None:
+        # GAP-A: ∴ (therefore) joins the ratified operator set (→ ⇌ ∴ ⊕).
+        _seed_repo(tmp_path)
+        ctx = assemble_intake_context(tmp_path, "record a decision")
+        assert "∴" in ctx.prompt
+
+    def test_prompt_carries_verbose_to_bytecode_fewshot(self, tmp_path: Path) -> None:
+        # GAP-B: a stable, distinctive few-shot marker must be present so the
+        # model sees a worked verbose→bytecode transformation, not just rules.
+        _seed_repo(tmp_path)
+        ctx = assemble_intake_context(tmp_path, "record a decision")
+        # The example label (the JIT prompt is deterministic; this is a pure
+        # prompt-contains assertion, no AI call).
+        assert "EXAMPLE (verbose prose → flat bytecode)" in ctx.prompt
+        # And both poles of the worked transform are present.
+        assert "BEFORE" in ctx.prompt and "AFTER" in ctx.prompt
+
+    @staticmethod
+    def _pole_field_line(prompt: str, pole: str, field_name: str) -> str | None:
+        """Return the ``field_name::`` line from one few-shot pole's segment.
+
+        The prompt carries both poles; each ``DECISION::``/``BECAUSE::`` value is a
+        single physical line. We slice the prompt to the requested pole's segment
+        (BEFORE = between the BEFORE and AFTER labels; AFTER = from the AFTER label
+        on) so the BEFORE and AFTER demonstration lines are never confused. The
+        returned line is fed to the guard exactly as ``_extract_meta_fields``
+        (``^\\s*KEY::value$``) would parse it.
+        """
+        if pole == "BEFORE":
+            segment = prompt.split("BEFORE", 1)[1].split("AFTER", 1)[0]
+        else:
+            segment = prompt.split("AFTER", 1)[1]
+        return next(
+            (ln for ln in segment.splitlines() if ln.lstrip().startswith(f"{field_name}::")),
+            None,
+        )
+
+    def test_fewshot_after_lines_pass_the_gate_a_guard(self, tmp_path: Path) -> None:
+        # The few-shot we TEACH must itself pass the guard it teaches: extract the
+        # AFTER DECISION::/BECAUSE:: lines from the assembled prompt and run them
+        # through the real Gate-A reasoning-density guard. Pure, no AI call.
+        from hestai_context_mcp.tools.governance.type_checker import (
+            REASONING_FIELDS,
+            _check_reasoning_density,
+        )
+
+        _seed_repo(tmp_path)
+        ctx = assemble_intake_context(tmp_path, "record a decision")
+
+        for field_name in REASONING_FIELDS:
+            line = self._pole_field_line(ctx.prompt, "AFTER", field_name)
+            assert line is not None, f"few-shot AFTER must demonstrate a {field_name}:: line"
+            errors: list[str] = []
+            _check_reasoning_density(line, errors)
+            assert errors == [], f"taught AFTER {field_name} example violates Gate-A: {errors}"
+
+    def test_fewshot_before_decision_fails_the_gate_a_guard(self, tmp_path: Path) -> None:
+        # Both poles are now test-verified: the BEFORE DECISION value is genuinely
+        # GUARD-FAILING (>40-word multi-sentence prose), so the "REJECTED" label is
+        # literally true under the Gate-A ≤40-word guard — not merely a style claim.
+        # Pure, no AI call.
+        from hestai_context_mcp.tools.governance.type_checker import (
+            MAX_REASONING_WORDS,
+            _check_reasoning_density,
+        )
+
+        _seed_repo(tmp_path)
+        ctx = assemble_intake_context(tmp_path, "record a decision")
+
+        before_line = self._pole_field_line(ctx.prompt, "BEFORE", "DECISION")
+        assert before_line is not None, "few-shot BEFORE must demonstrate a DECISION:: line"
+        errors: list[str] = []
+        _check_reasoning_density(before_line, errors)
+        # The guard must reject the BEFORE pole, and specifically on word count so
+        # the REJECTED label maps to the ≤40-word rule the example teaches.
+        assert errors, "few-shot BEFORE DECISION must FAIL the Gate-A guard (REJECTED pole)"
+        assert any(
+            f"max {MAX_REASONING_WORDS}" in e for e in errors
+        ), f"BEFORE must fail on the ≤{MAX_REASONING_WORDS}-word rule; got: {errors}"
+
+
 class TestMetadataFidelityContract:
     """The prompt must forbid fabricating governance provenance.
 


### PR DESCRIPTION
## feat(intake): complete #111 compression contract — add ∴ operator + verbose→bytecode few-shot

Completes the residual scope of #111 (compress Semantic Compiler output to bytecode AGRs). The compression contract + the Gate-A ≤40w guard already shipped (earlier intake work + Wave A); triage found two literal gaps vs the issue, both confined to the Stage-1 `_COMPRESSION_CONTRACT` prompt constant:

- **GAP-A:** the operator set omitted `∴` — now `→ ⇌ ∴ ⊕ ∧ ∨`, matching the ratified bytecode format (`HO-AGR-BYTECODE-FORMAT-TWO-BIRDS-20260620`) and the Gate-A guard's own remediation text.
- **GAP-B:** no worked **verbose→bytecode few-shot**. Added a provider-agnostic BEFORE (verbose, REJECTED) → AFTER (flat ≤40w bytecode, ACCEPTED) example *inside* `_COMPRESSION_CONTRACT` (honouring the A9 no-baked-prompt-constant invariant).

This is the prevention side of the #108.1 truncation handling: a sharper compression directive + a worked example teaches the AI compiler to emit records that pass the Gate-A guard first-try, reducing both wall-of-text rejections and output-token pressure.

### Both poles are test-verified
- `test_fewshot_after_lines_pass_the_gate_a_guard` — the taught AFTER lines (DECISION 22w, BECAUSE 20w) feed through the real `_check_reasoning_density` → **0 errors** (the example we teach is itself compliant).
- `test_fewshot_before_decision_fails_the_gate_a_guard` — the BEFORE value (60w) → guard error on the `max 40` rule (so the "REJECTED" label is literally true, not just stylistic).
- Plus `∴`-present and few-shot-marker assertions. **All deterministic, no AI call** (per the #66 lesson — AI-dependent tests aren't CI-robust).

### Scope notes
- #76 (OCTAVE/AGR envelope rules in the JIT prompt) was the same surface and is already closed-completed — subsumed here, no separate work.
- The empirical "first-try Gate-A pass on representative inputs" measurement is a billed/manual eval, **deferred to RFC-53 T6** (no standalone harness — MIP).
- Review gate (CE/CRS/TMG) recorded on the PR.

Verification: 28 targeted tests (intake_context + source-invariants) pass; ruff/mypy/black clean. The only full-suite failure is the pre-existing #66 clock_in AI-env flake (no clock_in code in this diff). Refs: #111 (residual), #76 (subsumed/closed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes #111 by adding the missing `∴` operator and an inline verbose→bytecode few-shot to `_COMPRESSION_CONTRACT`, so intake emits ≤40-word, guard-compliant bytecode on first pass.

- New Features
  - Added `∴` (therefore) to the compression operator set (`→ ⇌ ∴ ⊕ ∧ ∨`) to match the ratified bytecode format.
  - Embedded a provider-agnostic BEFORE→AFTER example in `_COMPRESSION_CONTRACT` showing verbose prose transformed into flat bytecode for DECISION/BECAUSE (single-line, quoted, ≤40 words; operators carry connectives). Verified with deterministic tests that AFTER passes and BEFORE fails the Gate-A guard.

<sup>Written for commit c6a3e7342c6244901735bd03074b3a8c98e8c2f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

