### PR TITLE
fix(review-gate): accept APPROVE/APPROVES as synonyms of APPROVED

### DIFF
--- a/.github/workflows/review-gate-caller.yml.template
+++ b/.github/workflows/review-gate-caller.yml.template
@@ -20,7 +20,10 @@ jobs:
   check-review:
     # Only invoke for PR events, or PR comments containing review verdicts.
     # Filters out irrelevant comments (discussion, bot noise) that can't change gate outcome.
-    # Keywords match review_formats.py: APPROVED, REVIEWED (covers SELF-REVIEWED), GO.
+    # Keywords match review_formats.py: APPROVE, REVIEWED (covers SELF-REVIEWED), GO.
+    # 'APPROVE' subsumes the APPROVED/APPROVES family (any body containing APPROVED or
+    # APPROVES also contains the substring APPROVE), mirroring the now-tolerant verdict
+    # matcher in review_formats.py so an APPROVE-only verdict table still triggers the gate.
     # Also matches markdown-bold variants (**APPROVED**, **GO**) since review_formats.py
     # strips bold markers before pattern matching.
     # IMPORTANT: Exclude bot comments to prevent self-triggering — the gate's own status
@@ -29,7 +32,7 @@ jobs:
       github.event_name == 'pull_request'
       || (github.event.issue.pull_request
           && github.event.comment.user.type != 'Bot'
-          && (contains(github.event.comment.body, 'APPROVED')
+          && (contains(github.event.comment.body, 'APPROVE')
               || contains(github.event.comment.body, 'REVIEWED')
               || contains(github.event.comment.body, ' GO')
               || contains(github.event.comment.body, ' GO:')

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -30,7 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on PR events, workflow_call, or PR comments containing review verdicts.
     # Filters out irrelevant comments (discussion, bot noise) that can't change gate outcome.
-    # Keywords match review_formats.py: APPROVED, REVIEWED (covers SELF-REVIEWED), GO.
+    # Keywords match review_formats.py: APPROVE, REVIEWED (covers SELF-REVIEWED), GO.
+    # 'APPROVE' subsumes the APPROVED/APPROVES family (any body containing APPROVED or
+    # APPROVES also contains the substring APPROVE), mirroring the now-tolerant verdict
+    # matcher in review_formats.py so an APPROVE-only verdict table still triggers the gate.
     # Also matches markdown-bold variants (**APPROVED**, **GO**) since review_formats.py
     # strips bold markers before pattern matching.
     # IMPORTANT: Exclude bot comments to prevent self-triggering — the gate's own ❌ status
@@ -41,7 +44,7 @@ jobs:
       || github.event_name == 'pull_request_review'
       || (github.event.issue.pull_request
           && github.event.comment.user.type != 'Bot'
-          && (contains(github.event.comment.body, 'APPROVED')
+          && (contains(github.event.comment.body, 'APPROVE')
               || contains(github.event.comment.body, 'REVIEWED')
               || contains(github.event.comment.body, ' GO')
               || contains(github.event.comment.body, ' GO:')

--- a/src/hestai_context_mcp/tools/shared/review_formats.py
+++ b/src/hestai_context_mcp/tools/shared/review_formats.py
@@ -70,7 +70,16 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
     # Valid positions: actual start of line (with optional whitespace) or
     # after a markdown table pipe character.
     prefix_re = re.compile(rf"(?:^|(?<=\|))\s*{re.escape(prefix)}\b", re.MULTILINE | re.IGNORECASE)
-    keyword_re = re.compile(rf"\b{re.escape(keyword)}\b", re.IGNORECASE)
+    # Verdict-synonym tolerance: treat the canonical APPROVED keyword as the
+    # conjugation family APPROVE(D|S)? so a table cell reading "APPROVE" or
+    # "APPROVES" clears the gate exactly as "APPROVED" does (regression:
+    # elevana-studio PR #1257 verdict-summary table). Word boundaries are
+    # preserved (\bAPPROVE(?:D|S)?\b), so "APPROVEMENT" still does NOT match,
+    # and only the APPROVED family is widened — GO/REVIEWED/SELF-REVIEWED
+    # callers pass other keywords and are unaffected. The deliberately-strict
+    # anti-spoof path has_crs_model_approval() is intentionally NOT widened.
+    keyword_pattern = r"APPROVE(?:D|S)?" if keyword == "APPROVED" else re.escape(keyword)
+    keyword_re = re.compile(rf"\b{keyword_pattern}\b", re.IGNORECASE)
     # Strip markdown heading markers (##, ###, etc.) per-line so agents that
     # write '## TMG APPROVED ✅' are accepted alongside the canonical format.
     heading_re = re.compile(r"^\s*#{1,6}\s*")

--- a/src/hestai_context_mcp/tools/shared/review_formats.py
+++ b/src/hestai_context_mcp/tools/shared/review_formats.py
@@ -29,6 +29,34 @@ _IL_APPROVED_KEYWORD = "SELF-REVIEWED"
 # --- HO uses REVIEWED keyword instead of APPROVED ---
 _HO_APPROVED_KEYWORD = "REVIEWED"
 
+# --- Negation / hedge guard (trust-model defect fix) ---
+# A role-anchored verdict only clears the gate when the span BETWEEN the role
+# prefix and the verdict verb is free of negation/conditional intent. Without
+# this guard the matcher accepted idiomatic NON-approvals -- e.g.
+# "CRS does not approve" or "CRS: I would approve if the tests passed" -- so a
+# blocking reviewer's own words wrongly cleared the gate (fail-open inversion).
+#
+# The guard inspects ONLY the gap between the role prefix and the verdict verb,
+# so benign trailing assessment text ("APPROVED: would have blocked if ...") is
+# unaffected, and the legitimate model-in-its-own-pipe-cell table formats
+# ("| CRS | Gemini | **APPROVED** |") still clear because a model name / tick /
+# pipe is not a negation token.
+#
+# NOTE: a denylist is inherently incomplete -- it cannot catch every phrasing of
+# refusal. It is chosen deliberately for its correctness/complexity trade-off:
+# it removes the verified false-clears while preserving every legitimate format.
+# The deliberately-strict anti-spoof path has_crs_model_approval() does NOT use
+# this matcher and is intentionally unchanged.
+_NEGATION_HEDGE_RE = re.compile(
+    r"\b(?:"
+    r"not|n't|cannot|can't|won't|wouldn't|shouldn't|couldn't|don't|doesn't|didn't|"
+    r"will\s+not|do\s+not|does\s+not|did\s+not|"
+    r"never|unable|unless|until|pending|blocked|reject|fail|"
+    r"if|would|should"
+    r")\b",
+    re.IGNORECASE,
+)
+
 
 def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
     """Check if text matches a flexible approval pattern.
@@ -89,9 +117,16 @@ def matches_approval_pattern(text: str, prefix: str, keyword: str) -> bool:
         prefix_match = prefix_re.search(stripped)
         if not prefix_match:
             continue
-        # Keyword must appear after the prefix on the same line
-        keyword_match = keyword_re.search(stripped, prefix_match.end())
-        if keyword_match:
+        # Keyword must appear after the prefix on the same line. Scan EVERY
+        # occurrence: a line clears only if some verdict verb has a gap (between
+        # the role prefix and that verb) free of negation/hedge intent. This
+        # rejects role-anchored non-approvals ("CRS does not approve") while
+        # preserving model-in-its-own-cell table formats and benign assessment
+        # text that follows the verdict.
+        for keyword_match in keyword_re.finditer(stripped, prefix_match.end()):
+            gap = stripped[prefix_match.end() : keyword_match.start()]
+            if _NEGATION_HEDGE_RE.search(gap):
+                continue
             return True
 
     return False

--- a/tests/unit/tools/shared/__init__.py
+++ b/tests/unit/tools/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for shared tool utilities."""

--- a/tests/unit/tools/shared/test_review_formats.py
+++ b/tests/unit/tools/shared/test_review_formats.py
@@ -151,3 +151,113 @@ class TestVerdictSynonymTolerance:
         assert not has_crs_model_approval(["CRS (Gemini) APPROVE: looks good"], "Gemini")
         # Canonical APPROVED still clears the model path.
         assert has_crs_model_approval(["CRS (Gemini) APPROVED: looks good"], "Gemini")
+
+
+@pytest.mark.unit
+class TestRoleAnchoredNegationGuard:
+    """Role-anchored NEGATED / conditional verdicts must NOT clear the gate.
+
+    Trust-model defect (PR #129): the matcher locates the role prefix
+    (line-start or after a ``|``) and then accepts the verdict verb ANYWHERE
+    later on the same line. Idiomatic NON-approvals therefore wrongly cleared
+    the gate -- a blocking reviewer's own words satisfied it. The fix rejects a
+    line when a negation/hedge token sits between the role prefix and the
+    verdict verb, WITHOUT breaking the legitimate model-in-its-own-cell table
+    formats (where only a benign model name / tick / pipes sit between).
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "CRS will not approve this",
+            "CRS cannot approve until tests pass",
+            "CRS does not approve",
+            "| CRS | Gemini | does not approve |",
+            "CRS: I would approve if the tests passed",
+        ],
+    )
+    def test_negated_or_conditional_crs_verdict_does_not_clear(self, line: str) -> None:
+        """A role-anchored negated/conditional verdict must NOT clear the gate."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert not has_crs_approval([line])
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "CRS will not approve this",
+            "CRS cannot approve until tests pass",
+            "CRS does not approve",
+            "| CRS | Gemini | does not approve |",
+            "CRS: I would approve if the tests passed",
+        ],
+    )
+    def test_negated_or_conditional_via_pattern_does_not_match(self, line: str) -> None:
+        """matches_approval_pattern rejects the same role-anchored non-approvals."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert not matches_approval_pattern(line, "CRS", "APPROVED")
+
+    @pytest.mark.parametrize(
+        "checker_name",
+        [
+            "has_crs_approval",
+            "has_ce_approval",
+            "has_tmg_approval",
+            "has_civ_approval",
+            "has_pe_approval",
+            "has_sr_approval",
+            "has_gr_approval",
+        ],
+    )
+    def test_negated_verdict_rejected_for_all_roles(self, checker_name: str) -> None:
+        """'<ROLE> does not approve' must NOT clear the gate for any role."""
+        import hestai_context_mcp.tools.shared.review_formats as rf
+
+        checker = getattr(rf, checker_name)
+        prefix = "GR" if checker_name == "has_gr_approval" else checker_name.split("_")[1].upper()
+        assert not checker([f"{prefix} does not approve"])
+
+    # --- Positive acceptance set: legitimate formats MUST still clear ---
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "CRS APPROVED: looks good",
+            "CRS APPROVE: looks good",
+            "CRS APPROVES: looks good",
+            "CRS (Gemini) APPROVED",
+            "CRS (Gemini): APPROVED",
+            "| **CRS** (code-review-specialist) | Gemini | ✅ APPROVE | notes |",
+            "| CRS | Gemini | **APPROVED** |",
+        ],
+    )
+    def test_legitimate_crs_formats_still_clear(self, line: str) -> None:
+        """The negation guard must not break any legitimate CRS approval format."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval([line])
+
+    def test_markdown_heading_approval_still_clears(self) -> None:
+        """'## TMG APPROVED ✅' heading form must still clear after the guard."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern("## TMG APPROVED ✅", "TMG", "APPROVED")
+
+    def test_model_in_own_column_table_preserved(self) -> None:
+        """Model-in-its-own-pipe-cell table format is not a negation and clears."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern("| CRS | Gemini | **APPROVED** |", "CRS", "APPROVED")
+
+    def test_benign_assessment_after_verdict_still_clears(self) -> None:
+        """A hedge word AFTER the verdict (in the assessment) must not block it.
+
+        The guard only inspects the gap BETWEEN the role prefix and the verdict
+        verb; words like 'if'/'would' in the trailing assessment are benign.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern(
+            "CRS APPROVED: would have blocked if tests failed, but they pass", "CRS", "APPROVED"
+        )

--- a/tests/unit/tools/shared/test_review_formats.py
+++ b/tests/unit/tools/shared/test_review_formats.py
@@ -1,0 +1,153 @@
+"""Regression tests for review-gate verdict-synonym tolerance.
+
+TDD RED phase: these tests are written BEFORE the matcher widening and
+must FAIL against the canonical ``\\bAPPROVED\\b`` matcher.
+
+Regression target — elevana-studio PR #1257 (TIER_3_CRITICAL, reviewers
+[CE, CIV, CRS, TMG]): an agent posted a verdict summary table with cells
+reading "✅ APPROVE" (no trailing D) for CRS/CIV/TMG and "✅ GO" for CE.
+GO cleared (already accepted); APPROVE failed the canonical matcher,
+forcing a manual re-post. The table STRUCTURE already parsed
+(matches_approval_pattern strips bold/headings and anchors role prefixes
+after a "|" pipe); only the verb conjugation broke.
+
+Contract pinned here: APPROVE and APPROVES are accepted as synonyms of
+APPROVED wherever APPROVED is, for all approval roles, WITHOUT weakening
+anchoring (role prefix at line-start or immediately after a pipe) or word
+boundaries. The deliberately-strict anti-spoof path has_crs_model_approval
+is intentionally excluded and stays APPROVED|GO only.
+"""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestVerdictSynonymTolerance:
+    """APPROVE / APPROVES accepted as synonyms of APPROVED (read-side)."""
+
+    # The #1257 verdict summary table (reconstructed structure).
+    _PR_1257_TABLE = (
+        "## Review Summary\n"
+        "\n"
+        "| Role | Reviewer | Verdict | Notes |\n"
+        "| --- | --- | --- | --- |\n"
+        "| **CRS** (code-review-specialist) | Gemini | ✅ APPROVE | clean diff |\n"
+        "| **CIV** (critical-implementation-validator) | Codex | ✅ APPROVE | spec ok |\n"
+        "| **TMG** (test-methodology-guardian) | Goose | ✅ APPROVE | tests sound |\n"
+        "| **CE** (critical-engineer) | Claude | ✅ GO | ship it |\n"
+    )
+
+    def test_pr_1257_table_approve_clears_crs(self) -> None:
+        """CRS '✅ APPROVE' table cell clears the gate (regression #1257)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert has_crs_approval([self._PR_1257_TABLE])
+
+    def test_pr_1257_table_approve_clears_civ(self) -> None:
+        """CIV '✅ APPROVE' table cell clears the gate (regression #1257)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_civ_approval
+
+        assert has_civ_approval([self._PR_1257_TABLE])
+
+    def test_pr_1257_table_approve_clears_tmg(self) -> None:
+        """TMG '✅ APPROVE' table cell clears the gate (regression #1257)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_tmg_approval
+
+        assert has_tmg_approval([self._PR_1257_TABLE])
+
+    def test_pr_1257_table_go_still_clears_ce(self) -> None:
+        """CE '✅ GO' table cell still clears the gate (unchanged)."""
+        from hestai_context_mcp.tools.shared.review_formats import has_ce_approval
+
+        assert has_ce_approval([self._PR_1257_TABLE])
+
+    def test_approve_synonym_matches_via_pattern(self) -> None:
+        """matches_approval_pattern accepts APPROVE when keyword is APPROVED."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern("CRS APPROVE: looks good", "CRS", "APPROVED")
+
+    def test_approves_synonym_matches_via_pattern(self) -> None:
+        """matches_approval_pattern accepts APPROVES when keyword is APPROVED."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern("CRS APPROVES this change", "CRS", "APPROVED")
+
+    def test_approved_still_matches(self) -> None:
+        """Canonical APPROVED still matches after the synonym widening."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert matches_approval_pattern("CRS APPROVED: ok", "CRS", "APPROVED")
+
+    @pytest.mark.parametrize(
+        "checker_name",
+        [
+            "has_crs_approval",
+            "has_ce_approval",
+            "has_tmg_approval",
+            "has_civ_approval",
+            "has_pe_approval",
+            "has_sr_approval",
+            "has_gr_approval",
+        ],
+    )
+    def test_approve_accepted_for_all_roles(self, checker_name: str) -> None:
+        """APPROVE clears the gate for every approval role (incl. legacy GR)."""
+        import hestai_context_mcp.tools.shared.review_formats as rf
+
+        checker = getattr(rf, checker_name)
+        prefix = "GR" if checker_name == "has_gr_approval" else checker_name.split("_")[1].upper()
+        assert checker([f"{prefix} APPROVE: looks good"])
+
+    @pytest.mark.parametrize(
+        "checker_name",
+        [
+            "has_crs_approval",
+            "has_ce_approval",
+            "has_tmg_approval",
+            "has_civ_approval",
+            "has_pe_approval",
+            "has_sr_approval",
+            "has_gr_approval",
+        ],
+    )
+    def test_approves_accepted_for_all_roles(self, checker_name: str) -> None:
+        """APPROVES clears the gate for every approval role (incl. legacy GR)."""
+        import hestai_context_mcp.tools.shared.review_formats as rf
+
+        checker = getattr(rf, checker_name)
+        prefix = "GR" if checker_name == "has_gr_approval" else checker_name.split("_")[1].upper()
+        assert checker([f"{prefix} APPROVES this change"])
+
+    def test_unanchored_prose_approve_does_not_match(self) -> None:
+        """Prose 'I would approve this change.' must NOT satisfy CRS approval.
+
+        No anchored role prefix precedes the verb, so the gate must not clear.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert not has_crs_approval(["I would approve this change."])
+
+    def test_bare_approve_no_role_does_not_match(self) -> None:
+        """A bare 'approve' with no anchored role prefix is not an approval."""
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_approval
+
+        assert not has_crs_approval(["approve"])
+
+    def test_approve_keyword_does_not_overmatch_longer_word(self) -> None:
+        """Word boundaries hold: 'APPROVEMENT' must not satisfy the matcher."""
+        from hestai_context_mcp.tools.shared.review_formats import matches_approval_pattern
+
+        assert not matches_approval_pattern("CRS APPROVEMENT pending", "CRS", "APPROVED")
+
+    def test_model_approval_path_unchanged_rejects_bare_approve(self) -> None:
+        """has_crs_model_approval stays strict: bare APPROVE (no D) does NOT clear.
+
+        The anti-spoof model-tag path is deliberately excluded from the synonym
+        widening; only APPROVED|GO satisfy it.
+        """
+        from hestai_context_mcp.tools.shared.review_formats import has_crs_model_approval
+
+        assert not has_crs_model_approval(["CRS (Gemini) APPROVE: looks good"], "Gemini")
+        # Canonical APPROVED still clears the model path.
+        assert has_crs_model_approval(["CRS (Gemini) APPROVED: looks good"], "Gemini")


### PR DESCRIPTION
## Summary

The review-gate verdict matchers only matched the canonical `\bAPPROVED\b` keyword. A markdown verdict-summary **table cell reading `✅ APPROVE`** (no trailing D) failed the gate, while `✅ GO` cleared it. This PR makes `APPROVE` and `APPROVES` accepted synonyms of `APPROVED` wherever `APPROVED` is, for all approval roles — without weakening anchoring or spoof resistance. `GO` is unchanged.

## Diagnosis (root cause — not re-litigated here)

Real incident: **elevana-studio PR #1257** (TIER_3_CRITICAL, reviewers [CE, CIV, CRS, TMG]). An agent posted a verdict summary table with cells `✅ APPROVE` for CRS/CIV/TMG and `✅ GO` for CE. CE cleared (GO matched); CRS/CIV/TMG were rejected on the missing `D`, forcing the operator to manually re-post `CRS APPROVED / CIV APPROVED / TMG APPROVED`.

The table **structure already parsed** — `matches_approval_pattern()` strips bold/headings and anchors role prefixes at line-start or immediately after a `|` pipe. The only thing that broke was the **verb conjugation**: `APPROVE` ≠ `\bAPPROVED\b`.

## The fix (minimal, localized)

In `src/hestai_context_mcp/tools/shared/review_formats.py`, `matches_approval_pattern()` now treats the canonical `APPROVED` keyword as the regex family `APPROVE(?:D|S)?`, localized so `GO`/`REVIEWED`/`SELF-REVIEWED` callers are unaffected (they pass other keywords). This file is the **single source of truth** — `scripts/validate_review.py` imports its matchers — so one change fixes both the CI gate and the `submit_review` tool.

## Anchoring & spoof resistance preserved

- Role prefix must still be at line-start **or** immediately after a `|` pipe.
- Word boundaries kept: `\bAPPROVE(?:D|S)?\b`, so `APPROVEMENT` does **not** match (no over-match; and `\bAPPROVE\b` cannot match inside `APPROVED`, so no double-count).
- Bold/heading stripping unchanged.
- Unanchored prose (`I would approve this change`) still does **NOT** match.
- The deliberately-strict anti-spoof path `has_crs_model_approval()` (model-tag adjacency) is **intentionally NOT widened** — it stays `APPROVED|GO` only, with a one-line comment noting the exclusion.

## Governance context

Governed by decision **HO-REVIEW-GATE-PLACEMENT-TRANSITION-20260620** (PROPOSED), which inherits the two P0 trust-model issues tracked in **#116**. Per that constraint the change is kept **minimal — a verdict-synonym tolerance only**; parsing is not broadened further.

## Tests (TDD: RED → GREEN)

New regression suite `tests/unit/tools/shared/test_review_formats.py` reproduces the #1257 table and pins the contract:
- RED first: positive synonym assertions failed against `\bAPPROVED\b` (19 failing), confirmed before the fix.
- `✅ APPROVE` table cells now clear CRS/CIV/TMG; `✅ GO` still clears CE.
- `APPROVE`/`APPROVES` accepted for all roles (CRS, CE, TMG, CIV, PE, SR, legacy GR).
- Negative: unanchored prose and bare `approve` do NOT match; `APPROVEMENT` does NOT match; `has_crs_model_approval` still rejects bare `APPROVE`.

## Verification

- `pytest` targeted (test_review_formats × 2, test_validate_review_pr_reviews, test_validate_review): **228 passed**.
- `mypy src`: **0 errors**. `ruff check src tests`: **All checks passed**. `black --check`: clean.
- Full suite: 1998 passed; the only 2 failures are `test_clock_in.py::TestClockInReturnShape::test_ai_synthesis_always_present_as_structured_dict` (pass in isolation) — pre-existing env-coupled flakiness tracked as **issue #66** (`clock_in AI-synthesis tests fail when a real AI client is env-configured`), unrelated to this change.

> Not self-merged — awaiting independent CRS + CE review per review-gate policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts APPROVE/APPROVES as synonyms of APPROVED and adds a negation/hedge guard so role-anchored non-approvals don’t clear the review gate. CI triggers now watch for APPROVE; anchoring, spoof resistance, and GO behavior are unchanged.

- **Bug Fixes**
  - Treat APPROVED as `APPROVE(?:D|S)?` in `matches_approval_pattern()` for all approval roles.
  - Add a same-line guard that rejects verdicts when a negation/conditional token sits between the role prefix and the verdict verb (e.g., “CRS does not approve”, “CRS would approve if …”); scans all occurrences on the line.
  - Preserve role-prefix anchoring (line start or after `|`) and word boundaries; tables/headings still match; `has_crs_model_approval()` stays strict (APPROVED/GO only).
  - Update workflow comment filters to `APPROVE` in `.github/workflows/review-gate.yml` and `.github/workflows/review-gate-caller.yml.template`; add regression tests in `tests/unit/tools/shared/test_review_formats.py`.

<sup>Written for commit 02c3107bb19bad2392bfa855cc6a049753706276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

