### PR TITLE
feat(governance): two-birds write_adr — verbatim ADR + HUMAN_ADR_REF-linked AGR (#112)

### DIFF
--- a/src/hestai_context_mcp/core/intake_pipeline.py
+++ b/src/hestai_context_mcp/core/intake_pipeline.py
@@ -41,7 +41,7 @@ from hestai_context_mcp.ports.octave_validator import (
     get_octave_validator,
 )
 from hestai_context_mcp.tools.governance.intake_context import IntakeContext
-from hestai_context_mcp.tools.governance.linker import run_linker
+from hestai_context_mcp.tools.governance.linker import _stamp_human_adr_ref, run_linker
 from hestai_context_mcp.tools.governance.type_checker import (
     ValidationResult,
     validate_octave_content,
@@ -283,6 +283,7 @@ async def run_intake_to_pr(
     dry_run: bool = False,
     max_output_tokens: int | None = None,
     max_cost_usd: float | None = None,
+    write_adr: bool = False,
 ) -> dict[str, Any]:
     """Stage 3 + Stage 4: validate prose->OCTAVE, then open a PR via the linker.
 
@@ -291,6 +292,15 @@ async def run_intake_to_pr(
     (Stage 4: branch->write->commit->PR). On abort, returns the structured
     failure and NEVER calls the linker — re-asserting hallucination immunity at
     the integration seam.
+
+    Two-birds (#112): when ``write_adr`` is True, after Stage 3 succeeds (the
+    TOKEN is now known) the engine DETERMINISTICALLY stamps
+    ``HUMAN_ADR_REF::<token>`` into the AGR's META block, RE-VALIDATES that the
+    stamped AGR still passes Gate A (token-form #11 — no fs resolution), and
+    passes both the stamped OCTAVE and the VERBATIM ``intake_context.prose_input``
+    to the linker, which dumb-writes ``docs/adr/<token>.md`` alongside the AGR in
+    ONE branch/commit/PR. The stamp is NOT trusted to the AI (it is engine-side,
+    post-validation) so the link is deterministic.
 
     Human Primacy (PROD::I3): ``run_linker`` only opens a PR; it never merges and
     never commits to main. No new git code is introduced here — the blocking
@@ -333,13 +343,50 @@ async def run_intake_to_pr(
         if require_real_validation:
             return _fail_closed_result(pipeline, dry_run)
 
+    # --- Two-birds (#112): deterministic HUMAN_ADR_REF stamp + ADR prose ---
+    # The validated OCTAVE and TOKEN are known here. When write_adr is set we
+    # stamp the AGR with HUMAN_ADR_REF::<token> (engine-side, NOT AI-echoed) and
+    # RE-VALIDATE that the stamped record still passes Gate A before the linker
+    # writes it — so a stamp can never smuggle an invalid record to disk. The
+    # verbatim prose becomes the ADR doc the linker dumb-writes alongside.
+    octave_to_link = pipeline["octave"]
+    adr_prose: str | None = None
+    if write_adr:
+        token = pipeline["validation"].token or ""
+        stamped = _stamp_human_adr_ref(octave_to_link, token)
+        restamped_validation = validate_octave_content(working_dir, stamped)
+        if not restamped_validation.valid:
+            # The stamp broke Gate A (should be impossible for token-form #11):
+            # abort BEFORE the linker — no write, no PR. Hallucination immunity.
+            return {
+                "success": False,
+                "token": token,
+                "card_type": pipeline["validation"].card_type,
+                "target_path": None,
+                "adr_target_path": None,
+                "branch": None,
+                "pr_url": None,
+                "validation_errors": [
+                    "HUMAN_ADR_REF stamp failed Gate-A re-validation: "
+                    + "; ".join(restamped_validation.errors)
+                ],
+                "octave_validation": None,
+                "real_validation_available": real_validation_available,
+                "octave": stamped,
+                "metrics": pipeline["metrics"],
+                "dry_run": dry_run,
+            }
+        octave_to_link = stamped
+        adr_prose = intake_context.prose_input
+
     loop = asyncio.get_running_loop()
     linker_fn = partial(
         run_linker,
         working_dir=working_dir,
         validation=pipeline["validation"],
-        octave_content=pipeline["octave"],
+        octave_content=octave_to_link,
         dry_run=dry_run,
+        adr_prose=adr_prose,
     )
     linker_output = await loop.run_in_executor(None, linker_fn)
 
@@ -349,6 +396,7 @@ async def run_intake_to_pr(
         "token": linker_output.get("token"),
         "card_type": linker_output.get("card_type"),
         "target_path": linker_output.get("target_path"),
+        "adr_target_path": linker_output.get("adr_target_path"),
         "branch": linker_output.get("branch"),
         "pr_url": linker_output.get("pr_url"),
         "validation_errors": [linker_error] if linker_error else [],
@@ -356,7 +404,9 @@ async def run_intake_to_pr(
         "real_validation_available": real_validation_available,
         # Surface the authored OCTAVE so the Stage-5 reviewer can read the exact
         # record that was PR'd (issue #77). Additive; ``None`` on the abort path.
-        "octave": pipeline["octave"],
+        # When write_adr stamped the record, this is the STAMPED OCTAVE actually
+        # written (so the reviewer reads exactly what was PR'd).
+        "octave": octave_to_link,
         "metrics": pipeline["metrics"],
         "dry_run": dry_run,
     }

--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -205,24 +205,74 @@ def _write_file(target_path: Path, content: str) -> str | None:
         return f"Failed to write {target_path}: {exc}"
 
 
+# ---------------------------------------------------------------------------
+# Two-birds: ADR doc placement + deterministic HUMAN_ADR_REF stamp (#112)
+# ---------------------------------------------------------------------------
+
+
+def _compute_adr_path(working_dir: Path, token: str) -> Path:
+    """Compute the verbatim-ADR doc path for a token: docs/adr/<TOKEN>.md.
+
+    The doc is named by the AGR's OWN ``token`` so the greppable
+    ``HUMAN_ADR_REF::<token>`` in the AGR points straight at it (self-token
+    linkage, #112). ``token`` is ``_TOKEN_FORMAT_RE``-validated upstream (no
+    ``/`` and no ``.``), so the join cannot introduce a path separator; the
+    caller still applies the path-traversal guard as defence-in-depth.
+    """
+    return working_dir / "docs" / "adr" / f"{token}.md"
+
+
+def _stamp_human_adr_ref(octave_content: str, token: str) -> str:
+    """Return ``octave_content`` with a ``HUMAN_ADR_REF::"<token>"`` META line.
+
+    Deterministic, engine-side stamp (#112): inserted as a SINGLE flat META line
+    immediately after the ``META:`` header so it never touches the DECISION /
+    BECAUSE bytecode (the ≤40-word reasoning-density guard is unaffected). The
+    value is the record's OWN token (token-form #11 — cross-repo survivable, no
+    filesystem resolution at Gate A).
+
+    Idempotent: if a ``HUMAN_ADR_REF::`` line is already present the content is
+    returned unchanged (no second line, no duplication).
+    """
+    if "HUMAN_ADR_REF::" in octave_content:
+        return octave_content
+
+    lines = octave_content.splitlines(keepends=True)
+    stamp_line = f'  HUMAN_ADR_REF::"{token}"\n'
+    for idx, line in enumerate(lines):
+        if line.strip() == "META:":
+            lines.insert(idx + 1, stamp_line)
+            return "".join(lines)
+    # No META: header found (malformed record) — return unchanged rather than
+    # corrupt the document; Gate-A re-validation downstream will surface it.
+    return octave_content
+
+
 def _git_add_and_commit(
     working_dir: Path,
     file_path: Path,
     manifest_path: Path,
     commit_message: str,
+    extra_paths: list[Path] | None = None,
 ) -> str | None:
-    """Stage the governance file + MANIFEST and commit.
+    """Stage the governance file (+ any ``extra_paths``) + MANIFEST and commit.
+
+    ``extra_paths`` (#112) carries the two-birds ADR doc so the AGR and its
+    verbatim ADR land in ONE commit. Each extra path is staged BEFORE the commit;
+    a failed ``git add`` on any of them aborts with a structured error (no commit
+    with a missing file).
 
     Returns an error string on failure, None on success.
     """
-    # Stage the governance file
-    try:
-        rel = file_path.relative_to(working_dir)
-    except ValueError:
-        rel = file_path
-    code, _, stderr = _run_git(["add", str(rel)], working_dir)
-    if code != 0:
-        return f"git add failed for {rel}: {stderr}"
+    # Stage the governance file (and any companion files, e.g. the ADR doc).
+    for path in [file_path, *(extra_paths or [])]:
+        try:
+            rel = path.relative_to(working_dir)
+        except ValueError:
+            rel = path
+        code, _, stderr = _run_git(["add", str(rel)], working_dir)
+        if code != 0:
+            return f"git add failed for {rel}: {stderr}"
 
     # Stage MANIFEST if it was written
     if manifest_path.exists():
@@ -305,19 +355,27 @@ def run_linker(
     validation: ValidationResult,
     octave_content: str,
     dry_run: bool,
+    adr_prose: str | None = None,
 ) -> dict[str, Any]:
     """Execute the Git Orchestrator for a validated governance artifact.
 
     Args:
         working_dir: Project root directory.
         validation: Successful ValidationResult from type_checker.
-        octave_content: Raw OCTAVE document text to commit.
+        octave_content: Raw OCTAVE document text to commit. When ``adr_prose`` is
+            supplied this is expected to ALREADY carry the deterministic
+            ``HUMAN_ADR_REF::<token>`` stamp (the caller stamps + re-validates).
         dry_run: If True, skip all git/file operations and return
                  what WOULD happen without touching disk or git.
+        adr_prose: Two-birds (#112). When non-None, the VERBATIM prose is
+            dumb-written to ``docs/adr/<token>.md`` (no AI, no OCTAVE, no marker)
+            and committed ALONGSIDE the AGR in the SAME branch/commit/PR. When
+            None the behaviour is byte-stable AGR-only.
 
     Returns:
-        Dict with keys: token, card_type, target_path, branch,
-        pr_url, error, dry_run.
+        Dict with keys: token, card_type, target_path, branch, pr_url, error,
+        dry_run, staged_uncommitted, and ``adr_target_path`` (the
+        ``docs/adr/<token>.md`` path when ``adr_prose`` is supplied, else None).
     """
     token = validation.token or ""
     card_type = validation.card_type or ""
@@ -329,11 +387,16 @@ def run_linker(
     except ValueError:
         target_path_str = str(target_path) if target_path else None
 
+    # Two-birds ADR doc path (relative form for the structured return).
+    adr_target_path = _compute_adr_path(working_dir, token) if adr_prose is not None else None
+    adr_target_path_str = str(adr_target_path.relative_to(working_dir)) if adr_target_path else None
+
     if dry_run:
         return {
             "token": token,
             "card_type": card_type,
             "target_path": target_path_str,
+            "adr_target_path": adr_target_path_str,
             "branch": branch_name,
             "pr_url": None,
             "error": None,
@@ -355,6 +418,7 @@ def run_linker(
             "token": token,
             "card_type": card_type,
             "target_path": target_path_str,
+            "adr_target_path": adr_target_path_str,
             "branch": None,
             "pr_url": None,
             "error": preflight_err,
@@ -370,6 +434,7 @@ def run_linker(
             "token": token,
             "card_type": card_type,
             "target_path": target_path_str,
+            "adr_target_path": adr_target_path_str,
             "branch": branch_name,
             "pr_url": None,
             "error": err,
@@ -385,6 +450,7 @@ def run_linker(
             "token": token,
             "card_type": card_type,
             "target_path": None,
+            "adr_target_path": adr_target_path_str,
             "branch": branch_name,
             "pr_url": None,
             "error": "target_path is None -- cannot write file",
@@ -392,30 +458,44 @@ def run_linker(
             "dry_run": False,
         }
 
-    # Bug 4: path traversal guard -- verify target_path is inside working_dir
-    try:
-        target_path.resolve().relative_to(working_dir.resolve())
-    except (ValueError, RuntimeError, OSError):
-        # Branch WAS created (surfaced via ``branch``) but the write was rejected
-        # before any ``git add``, so nothing is staged-uncommitted (contract:
-        # False); the branch-exists recovery is conveyed by ``branch`` + ``error``.
-        return {
-            "token": token,
-            "card_type": card_type,
-            "target_path": target_path_str,
-            "branch": branch_name,
-            "pr_url": None,
-            "error": (
-                f"target_path {target_path} is outside working_dir {working_dir} "
-                "-- path traversal rejected"
-            ),
-            "staged_uncommitted": False,
-            "dry_run": False,
-        }
+    # Bug 4: path traversal guard -- verify target_path is inside working_dir.
+    # #112: the SAME guard is applied to the two-birds ADR path so a crafted
+    # token/symlink cannot escape the repo. Both paths are checked here, BEFORE
+    # any write, so a rejection writes/stages nothing.
+    guard_paths = [target_path, *([adr_target_path] if adr_target_path is not None else [])]
+    for guarded in guard_paths:
+        try:
+            guarded.resolve().relative_to(working_dir.resolve())
+        except (ValueError, RuntimeError, OSError):
+            # Branch WAS created (surfaced via ``branch``) but the write was
+            # rejected before any ``git add``, so nothing is staged-uncommitted
+            # (contract: False); recovery is conveyed by ``branch`` + ``error``.
+            return {
+                "token": token,
+                "card_type": card_type,
+                "target_path": target_path_str,
+                "adr_target_path": adr_target_path_str,
+                "branch": branch_name,
+                "pr_url": None,
+                "error": (
+                    f"target_path {guarded} is outside working_dir {working_dir} "
+                    "-- path traversal rejected"
+                ),
+                "staged_uncommitted": False,
+                "dry_run": False,
+            }
 
     err = _write_file(target_path, octave_content)
     if err:
         errors.append(err)
+
+    # 2b. Two-birds (#112): dumb-write the VERBATIM ADR prose alongside the AGR.
+    #     No AI, no OCTAVE, no provenance marker. Guarded above; written only
+    #     when the AGR write succeeded so we never leave an orphan ADR doc.
+    if not errors and adr_prose is not None and adr_target_path is not None:
+        err = _write_file(adr_target_path, adr_prose)
+        if err:
+            errors.append(err)
 
     # 3. Update MANIFEST (best-effort -- failure is non-fatal, Bug 9 fix)
     if not errors:
@@ -437,7 +517,10 @@ def run_linker(
     # staged), is NOT staged-uncommitted.
     commit_failed = False
     if not errors:
-        err = _git_add_and_commit(working_dir, target_path, manifest_path, commit_message)
+        extra_paths = [adr_target_path] if adr_target_path is not None else None
+        err = _git_add_and_commit(
+            working_dir, target_path, manifest_path, commit_message, extra_paths=extra_paths
+        )
         if err:
             errors.append(err)
             commit_failed = True
@@ -473,6 +556,7 @@ def run_linker(
         "token": token,
         "card_type": card_type,
         "target_path": target_path_str,
+        "adr_target_path": adr_target_path_str,
         "branch": branch_name,
         "pr_url": pr_url,
         "error": error_str,

--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -231,14 +231,23 @@ def _stamp_human_adr_ref(octave_content: str, token: str) -> str:
     value is the record's OWN token (token-form #11 — cross-repo survivable, no
     filesystem resolution at Gate A).
 
-    Idempotent: if a ``HUMAN_ADR_REF::`` line is already present the content is
-    returned unchanged (no second line, no duplication).
+    Idempotent: if a ``HUMAN_ADR_REF::`` line is already present, its value is
+    overwritten to the correct token (preserving exactly one line). If absent,
+    it is inserted immediately after the ``META:`` header.
     """
-    if "HUMAN_ADR_REF::" in octave_content:
-        return octave_content
-
     lines = octave_content.splitlines(keepends=True)
     stamp_line = f'  HUMAN_ADR_REF::"{token}"\n'
+
+    found_idx = -1
+    for idx, line in enumerate(lines):
+        if "HUMAN_ADR_REF::" in line:
+            found_idx = idx
+            break
+
+    if found_idx != -1:
+        lines[found_idx] = stamp_line
+        return "".join(lines)
+
     for idx, line in enumerate(lines):
         if line.strip() == "META:":
             lines.insert(idx + 1, stamp_line)

--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -238,20 +238,26 @@ def _stamp_human_adr_ref(octave_content: str, token: str) -> str:
     lines = octave_content.splitlines(keepends=True)
     stamp_line = f'  HUMAN_ADR_REF::"{token}"\n'
 
-    found_idx = -1
-    for idx, line in enumerate(lines):
-        if "HUMAN_ADR_REF::" in line:
-            found_idx = idx
-            break
+    matching_indices = [
+        idx for idx, line in enumerate(lines) if line.lstrip().startswith("HUMAN_ADR_REF::")
+    ]
 
-    if found_idx != -1:
-        lines[found_idx] = stamp_line
+    if len(matching_indices) > 1:
+        for idx in reversed(matching_indices):
+            lines.pop(idx)
+        for idx, line in enumerate(lines):
+            if line.strip() == "META:":
+                lines.insert(idx + 1, stamp_line)
+                return "".join(lines)
+    elif len(matching_indices) == 1:
+        lines[matching_indices[0]] = stamp_line
         return "".join(lines)
+    else:
+        for idx, line in enumerate(lines):
+            if line.strip() == "META:":
+                lines.insert(idx + 1, stamp_line)
+                return "".join(lines)
 
-    for idx, line in enumerate(lines):
-        if line.strip() == "META:":
-            lines.insert(idx + 1, stamp_line)
-            return "".join(lines)
     # No META: header found (malformed record) — return unchanged rather than
     # corrupt the document; Gate-A re-validation downstream will surface it.
     return octave_content

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -186,10 +186,19 @@ async def submit_governance(
     prose_input: str | None = None,
     dry_run: bool = False,
     review: bool = True,
+    write_adr: bool = False,
 ) -> dict[str, Any]:
     """Submit a governance artifact via OCTAVE content OR prose intent.
 
     EXACTLY ONE of ``octave_content`` / ``prose_input`` must be non-None.
+
+    ``write_adr`` (two-birds, #112) is PROSE-ONLY. When True (with
+    ``prose_input``) the natural-language prose IS the ADR source: the linker
+    dumb-writes the VERBATIM prose to ``docs/adr/<token>.md`` and the condensed
+    AGR carries a deterministically-stamped ``HUMAN_ADR_REF::<token>`` — depth +
+    condensed AGR in ONE call, ONE PR. ``write_adr`` with ``octave_content`` (or
+    no ``prose_input``) is a structured error: there is no natural prose to dump,
+    so ``octave_content`` stays AGR-only. Default False = AGR-only, byte-stable.
 
     ``octave_content`` mode (Gate A/B): regex sentinel check + real
     OctaveValidator + path placement + PR creation. Byte-stable vs post-#70 main.
@@ -237,8 +246,22 @@ async def submit_governance(
             ],
         )
 
+    # --- write_adr is PROSE-ONLY (#112) ---
+    # Exactly-one is satisfied here; prose_input is None ⇒ octave_content mode,
+    # which has no natural prose to dump verbatim into an ADR doc. Reject loudly
+    # rather than silently ignore the flag.
+    if write_adr and prose_input is None:
+        return _empty_result(
+            dry_run,
+            [
+                "ADR+AGR (write_adr=True) requires prose_input; octave_content is "
+                "AGR-only. Re-submit the decision as prose_input to author both the "
+                "verbatim ADR doc and the condensed AGR in one call."
+            ],
+        )
+
     if prose_input is not None:
-        return await _submit_prose_input(working_dir, prose_input, dry_run, review)
+        return await _submit_prose_input(working_dir, prose_input, dry_run, review, write_adr)
 
     # The EXACTLY-ONE-OF guard above guarantees octave_content is non-None here.
     assert octave_content is not None
@@ -278,6 +301,7 @@ async def _submit_prose_input(
     prose_input: str,
     dry_run: bool,
     review: bool,
+    write_adr: bool = False,
 ) -> dict[str, Any]:
     """Gate C prose mode: Stage 1 assemble -> Stage 2+3+4 via run_intake_to_pr.
 
@@ -286,6 +310,9 @@ async def _submit_prose_input(
     which rejoins the same validate->link tail as the octave_content path. On a
     successful real PR, Stage 5 reviews the GENERATED OCTAVE threaded out of
     ``run_intake_to_pr`` (issue #77).
+
+    ``write_adr`` (#112) is forwarded to ``run_intake_to_pr`` so the two-birds
+    path dumb-writes the verbatim ADR doc + stamps the AGR's HUMAN_ADR_REF.
     """
     loop = asyncio.get_running_loop()
     try:
@@ -294,7 +321,7 @@ async def _submit_prose_input(
         return _empty_result(dry_run, [str(exc)])
 
     intake_context = await loop.run_in_executor(None, assemble_intake_context, wd, prose_input)
-    result = await run_intake_to_pr(wd, intake_context, dry_run=dry_run)
+    result = await run_intake_to_pr(wd, intake_context, dry_run=dry_run, write_adr=write_adr)
     return await _maybe_review(result, result.get("octave"), dry_run, review, working_dir=str(wd))
 
 

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -429,6 +429,7 @@ async def _submit_octave_content(
         "token": linker_output.get("token"),
         "card_type": linker_output.get("card_type"),
         "target_path": linker_output.get("target_path"),
+        "adr_target_path": linker_output.get("adr_target_path"),
         "branch": linker_output.get("branch"),
         "pr_url": linker_output.get("pr_url"),
         "validation_errors": errors,

--- a/src/hestai_context_mcp/tools/submit_governance.py
+++ b/src/hestai_context_mcp/tools/submit_governance.py
@@ -66,6 +66,7 @@ def _empty_result(
     octave_validation: dict[str, Any] | None = None,
     *,
     real_validation_available: bool = True,
+    adr_target_path: str | None = None,
 ) -> dict[str, Any]:
     """Return the I4-conformant failure shape with all fields present.
 
@@ -79,6 +80,7 @@ def _empty_result(
         "token": None,
         "card_type": None,
         "target_path": None,
+        "adr_target_path": adr_target_path,
         "branch": None,
         "pr_url": None,
         "validation_errors": errors,

--- a/tests/unit/core/test_intake_linker_wiring.py
+++ b/tests/unit/core/test_intake_linker_wiring.py
@@ -226,6 +226,65 @@ class TestRealValidationSignalAndFailClosed:
         assert len(spy_linker.calls) == 1
 
 
+class TestTwoBirdsStampRevalidationAbort:
+    """#112 hallucination immunity: if the deterministic HUMAN_ADR_REF stamp ever
+
+    makes the AGR FAIL Gate-A re-validation, ``run_intake_to_pr`` MUST abort
+    BEFORE the linker -- no write, no PR, no ADR doc. CRS/CIV verified this at
+    runtime; this pins the production abort branch against regression.
+
+    The test drives the REAL ``run_intake_to_pr`` abort branch (only the seams
+    around it are stubbed): the pipeline returns a clean success, but the
+    post-stamp ``validate_octave_content`` is forced to return an invalid
+    result, and the linker is monkeypatched to RAISE so any call is a hard
+    failure. RED-if-bypassed: were the abort removed, control would reach the
+    raising linker and the test would error instead of asserting the structured
+    abort.
+    """
+
+    async def test_stamp_revalidation_failure_aborts_before_linker(
+        self, tmp_path: Path, stub_pipeline, monkeypatch
+    ) -> None:
+        # Linker MUST NOT be reached: make any invocation an explicit failure.
+        def _boom_linker(**kwargs: Any) -> dict[str, Any]:
+            raise AssertionError(
+                "run_linker was called despite a failed stamp re-validation "
+                "(hallucination-immunity abort bypassed)"
+            )
+
+        monkeypatch.setattr(mod, "run_linker", _boom_linker, raising=True)
+
+        # Force the POST-STAMP Gate-A re-validation to FAIL. stub_pipeline has
+        # already replaced run_intake_pipeline, so this is the ONLY call to
+        # validate_octave_content on this path -- the stamped-record check.
+        def _invalid_revalidation(working_dir: Path, content: str) -> ValidationResult:
+            return ValidationResult(
+                valid=False,
+                errors=["forced stamp re-validation failure (test)"],
+                token=RECORD_TOKEN,
+                card_type="DECISION_RECORD",
+                target_path=None,
+            )
+
+        monkeypatch.setattr(mod, "validate_octave_content", _invalid_revalidation, raising=True)
+
+        stub_pipeline(_pipeline_ok())
+        result = await run_intake_to_pr(tmp_path, _ctx(), dry_run=False, write_adr=True)
+
+        # Structured abort (PROD I4), not a raise, not a silent write.
+        assert result["success"] is False
+        # The error names the stamp re-validation failure.
+        joined = " ".join(result["validation_errors"]).lower()
+        assert "human_adr_ref" in joined and "re-validation" in joined
+        # No ADR doc target, no branch, no PR.
+        assert result["adr_target_path"] is None
+        assert result["branch"] is None
+        assert result["pr_url"] is None
+        # Nothing written to disk on either surface.
+        assert not (tmp_path / "docs" / "adr").exists()
+        assert not (tmp_path / ".hestai" / "decisions").exists()
+
+
 class TestHumanPrimacy:
     def test_linker_argv_has_no_auto_merge(self) -> None:
         # Structural Human-Primacy guard: the reused linker opens a PR and never

--- a/tests/unit/tools/governance/test_linker_two_birds.py
+++ b/tests/unit/tools/governance/test_linker_two_birds.py
@@ -102,6 +102,59 @@ class TestStampHumanAdrRef:
         assert once == twice
         assert twice.count("HUMAN_ADR_REF::") == 1
 
+    def test_stamp_replaces_stale_human_adr_ref(self) -> None:
+        stale_octave = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_TOKEN}"\n'
+            '  HUMAN_ADR_REF::"HO-WRONG-STALE-VALUE-20200101"\n'
+            "  STATUS::PROPOSED\n"
+            "  TIER::OPERATIONAL\n"
+            '  DECISION::"Adopt fail-closed redaction on archive write."\n'
+            '  BECAUSE::"Single leaked credential ⇌ security incident → fail closed."\n'
+            '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+            "===END===\n"
+        )
+        stamped = _stamp_human_adr_ref(stale_octave, _TOKEN)
+        assert f'HUMAN_ADR_REF::"{_TOKEN}"' in stamped
+        assert "HO-WRONG-STALE-VALUE-20200101" not in stamped
+        assert stamped.count("HUMAN_ADR_REF::") == 1
+        assert '  DECISION::"Adopt fail-closed redaction on archive write."' in stamped
+
+    def test_stamp_correct_present_is_unchanged(self) -> None:
+        correct_octave = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_TOKEN}"\n'
+            f'  HUMAN_ADR_REF::"{_TOKEN}"\n'
+            "  STATUS::PROPOSED\n"
+            "  TIER::OPERATIONAL\n"
+            '  DECISION::"Adopt fail-closed redaction on archive write."\n'
+            '  BECAUSE::"Single leaked credential ⇌ security incident → fail closed."\n'
+            '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+            "===END===\n"
+        )
+        stamped = _stamp_human_adr_ref(correct_octave, _TOKEN)
+        assert stamped == correct_octave
+
+    def test_stamp_none_present_inserted_after_meta(self) -> None:
+        stamped = _stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN)
+        lines = stamped.splitlines()
+        meta_idx = -1
+        ref_idx = -1
+        for idx, line in enumerate(lines):
+            if "META:" in line:
+                meta_idx = idx
+            if "HUMAN_ADR_REF::" in line:
+                ref_idx = idx
+        assert meta_idx != -1
+        assert ref_idx != -1
+        assert ref_idx == meta_idx + 1
+
     def test_stamped_agr_still_passes_gate_a(self, tmp_path: Path) -> None:
         # RED #4: the stamped AGR (token-form HUMAN_ADR_REF) still passes Gate A.
         stamped = _stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN)

--- a/tests/unit/tools/governance/test_linker_two_birds.py
+++ b/tests/unit/tools/governance/test_linker_two_birds.py
@@ -1,0 +1,213 @@
+"""Linker-level tests for the two-birds ADR write surface (#112).
+
+When ``adr_prose`` is supplied, ``run_linker`` must:
+  * dumb-write the VERBATIM prose to ``docs/adr/<TOKEN>.md`` (no AI, no OCTAVE,
+    no provenance marker -- pure verbatim),
+  * write the AGR to ``.hestai/decisions/<TOKEN>.oct.md`` as before,
+  * stage BOTH in ONE branch/commit/PR,
+  * apply the SAME path-traversal guard to the ADR path as the AGR path,
+  * on dry_run, report the WOULD-write ADR path and write nothing.
+
+These are deterministic, no AI call. A real (hooks-disabled) git repo is used so
+the live commit path is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hestai_context_mcp.tools.governance.linker import _stamp_human_adr_ref, run_linker
+from hestai_context_mcp.tools.governance.type_checker import (
+    ValidationResult,
+    validate_octave_content,
+)
+
+_TOKEN = "HO-CONTEXT-MCP-TWOBIRDS-20260601"
+_ADR_PROSE = (
+    "# Decision: adopt fail-closed redaction\n\n"
+    "We considered three options ... and chose fail-closed because a single "
+    "leaked credential is a security incident. This is the full ADR narrative, "
+    "verbatim, with multiple sentences and newlines that an AGR would compress.\n"
+)
+
+_AGR_OCTAVE = (
+    "===DECISION_RECORD===\n"
+    "META:\n"
+    "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
+    f'  TOKEN::"{_TOKEN}"\n'
+    "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
+    '  DECISION::"Adopt fail-closed redaction on archive write."\n'
+    '  BECAUSE::"Single leaked credential ⇌ security incident → fail closed."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+    "===END===\n"
+)
+
+
+def _init_isolated_git_repo(repo: Path) -> None:
+    """Initialise a temp git repo isolated from the developer's global config."""
+    subprocess.run(["git", "init"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(repo / ".git" / "no-hooks")],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    (repo / "README.md").write_text("test")
+    subprocess.run(["git", "add", "."], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=str(repo), check=True, capture_output=True
+    )
+
+
+def _validation(target: Path) -> ValidationResult:
+    return ValidationResult(
+        valid=True,
+        errors=[],
+        token=_TOKEN,
+        card_type="DECISION_RECORD",
+        target_path=target,
+    )
+
+
+class TestStampHumanAdrRef:
+    def test_stamp_inserts_single_meta_line(self) -> None:
+        # RED #8: the stamp is a single META line; it must not touch DECISION/
+        # BECAUSE or otherwise break the bytecode form.
+        stamped = _stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN)
+        assert f'HUMAN_ADR_REF::"{_TOKEN}"' in stamped
+        # Exactly one HUMAN_ADR_REF line.
+        assert stamped.count("HUMAN_ADR_REF::") == 1
+        # The reasoning fields are untouched.
+        assert '  DECISION::"Adopt fail-closed redaction on archive write."' in stamped
+        assert "  BECAUSE::" in stamped
+
+    def test_stamp_is_idempotent(self) -> None:
+        once = _stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN)
+        twice = _stamp_human_adr_ref(once, _TOKEN)
+        assert once == twice
+        assert twice.count("HUMAN_ADR_REF::") == 1
+
+    def test_stamped_agr_still_passes_gate_a(self, tmp_path: Path) -> None:
+        # RED #4: the stamped AGR (token-form HUMAN_ADR_REF) still passes Gate A.
+        stamped = _stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN)
+        result = validate_octave_content(tmp_path, stamped)
+        assert result.valid, result.errors
+        # And the reasoning-density guard is unaffected (bytecode intact).
+        assert not any("words (max" in e for e in result.errors)
+
+
+class TestLinkerDualWrite:
+    def test_adr_prose_writes_verbatim_doc(self, tmp_path: Path) -> None:
+        # RED #2: docs/adr/<TOKEN>.md written byte-exact to the prose.
+        _init_isolated_git_repo(tmp_path)
+        target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
+        run_linker(
+            working_dir=tmp_path,
+            validation=_validation(target),
+            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+            dry_run=False,
+            adr_prose=_ADR_PROSE,
+        )
+        adr_path = tmp_path / "docs" / "adr" / f"{_TOKEN}.md"
+        assert adr_path.is_file()
+        # VERBATIM: byte-exact, no AI/OCTAVE/marker mutation.
+        assert adr_path.read_text(encoding="utf-8") == _ADR_PROSE
+
+    def test_both_files_staged_in_one_commit(self, tmp_path: Path) -> None:
+        # RED #3: AGR + ADR land in the SAME commit on one branch.
+        _init_isolated_git_repo(tmp_path)
+        target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
+        output = run_linker(
+            working_dir=tmp_path,
+            validation=_validation(target),
+            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+            dry_run=False,
+            adr_prose=_ADR_PROSE,
+        )
+        # Branch created; no orphan-state error from the write/commit steps.
+        assert output["branch"]
+        # HEAD commit contains BOTH files.
+        files = subprocess.run(
+            ["git", "show", "--name-only", "--pretty=format:", "HEAD"],
+            cwd=str(tmp_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert f".hestai/decisions/{_TOKEN}.oct.md" in files
+        assert f"docs/adr/{_TOKEN}.md" in files
+
+    def test_no_adr_prose_writes_no_doc(self, tmp_path: Path) -> None:
+        # RED #1: absent adr_prose -> no docs/adr write (back-compat).
+        _init_isolated_git_repo(tmp_path)
+        target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
+        run_linker(
+            working_dir=tmp_path,
+            validation=_validation(target),
+            octave_content=_AGR_OCTAVE,
+            dry_run=False,
+        )
+        assert not (tmp_path / "docs" / "adr").exists()
+
+
+class TestLinkerAdrTraversalGuard:
+    def test_adr_path_traversal_rejected(self, tmp_path: Path) -> None:
+        # RED #5: an ADR path escaping working_dir is rejected; nothing written.
+        # We force the escape by making working_dir a SUBDIR while the AGR target
+        # and the computed docs/adr path are derived from it; the guard must use
+        # resolve().relative_to(working_dir.resolve()). Here we assert the guard
+        # exists by pointing the AGR target inside but tampering the token cannot
+        # (token is format-validated), so we exercise the guard via a working_dir
+        # that does not contain the resolved docs/adr path.
+        _init_isolated_git_repo(tmp_path)
+        inner = tmp_path / "inner"
+        inner.mkdir()
+        _init_isolated_git_repo(inner)
+        # AGR target is inside `inner`; but we pass a docs root that resolves
+        # outside by symlinking docs to the parent (path-escape simulation).
+        evil_docs = tmp_path / "evil"
+        evil_docs.mkdir()
+        (inner / "docs").symlink_to(evil_docs)
+        target = inner / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
+        output = run_linker(
+            working_dir=inner,
+            validation=_validation(target),
+            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+            dry_run=False,
+            adr_prose=_ADR_PROSE,
+        )
+        assert output["error"] is not None
+        assert "outside" in output["error"].lower() or "traversal" in output["error"].lower()
+        # The evil ADR file must NOT have been written.
+        assert not (evil_docs / "adr" / f"{_TOKEN}.md").exists()
+
+
+class TestLinkerDryRunReportsAdr:
+    def test_dry_run_reports_would_write_adr_and_writes_nothing(self, tmp_path: Path) -> None:
+        # RED #6: dry_run + adr_prose -> report the WOULD-write ADR path, no write.
+        target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
+        output = run_linker(
+            working_dir=tmp_path,
+            validation=_validation(target),
+            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+            dry_run=True,
+            adr_prose=_ADR_PROSE,
+        )
+        assert output["dry_run"] is True
+        assert output.get("adr_target_path") == f"docs/adr/{_TOKEN}.md"
+        assert not (tmp_path / "docs" / "adr" / f"{_TOKEN}.md").exists()

--- a/tests/unit/tools/governance/test_linker_two_birds.py
+++ b/tests/unit/tools/governance/test_linker_two_birds.py
@@ -163,6 +163,55 @@ class TestStampHumanAdrRef:
         # And the reasoning-density guard is unaffected (bytecode intact).
         assert not any("words (max" in e for e in result.errors)
 
+    def test_stamp_preserves_decision_containing_substring(self) -> None:
+        # (a) BYTECODE-PRESERVE (the bug): an AGR whose DECISION value contains the literal HUMAN_ADR_REF::
+        octave_with_substring = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_TOKEN}"\n'
+            "  STATUS::PROPOSED\n"
+            "  TIER::OPERATIONAL\n"
+            '  DECISION::"adopt the engine-side HUMAN_ADR_REF:: stamp ∴ deterministic link"\n'
+            '  BECAUSE::"Single leaked credential ⇌ security incident → fail closed."\n'
+            '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+            "===END===\n"
+        )
+        stamped = _stamp_human_adr_ref(octave_with_substring, _TOKEN)
+        # Verify the DECISION line is completely unchanged
+        assert (
+            '  DECISION::"adopt the engine-side HUMAN_ADR_REF:: stamp ∴ deterministic link"\n'
+            in stamped
+        )
+        # Verify a separate correct HUMAN_ADR_REF META line is present (after META:)
+        assert f'  HUMAN_ADR_REF::"{_TOKEN}"\n' in stamped
+        assert stamped.count("HUMAN_ADR_REF::") == 2
+
+    def test_stamp_collapses_multiple_pre_existing_refs(self) -> None:
+        # (b) MULTI-LINE: an AGR with TWO pre-existing HUMAN_ADR_REF lines
+        octave_with_multi = (
+            "===DECISION_RECORD===\n"
+            "META:\n"
+            "  TYPE::DECISION_RECORD\n"
+            '  VERSION::"1.0"\n'
+            f'  TOKEN::"{_TOKEN}"\n'
+            '  HUMAN_ADR_REF::"HO-WRONG-STALE-ONE-20260601"\n'
+            "  STATUS::PROPOSED\n"
+            '  HUMAN_ADR_REF::"HO-WRONG-STALE-TWO-20260601"\n'
+            "  TIER::OPERATIONAL\n"
+            '  DECISION::"Adopt fail-closed redaction on archive write."\n'
+            '  BECAUSE::"Single leaked credential ⇌ security incident → fail closed."\n'
+            '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+            "===END===\n"
+        )
+        stamped = _stamp_human_adr_ref(octave_with_multi, _TOKEN)
+        # Verify exactly one HUMAN_ADR_REF line remains and has the correct token
+        assert f'  HUMAN_ADR_REF::"{_TOKEN}"\n' in stamped
+        assert "HO-WRONG-STALE-ONE-20260601" not in stamped
+        assert "HO-WRONG-STALE-TWO-20260601" not in stamped
+        assert stamped.count("HUMAN_ADR_REF::") == 1
+
 
 class TestLinkerDualWrite:
     def test_adr_prose_writes_verbatim_doc(self, tmp_path: Path) -> None:

--- a/tests/unit/tools/test_submit_governance_octave_validator.py
+++ b/tests/unit/tools/test_submit_governance_octave_validator.py
@@ -370,7 +370,8 @@ class TestPublicContractUnchanged:
         params = inspect.signature(submit_governance).parameters
         # Gate C (T5) adds prose_input back-compatibly: octave_content becomes
         # optional and prose_input is the second mode. Issue #77 adds the
-        # ``review`` flag back-compatibly (defaults True). The pre-existing
+        # ``review`` flag back-compatibly (defaults True). Issue #112 adds the
+        # ``write_adr`` flag back-compatibly (defaults False). The pre-existing
         # params remain so octave_content callers are unaffected.
         assert set(params) == {
             "working_dir",
@@ -378,6 +379,7 @@ class TestPublicContractUnchanged:
             "prose_input",
             "dry_run",
             "review",
+            "write_adr",
         }
         # Back-compat: octave_content is now optional (defaults to None) so the
         # EXACTLY-ONE-OF guard can distinguish the two modes.
@@ -385,3 +387,6 @@ class TestPublicContractUnchanged:
         assert params["prose_input"].default is None
         # Issue #77: review defaults True (Stage 5 active on real PRs by default).
         assert params["review"].default is True
+        # Issue #112: write_adr defaults False (two-birds OFF) -> AGR-only callers
+        # are byte-stable; the flag is purely additive.
+        assert params["write_adr"].default is False

--- a/tests/unit/tools/test_submit_governance_prose.py
+++ b/tests/unit/tools/test_submit_governance_prose.py
@@ -159,6 +159,7 @@ class TestOctaveContentBackCompat:
         "token",
         "card_type",
         "target_path",
+        "adr_target_path",
         "branch",
         "pr_url",
         "validation_errors",

--- a/tests/unit/tools/test_submit_governance_semantic_review.py
+++ b/tests/unit/tools/test_submit_governance_semantic_review.py
@@ -210,6 +210,7 @@ class TestOctaveContentStage5:
             "token",
             "card_type",
             "target_path",
+            "adr_target_path",
             "branch",
             "pr_url",
             "validation_errors",

--- a/tests/unit/tools/test_submit_governance_two_birds.py
+++ b/tests/unit/tools/test_submit_governance_two_birds.py
@@ -109,6 +109,20 @@ class TestWriteAdrIsProseOnly:
         assert result["success"] is False
         assert result["validation_errors"]
 
+    def test_error_path_includes_adr_target_path_none(self, tmp_path: Path) -> None:
+        # F2 (P2) error-path return includes adr_target_path is None
+        result = asyncio.run(
+            submit_governance(
+                working_dir=str(tmp_path),
+                octave_content=_VALID_OCTAVE,
+                write_adr=True,
+                dry_run=True,
+            )
+        )
+        assert result["success"] is False
+        assert "adr_target_path" in result
+        assert result["adr_target_path"] is None
+
 
 class TestWriteAdrForwarding:
     def test_write_adr_true_forwarded_to_intake(self, tmp_path: Path, stub_intake) -> None:

--- a/tests/unit/tools/test_submit_governance_two_birds.py
+++ b/tests/unit/tools/test_submit_governance_two_birds.py
@@ -1,0 +1,142 @@
+"""Tests for the two-birds ``write_adr`` mode of submit_governance (#112).
+
+ONE-INPUT design (operator-finalized): the agent's natural-language
+``prose_input`` IS the ADR source. ``write_adr`` is a bool flag:
+
+    submit_governance(working_dir, ..., prose_input=..., write_adr=True)
+
+  * ``write_adr=False`` (default) -> AGR-only, current behaviour, byte-stable.
+  * ``write_adr=True`` (prose mode) -> the linker ALSO dumb-writes the verbatim
+    ``prose_input`` to ``docs/adr/<TOKEN>.md`` and the condensed AGR carries a
+    deterministically-stamped ``HUMAN_ADR_REF::<TOKEN>`` (token-form #11).
+
+``write_adr=True`` is PROSE-ONLY: with ``octave_content`` (or with no
+``prose_input``) there is no natural prose to dump, so the tool returns a
+structured error.
+
+CI-safe: the prose intake composition (``run_intake_to_pr``) is stubbed exactly
+as in ``test_submit_governance_prose.py`` -- NO AI call, fully deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import hestai_context_mcp.tools.submit_governance as sg
+from hestai_context_mcp.tools.submit_governance import submit_governance
+
+_TOKEN = "HO-CONTEXT-MCP-TWOBIRDS-20260601"
+
+_VALID_OCTAVE = (
+    "===DECISION_RECORD===\n"
+    "META:\n"
+    "  TYPE::DECISION_RECORD\n"
+    '  VERSION::"1.0"\n'
+    f'  TOKEN::"{_TOKEN}"\n'
+    "  STATUS::PROPOSED\n"
+    "  TIER::OPERATIONAL\n"
+    '  DECISION::"Two-birds decision."\n'
+    '  BECAUSE::"Gate C end-to-end."\n'
+    '  AUTHORED_AT::"2026-06-01T00:00:00Z"\n'
+    "===END===\n"
+)
+
+
+@pytest.fixture
+def stub_intake(monkeypatch: pytest.MonkeyPatch):
+    """Patch the Stage 1+2+3+4 composition reached by the prose path.
+
+    Mirrors ``test_submit_governance_prose.py`` so the two-birds API-layer tests
+    never make an AI call. The stub captures the kwargs run_intake_to_pr is
+    called with, so we can assert ``write_adr`` is forwarded.
+    """
+
+    def _install(result: dict[str, Any]) -> None:
+        async def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            _install.captured = {"args": args, "kwargs": kwargs}  # type: ignore[attr-defined]
+            return result
+
+        monkeypatch.setattr(sg, "run_intake_to_pr", _fake, raising=True)
+
+    _install.captured = None  # type: ignore[attr-defined]
+    return _install
+
+
+def _intake_ok(dry_run: bool = True) -> dict[str, Any]:
+    return {
+        "success": True,
+        "token": _TOKEN,
+        "card_type": "DECISION_RECORD",
+        "target_path": f".hestai/decisions/{_TOKEN}.oct.md",
+        "branch": f"governance/20260601-{_TOKEN.lower()}",
+        "pr_url": None,
+        "validation_errors": [],
+        "octave_validation": None,
+        "metrics": {"tokens": 42, "cost": 0.01, "model": "test-model"},
+        "dry_run": dry_run,
+    }
+
+
+class TestWriteAdrIsProseOnly:
+    def test_write_adr_with_octave_content_is_structured_error(self, tmp_path: Path) -> None:
+        # RED #7: write_adr=True with octave_content -> structured error, no write.
+        result = asyncio.run(
+            submit_governance(
+                working_dir=str(tmp_path),
+                octave_content=_VALID_OCTAVE,
+                write_adr=True,
+                dry_run=True,
+            )
+        )
+        assert result["success"] is False
+        assert result["validation_errors"]
+        joined = " ".join(result["validation_errors"]).lower()
+        assert "prose_input" in joined and "adr" in joined
+
+    def test_write_adr_with_no_prose_is_structured_error(self, tmp_path: Path) -> None:
+        # RED #7: write_adr=True but neither input provided -> structured error.
+        result = asyncio.run(
+            submit_governance(
+                working_dir=str(tmp_path),
+                write_adr=True,
+                dry_run=True,
+            )
+        )
+        assert result["success"] is False
+        assert result["validation_errors"]
+
+
+class TestWriteAdrForwarding:
+    def test_write_adr_true_forwarded_to_intake(self, tmp_path: Path, stub_intake) -> None:
+        # RED: the prose path must forward write_adr + prose_input to the intake
+        # composition so the linker can dual-write.
+        stub_intake(_intake_ok())
+        asyncio.run(
+            submit_governance(
+                working_dir=str(tmp_path),
+                prose_input="A full ADR-grade decision narrative.",
+                write_adr=True,
+                dry_run=True,
+            )
+        )
+        captured = stub_intake.captured
+        assert captured is not None
+        assert captured["kwargs"].get("write_adr") is True
+
+    def test_write_adr_default_false_is_back_compat(self, tmp_path: Path, stub_intake) -> None:
+        # RED #1: default (no write_adr) forwards write_adr=False -> AGR-only.
+        stub_intake(_intake_ok())
+        asyncio.run(
+            submit_governance(
+                working_dir=str(tmp_path),
+                prose_input="record a decision",
+                dry_run=True,
+            )
+        )
+        captured = stub_intake.captured
+        assert captured is not None
+        assert captured["kwargs"].get("write_adr") is False


### PR DESCRIPTION
## feat(governance): two-birds write_adr — verbatim ADR doc + HUMAN_ADR_REF-linked condensed AGR (#112)

Implements the ratified DEPTH_MODEL (HO-AGR-BYTECODE-FORMAT-TWO-BIRDS-20260620 / #101): an agent writes the decision once in natural language and picks **AGR only** or **ADR + AGR** — the tool does the rest. One input, two artifacts.

### API
`submit_governance(..., write_adr=False)` — additive, default `False` (AGR-only, byte-stable). New return key `adr_target_path` (the `docs/adr/<TOKEN>.md` path when `write_adr`, else `None`).

### Behaviour (`write_adr=True`, prose_input only)
1. Compile the natural-language `prose_input` to a bytecode AGR as normal (Stage-1/2, the #111 compression contract — left untouched).
2. **Deterministically** stamp `HUMAN_ADR_REF::"<TOKEN>"` into the AGR's META from the validated TOKEN — the AI never touches the link — then **re-validate Gate-A** and **abort before the linker** if it ever fails (hallucination immunity / PROD-I4).
3. **Verbatim dumb-write** the prose to `docs/adr/<TOKEN>.md` (no AI, no OCTAVE, no marker).
4. The linker writes **both** files atomically in one branch/commit/PR.
- `octave_content` (no natural prose) or missing `prose_input` + `write_adr=True` → structured error (AGR-only path unchanged).
- `dry_run` reports the would-write `adr_target_path`, writes nothing.

The link is purely greppable: `HUMAN_ADR_REF::<TOKEN>` ↔ `docs/adr/<TOKEN>.md`. Gate-A #11 (Wave A) accepts the token-form with no filesystem resolution, so it's cross-repo survivable.

### Security
The `docs/adr/<TOKEN>.md` path gets the **same `resolve()+relative_to(working_dir)` containment guard** as the AGR path, applied to both before any write. Two-layer defense: upstream `_TOKEN_FORMAT_RE` rejects any `/`/`.`/`..` token (so the path can't be poisoned), and the containment guard catches the symlink-escape vector — the latter is mutation-proven (dropping the ADR path from the guard → the escape test goes RED).

### Verification
T-deep review (CRS⊕CE⊕CIV⊕TMG, all GO): deterministic engine-side stamp (idempotent, bytecode-preserving, re-validated with abort-before-linker — now pinned by a dedicated regression test that fails if the abort is bypassed); dual-write atomic in one commit; byte-exact verbatim ADR; traversal guard mutation-proven; byte-stable when off. Hermetic git fixtures (CI-portable, the #66 lesson). 37 two-birds/intake tests pass; full sweep green except the pre-existing #66 clock_in env flake (no clock_in code in this diff). ruff/mypy/black clean.

### Note for reviewers
ADR placement is `docs/adr/<TOKEN>.md` per the operator-confirmed design (token-named for the greppable join key). This is a third ADR naming alongside `docs/adr/adr-NNNN-*.md` and `.hestai/decisions/rfc-arch/ADR-RFC-ARCH-*.md`; reconciling the conventions is a possible follow-up, not in scope here.

Refs: #112; ratified basis #101; builds on #11 token-form (Wave A) + the #108.3 worktree pre-flight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “two-birds” mode to governance: from one prose input, create a verbatim ADR doc and a condensed AGR in the same branch/commit/PR. Default is off; AGR-only behavior stays stable, and `adr_target_path` is now consistently present (None) on AGR-only results.

- **New Features**
  - Add `write_adr` to `submit_governance` (default False). Prose-only; using it with `octave_content` returns a structured error.
  - Deterministic engine-side `HUMAN_ADR_REF::"<TOKEN>"` stamp in AGR META, followed by Gate-A re-validation; abort before the linker on failure.
  - Linker dumb-writes `docs/adr/<TOKEN>.md` verbatim and commits it with the AGR in one commit; `adr_target_path` returned (also in `dry_run`).
  - Apply the same path traversal guard to the ADR path as the AGR path, before any write.

- **Bug Fixes**
  - Ensure `HUMAN_ADR_REF` matching only affects META lines; DECISION text substrings are never altered.
  - Collapse multiple pre-existing `HUMAN_ADR_REF` lines to a single correct line.
  - Return shape is uniform: `adr_target_path` is included and set to None on AGR-only success paths, including `octave_content` mode.

<sup>Written for commit b40179879cbf84bd0accd368fff496c54ab8335c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

