### PR TITLE
fix(governance): author governance branch in a dedicated worktree

### DIFF
--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -552,8 +552,11 @@ def run_linker(
         # ALWAYS remove the worktree -- the operator's tree was never mutated, so
         # there is no partial state to surface. If the branch never reached
         # origin, roll the local branch back too so no half-built branch lingers.
+        # Rollback keys on ``pushed_ok`` ALONE (not on ``errors``): an unexpected
+        # exception before the push never populates ``errors``, yet still leaves
+        # an unpushed branch that must be cleaned up (cubic P2).
         _remove_worktree(working_dir, worktree_path)
-        if errors and not pushed_ok:
+        if not pushed_ok:
             _delete_branch(working_dir, branch_name)
 
     error_str = "; ".join(errors) if errors else None

--- a/src/hestai_context_mcp/tools/governance/linker.py
+++ b/src/hestai_context_mcp/tools/governance/linker.py
@@ -1,12 +1,23 @@
 """Git Orchestrator (Linker) for governance intake.
 
 Accepts a ValidationResult + raw OCTAVE content, then:
-  1. Creates branch: governance/{date}-{token-slug}
-  2. Writes OCTAVE content to the computed target_path
+  1. Creates a DEDICATED git worktree on a fresh ``governance/{date}-{token-slug}``
+     branch based off ``origin/main`` (after a ``git fetch origin``)
+  2. Writes OCTAVE content to the computed target_path INSIDE that worktree
   3. Commits with: chore(governance): add {token} [{card_type}]
   4. Updates MANIFEST (write_manifest)
   5. Pushes the branch to origin (git push -u origin <branch>)
   6. Opens PR via gh pr create
+  7. Removes the worktree (always); rolls back the local branch if nothing was
+     pushed.
+
+The worktree is the load-bearing design choice: ALL git mutation happens inside
+a throwaway worktree, so the invoking working tree's HEAD is NEVER moved. The
+repo the operator is sitting in (``main`` or any feature branch) is left exactly
+as it was found — the tool can never "leave" a checkout on ``governance/...``
+(issue #108: the old in-place ``git checkout -b`` brute-forced the invoking
+tree's branch and stranded it there). This also sidesteps the worktree-discipline
+pre-commit hook entirely, since commits are always made from a real worktree.
 
 dry_run=True: skips all git/file operations, returns what WOULD happen.
 
@@ -19,7 +30,9 @@ that previously copied this logic from submit_review). It is re-exported here as
 
 import logging
 import os
+import shutil
 import subprocess
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -95,85 +108,68 @@ def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
         return 1, "", str(exc)
 
 
-# Branches the global worktree-discipline pre-commit hook protects. A commit on
-# one of these, from a MAIN working tree (not a worktree), is blocked.
-_PROTECTED_BRANCHES = frozenset({"main", "master"})
+# The base ref every governance branch is cut from. The PR also targets ``main``
+# (``_open_pr`` passes ``--base main``), so ``origin/main`` keeps the branch base
+# and the PR base identical, and guarantees the worktree is cut from the current
+# remote tip rather than a possibly-stale local ``main``.
+_BASE_REF = "origin/main"
 
 
-def _preflight_commit_safety(working_dir: Path) -> str | None:
-    """Return a recovery error iff committing here would be blocked, else None.
+def _create_worktree(working_dir: Path, branch_name: str) -> tuple[Path | None, str | None]:
+    """Create a throwaway git worktree on a fresh ``branch_name`` off ``origin/main``.
 
-    #108.3: the global worktree-discipline pre-commit hook
-    (``~/.githooks/pre-commit``) blocks a commit when ALL of the following hold:
+    ALL git mutation for a governance submission happens inside this dedicated
+    worktree so the invoking working tree's HEAD is NEVER moved (issue #108: the
+    old in-place ``git checkout -b`` stranded the operator's checkout on the
+    ``governance/...`` branch). The worktree is created under a fresh temp dir;
+    the caller is responsible for removing it via ``_remove_worktree`` (always,
+    in a ``finally``).
 
-      1. ``working_dir`` is a MAIN working tree -- NOT a linked worktree. Git
-         reports the same path for ``--git-dir`` and ``--git-common-dir`` in a
-         main tree; a linked worktree's ``--git-dir`` is ``.git/worktrees/<name>``
-         and differs from the common dir.
-      2. the current branch is a protected branch (``main``/``master``).
-      3. an executable ``pre-commit`` hook is actually installed at the repo's
-         effective ``core.hooksPath`` (so a repo with hooks disabled -- e.g. the
-         isolated test fixture -- does NOT trip this guard).
+    A ``git fetch origin`` runs first so the branch is cut from the current
+    remote tip. ``git worktree add -b <branch> <path> origin/main`` then creates
+    the branch and checks it out into the worktree in one step.
 
-    The hook also auto-reverts a ``git checkout -b`` back to the protected branch
-    (a companion ``post-checkout`` hook), so the linker's own branch creation
-    cannot escape the block from a main tree -- hence we MUST fail fast *before*
-    creating a branch rather than relying on the checkout to move us off main.
-
-    When this returns a non-None error the linker aborts before touching git, so
-    no branch is created and nothing is staged (PROD::I4 structured failure with
-    explicit recovery guidance). Returns ``None`` (proceed) whenever the path is
-    not a git repo or any of conditions 1-3 do not hold -- including every linked
-    worktree, which is the supported authoring location.
+    Returns ``(worktree_path, None)`` on success or ``(None, error)`` on failure.
+    On failure no worktree and no temp dir are left behind.
     """
-    # Not a git repo (or git unavailable) -> cannot be a blocked main tree.
-    code, git_dir, _ = _run_git(["rev-parse", "--absolute-git-dir"], working_dir)
-    if code != 0 or not git_dir:
-        return None
-    code, common_dir, _ = _run_git(
-        ["rev-parse", "--path-format=absolute", "--git-common-dir"], working_dir
-    )
-    if code != 0 or not common_dir:
-        return None
-
-    # (1) MAIN tree iff the per-worktree git-dir IS the common dir.
-    if Path(git_dir).resolve() != Path(common_dir).resolve():
-        return None  # linked worktree -> supported, never blocked.
-
-    # (2) Protected branch only. A main tree on a feature branch commits fine.
-    code, branch, _ = _run_git(["branch", "--show-current"], working_dir)
-    if code != 0 or branch not in _PROTECTED_BRANCHES:
-        return None
-
-    # (3) An executable pre-commit hook must actually be installed at the repo's
-    #     effective hooks path; a repo with hooks disabled does not block.
-    code, hooks_dir, _ = _run_git(["rev-parse", "--git-path", "hooks"], working_dir)
-    if code != 0 or not hooks_dir:
-        return None
-    hook_path = (working_dir / hooks_dir / "pre-commit").resolve()
-    if not (hook_path.is_file() and os.access(hook_path, os.X_OK)):
-        return None
-
-    return (
-        f"BLOCKED: cannot author governance from the main working tree on "
-        f"'{branch}' -- the worktree-discipline pre-commit hook blocks commits "
-        f"here. Author from a git worktree instead:\n"
-        f"  git worktree add -b governance/your-record ../<repo>-governance main\n"
-        f"  # then re-run submit_governance with working_dir pointed at that "
-        f"worktree.\n"
-        f"No branch was created and nothing was staged."
-    )
-
-
-def _create_branch(working_dir: Path, branch_name: str) -> str | None:
-    """Create and checkout a new git branch.
-
-    Returns an error string on failure, None on success.
-    """
-    code, _, stderr = _run_git(["checkout", "-b", branch_name], working_dir)
+    code, _, stderr = _run_git(["fetch", "origin"], working_dir)
     if code != 0:
-        return f"Failed to create branch '{branch_name}': {stderr}"
-    return None
+        return None, f"git fetch origin failed: {stderr}"
+
+    # A fresh temp parent; the worktree itself lives in a not-yet-existing subdir
+    # (``git worktree add`` creates it). Cleanup removes the whole parent.
+    parent = Path(tempfile.mkdtemp(prefix="hestai-governance-"))
+    worktree_path = parent / "worktree"
+
+    code, _, stderr = _run_git(
+        ["worktree", "add", "-b", branch_name, str(worktree_path), _BASE_REF],
+        working_dir,
+    )
+    if code != 0:
+        shutil.rmtree(parent, ignore_errors=True)
+        return None, f"Failed to create governance worktree for '{branch_name}': {stderr}"
+
+    return worktree_path, None
+
+
+def _remove_worktree(working_dir: Path, worktree_path: Path) -> None:
+    """Remove the governance worktree and its temp parent dir (best-effort).
+
+    Never raises: a cleanup failure must not mask the linker's own result. The
+    branch ref created with the worktree is intentionally NOT deleted here (the
+    caller decides whether to roll it back based on whether it was pushed).
+    """
+    _run_git(["worktree", "remove", "--force", str(worktree_path)], working_dir)
+    shutil.rmtree(worktree_path.parent, ignore_errors=True)
+
+
+def _delete_branch(working_dir: Path, branch_name: str) -> None:
+    """Delete the local ``branch_name`` ref (best-effort rollback).
+
+    Called only when a submission failed BEFORE the branch reached ``origin`` —
+    so the half-built local branch leaves no trace. Never raises.
+    """
+    _run_git(["branch", "-D", branch_name], working_dir)
 
 
 def _push_branch(working_dir: Path, branch_name: str) -> str | None:
@@ -391,6 +387,14 @@ def run_linker(
         Dict with keys: token, card_type, target_path, branch, pr_url, error,
         dry_run, staged_uncommitted, and ``adr_target_path`` (the
         ``docs/adr/<token>.md`` path when ``adr_prose`` is supplied, else None).
+
+        ``branch`` is the would-be branch name on ``dry_run``; on a live run it
+        is non-None ONLY when the branch actually reached ``origin`` (a push
+        succeeded), and None when a pre-push failure rolled the local branch back
+        (no misleading name for a branch that was never persisted — issue #108).
+        ``staged_uncommitted`` is always False on the live path: every git
+        mutation happens inside a throwaway worktree that is always removed, so
+        nothing is ever left staged in the operator's working tree.
     """
     token = validation.token or ""
     card_type = validation.card_type or ""
@@ -419,54 +423,18 @@ def run_linker(
             "dry_run": True,
         }
 
-    # --- Live path: git operations ---
+    # --- Live path: hermetic worktree git operations ---
     errors: list[str] = []
 
-    # 0. Pre-flight (#108.3): if committing here would be blocked by the
-    #    worktree-discipline hook, fail fast BEFORE creating any branch so no
-    #    orphan branch and no staged state is ever produced. Honours a worktree
-    #    working_dir (which is the supported authoring location) unchanged.
-    preflight_err = _preflight_commit_safety(working_dir)
-    if preflight_err:
-        # Aborted before branch creation: no branch, nothing staged.
-        return {
-            "token": token,
-            "card_type": card_type,
-            "target_path": target_path_str,
-            "adr_target_path": adr_target_path_str,
-            "branch": None,
-            "pr_url": None,
-            "error": preflight_err,
-            "staged_uncommitted": False,
-            "dry_run": False,
-        }
-
-    # 1. Create branch
-    err = _create_branch(working_dir, branch_name)
-    if err:
-        # Branch creation itself failed: no branch, nothing staged.
-        return {
-            "token": token,
-            "card_type": card_type,
-            "target_path": target_path_str,
-            "adr_target_path": adr_target_path_str,
-            "branch": branch_name,
-            "pr_url": None,
-            "error": err,
-            "staged_uncommitted": False,
-            "dry_run": False,
-        }
-
-    # 2. Write OCTAVE content to target path
+    # target_path is required before we touch git.
     if target_path is None:
-        # Branch WAS created (surfaced via ``branch`` for recovery) but no write
-        # or ``git add`` ran, so nothing is staged-uncommitted (contract: False).
+        # Nothing created, nothing staged: no worktree, no branch.
         return {
             "token": token,
             "card_type": card_type,
             "target_path": None,
             "adr_target_path": adr_target_path_str,
-            "branch": branch_name,
+            "branch": None,
             "pr_url": None,
             "error": "target_path is None -- cannot write file",
             "staged_uncommitted": False,
@@ -476,21 +444,21 @@ def run_linker(
     # Bug 4: path traversal guard -- verify target_path is inside working_dir.
     # #112: the SAME guard is applied to the two-birds ADR path so a crafted
     # token/symlink cannot escape the repo. Both paths are checked here, BEFORE
-    # any write, so a rejection writes/stages nothing.
+    # any worktree is created, so a rejection touches nothing. The guard also
+    # yields the repo-relative paths we replay INSIDE the worktree.
     guard_paths = [target_path, *([adr_target_path] if adr_target_path is not None else [])]
+    rels: list[Path] = []
     for guarded in guard_paths:
         try:
-            guarded.resolve().relative_to(working_dir.resolve())
+            rels.append(guarded.resolve().relative_to(working_dir.resolve()))
         except (ValueError, RuntimeError, OSError):
-            # Branch WAS created (surfaced via ``branch``) but the write was
-            # rejected before any ``git add``, so nothing is staged-uncommitted
-            # (contract: False); recovery is conveyed by ``branch`` + ``error``.
+            # Nothing created: no worktree, no branch, nothing staged.
             return {
                 "token": token,
                 "card_type": card_type,
                 "target_path": target_path_str,
                 "adr_target_path": adr_target_path_str,
-                "branch": branch_name,
+                "branch": None,
                 "pr_url": None,
                 "error": (
                     f"target_path {guarded} is outside working_dir {working_dir} "
@@ -500,81 +468,113 @@ def run_linker(
                 "dry_run": False,
             }
 
-    err = _write_file(target_path, octave_content)
+    # 1. Create the dedicated worktree on a fresh branch off origin/main. The
+    #    operator's own working tree (whatever branch it is on) is NEVER touched.
+    worktree_path, err = _create_worktree(working_dir, branch_name)
     if err:
-        errors.append(err)
+        # Worktree creation failed: nothing created, nothing staged.
+        return {
+            "token": token,
+            "card_type": card_type,
+            "target_path": target_path_str,
+            "adr_target_path": adr_target_path_str,
+            "branch": None,
+            "pr_url": None,
+            "error": err,
+            "staged_uncommitted": False,
+            "dry_run": False,
+        }
 
-    # 2b. Two-birds (#112): dumb-write the VERBATIM ADR prose alongside the AGR.
-    #     No AI, no OCTAVE, no provenance marker. Guarded above; written only
-    #     when the AGR write succeeded so we never leave an orphan ADR doc.
-    if not errors and adr_prose is not None and adr_target_path is not None:
-        err = _write_file(adr_target_path, adr_prose)
-        if err:
-            errors.append(err)
+    # On success ``_create_worktree`` returns a non-None path (err is None).
+    assert worktree_path is not None
 
-    # 3. Update MANIFEST (best-effort -- failure is non-fatal, Bug 9 fix)
-    if not errors:
-        try:
-            write_manifest(working_dir)
-        except Exception as exc:  # noqa: BLE001
-            # Log warning instead of appending to errors; MANIFEST failure
-            # must not block the commit/PR flow (Bug 9: non-fatal).
-            logger.warning("MANIFEST update failed (non-fatal): %s", exc)
-
-    # 4. Commit
-    commit_message = f"chore(governance): add {token} [{card_type}]"
-    manifest_path = working_dir / ".hestai" / "MANIFEST.md"
-
-    # Track commit failure explicitly. ``_git_add_and_commit`` stages (git add)
-    # BEFORE committing, so a commit failure leaves changes staged-but-uncommitted
-    # -- the ONLY state where ``staged_uncommitted`` is True. A successful commit,
-    # or a step that never reached the commit (write/traversal failure: nothing
-    # staged), is NOT staged-uncommitted.
-    commit_failed = False
-    if not errors:
-        extra_paths = [adr_target_path] if adr_target_path is not None else None
-        err = _git_add_and_commit(
-            working_dir, target_path, manifest_path, commit_message, extra_paths=extra_paths
-        )
-        if err:
-            errors.append(err)
-            commit_failed = True
-
-    # 5. Push branch to origin (REQUIRED before gh pr create -- issue #73).
-    #    gh aborts PR creation if the branch is not on a remote. A push
-    #    failure is a structured error (PROD I4) and skips PR creation.
-    if not errors:
-        err = _push_branch(working_dir, branch_name)
-        if err:
-            errors.append(err)
-
-    # 6. Open PR
+    pushed_ok = False
     pr_url: str | None = None
-    if not errors:
-        gh_token = _resolve_github_token()
-        pr_url, pr_err = _open_pr(working_dir, branch_name, token, card_type, gh_token)
-        if pr_err:
-            errors.append(pr_err)
+    try:
+        # Replay the repo-relative paths inside the worktree.
+        target_in_wt = worktree_path / rels[0]
+        adr_in_wt = (worktree_path / rels[1]) if adr_target_path is not None else None
+
+        # 2. Write OCTAVE content into the worktree.
+        err = _write_file(target_in_wt, octave_content)
+        if err:
+            errors.append(err)
+
+        # 2b. Two-birds (#112): dumb-write the VERBATIM ADR prose alongside the
+        #     AGR. No AI, no OCTAVE, no provenance marker. Written only when the
+        #     AGR write succeeded so we never leave an orphan ADR doc.
+        if not errors and adr_prose is not None and adr_in_wt is not None:
+            err = _write_file(adr_in_wt, adr_prose)
+            if err:
+                errors.append(err)
+
+        # 3. Update MANIFEST (best-effort -- failure is non-fatal, Bug 9 fix).
+        if not errors:
+            try:
+                write_manifest(worktree_path)
+            except Exception as exc:  # noqa: BLE001
+                # Log warning instead of appending to errors; MANIFEST failure
+                # must not block the commit/PR flow (Bug 9: non-fatal).
+                logger.warning("MANIFEST update failed (non-fatal): %s", exc)
+
+        # 4. Commit (inside the worktree).
+        if not errors:
+            commit_message = f"chore(governance): add {token} [{card_type}]"
+            manifest_path = worktree_path / ".hestai" / "MANIFEST.md"
+            extra_paths = [adr_in_wt] if adr_in_wt is not None else None
+            err = _git_add_and_commit(
+                worktree_path,
+                target_in_wt,
+                manifest_path,
+                commit_message,
+                extra_paths=extra_paths,
+            )
+            if err:
+                errors.append(err)
+
+        # 5. Push branch to origin (REQUIRED before gh pr create -- issue #73).
+        #    gh aborts PR creation if the branch is not on a remote. A push
+        #    failure is a structured error (PROD I4) and skips PR creation.
+        if not errors:
+            err = _push_branch(worktree_path, branch_name)
+            if err:
+                errors.append(err)
+            else:
+                pushed_ok = True
+
+        # 6. Open PR.
+        if not errors:
+            gh_token = _resolve_github_token()
+            pr_url, pr_err = _open_pr(worktree_path, branch_name, token, card_type, gh_token)
+            if pr_err:
+                errors.append(pr_err)
+    finally:
+        # ALWAYS remove the worktree -- the operator's tree was never mutated, so
+        # there is no partial state to surface. If the branch never reached
+        # origin, roll the local branch back too so no half-built branch lingers.
+        _remove_worktree(working_dir, worktree_path)
+        if errors and not pushed_ok:
+            _delete_branch(working_dir, branch_name)
 
     error_str = "; ".join(errors) if errors else None
 
-    # #108.3 orphan/partial-state surfacing (cubic P2 contract): the branch HAS
-    # been created (step 1 succeeded) by this point. ``staged_uncommitted`` is
-    # True IFF the commit itself failed -- i.e. changes were staged (git add) but
-    # not committed. It is False whenever the commit succeeded, INCLUDING when a
-    # later push (step 5) or PR-creation (step 6) failed: those are committed
-    # states with a different recovery, already described by ``error``. The flag
-    # stays literally "staged but not committed," matching its name.
-    staged_uncommitted = commit_failed
+    # Report ``branch`` for recovery ONLY when it actually persists on origin (a
+    # push succeeded). On a pre-push failure the branch was rolled back, so we
+    # report None rather than a misleading name (issue #108: the old in-place
+    # code returned a branch that was never persisted).
+    persisted_branch = branch_name if pushed_ok else None
 
     return {
         "token": token,
         "card_type": card_type,
         "target_path": target_path_str,
         "adr_target_path": adr_target_path_str,
-        "branch": branch_name,
+        "branch": persisted_branch,
         "pr_url": pr_url,
+        # Hermetic model: the worktree is always removed and nothing is ever
+        # staged in the operator's working tree, so this is always False.
+        # Retained for I4 shape stability.
+        "staged_uncommitted": False,
         "error": error_str,
-        "staged_uncommitted": staged_uncommitted,
         "dry_run": False,
     }

--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -525,6 +525,29 @@ class TestRunLinkerLivePath:
         h.delete.assert_called_once()
 
     @pytest.mark.unit
+    def test_unexpected_exception_still_rolls_back_branch(self, tmp_path: Path) -> None:
+        """An unhandled exception before push must STILL roll the branch back.
+
+        The cleanup contract ("if the branch never reached origin, roll it back")
+        must hold even when the failure is an unexpected exception that never
+        populated ``errors`` -- otherwise a half-built local governance branch is
+        left behind despite the worktree being removed. Rollback therefore keys on
+        ``pushed_ok`` alone, NOT on whether ``errors`` was recorded (cubic P2).
+        """
+        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+        with (
+            patch(f"{_LINKER}._create_worktree", return_value=(tmp_path / "wt", None)),
+            patch(f"{_LINKER}._remove_worktree") as remove,
+            patch(f"{_LINKER}._delete_branch") as delete,
+            patch(f"{_LINKER}._write_file", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        # Worktree removed AND the unpushed branch rolled back, despite the raise.
+        remove.assert_called_once()
+        delete.assert_called_once()
+
+    @pytest.mark.unit
     def test_pr_failure_keeps_pushed_branch(self, tmp_path: Path) -> None:
         """A PR error after a successful push keeps the (pushed) branch, no rollback.
 

--- a/tests/unit/tools/governance/test_linker.py
+++ b/tests/unit/tools/governance/test_linker.py
@@ -6,22 +6,26 @@ tests/unit/tools/test_submit_governance.py::TestLinker and TestLinkerIntegration
 This module hardens the previously-untested branches by mocking the
 subprocess boundary (git / gh) and the filesystem write layer:
   - _run_git: timeout and FileNotFoundError/OSError branches.
-  - _create_branch / _git_add_and_commit failure paths.
+  - _create_worktree / _git_add_and_commit failure paths.
   - _write_file OSError branch.
   - _open_pr: argv construction, success, non-zero exit, timeout, gh-missing.
   - run_linker: write failure, commit failure, PR failure aggregation, and
-    the target_path-is-None guard on the live path.
+    the target_path-is-None guard on the live path. All git mutation happens in
+    a throwaway worktree, so run_linker never moves the invoking tree's HEAD.
 """
 
 import subprocess
+from contextlib import ExitStack
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hestai_context_mcp.tools.governance import linker
 from hestai_context_mcp.tools.governance.linker import (
-    _create_branch,
+    _create_worktree,
     _git_add_and_commit,
     _open_pr,
     _push_branch,
@@ -98,23 +102,78 @@ class TestRunGit:
 
 
 # ---------------------------------------------------------------------------
-# _create_branch
+# _create_worktree
 # ---------------------------------------------------------------------------
 
 
-class TestCreateBranch:
+class TestCreateWorktree:
     @pytest.mark.unit
-    def test_success_returns_none(self, tmp_path: Path) -> None:
-        with patch(f"{_LINKER}._run_git", return_value=(0, "", "")):
-            assert _create_branch(tmp_path, "governance/x") is None
+    def test_success_returns_worktree_path(self, tmp_path: Path) -> None:
+        """fetch + worktree add both succeed -> (worktree_path, None)."""
+        parent = tmp_path / "parent"
+        with (
+            patch(f"{_LINKER}._run_git", return_value=(0, "", "")) as run,
+            patch(f"{_LINKER}.tempfile.mkdtemp", return_value=str(parent)),
+        ):
+            wt, err = _create_worktree(tmp_path, "governance/x")
+        assert err is None
+        assert wt == parent / "worktree"
+        # First call fetches origin; second creates the worktree off origin/main.
+        argvs = [c.args[0] for c in run.call_args_list]
+        assert argvs[0] == ["fetch", "origin"]
+        assert argvs[1][:3] == ["worktree", "add", "-b"]
+        assert "origin/main" in argvs[1]
 
     @pytest.mark.unit
-    def test_failure_returns_error_string(self, tmp_path: Path) -> None:
-        with patch(f"{_LINKER}._run_git", return_value=(128, "", "branch exists")):
-            err = _create_branch(tmp_path, "governance/x")
-        assert err is not None
-        assert "governance/x" in err
-        assert "branch exists" in err
+    def test_fetch_failure_aborts_before_mkdtemp(self, tmp_path: Path) -> None:
+        """A failed `git fetch origin` returns an error and creates no temp dir."""
+        with (
+            patch(f"{_LINKER}._run_git", return_value=(1, "", "no network")),
+            patch(f"{_LINKER}.tempfile.mkdtemp") as mkdtemp,
+        ):
+            wt, err = _create_worktree(tmp_path, "governance/x")
+        assert wt is None
+        assert err is not None and "fetch" in err and "no network" in err
+        mkdtemp.assert_not_called()
+
+    @pytest.mark.unit
+    def test_worktree_add_failure_cleans_up_temp_dir(self, tmp_path: Path) -> None:
+        """A failed `worktree add` removes the temp parent and returns an error."""
+        parent = tmp_path / "parent"
+        # fetch ok (0), worktree add fails (1)
+        with (
+            patch(f"{_LINKER}._run_git", side_effect=[(0, "", ""), (1, "", "exists")]),
+            patch(f"{_LINKER}.tempfile.mkdtemp", return_value=str(parent)),
+            patch(f"{_LINKER}.shutil.rmtree") as rmtree,
+        ):
+            wt, err = _create_worktree(tmp_path, "governance/x")
+        assert wt is None
+        assert err is not None and "governance/x" in err and "exists" in err
+        rmtree.assert_called_once_with(parent, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# _remove_worktree / _delete_branch
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeLifecycle:
+    @pytest.mark.unit
+    def test_remove_worktree_runs_git_and_rmtree(self, tmp_path: Path) -> None:
+        wt = tmp_path / "parent" / "worktree"
+        with (
+            patch(f"{_LINKER}._run_git", return_value=(0, "", "")) as run,
+            patch(f"{_LINKER}.shutil.rmtree") as rmtree,
+        ):
+            linker._remove_worktree(tmp_path, wt)
+        assert run.call_args.args[0] == ["worktree", "remove", "--force", str(wt)]
+        rmtree.assert_called_once_with(wt.parent, ignore_errors=True)
+
+    @pytest.mark.unit
+    def test_delete_branch_force_deletes(self, tmp_path: Path) -> None:
+        with patch(f"{_LINKER}._run_git", return_value=(0, "", "")) as run:
+            linker._delete_branch(tmp_path, "governance/x")
+        assert run.call_args.args[0] == ["branch", "-D", "governance/x"]
 
 
 # ---------------------------------------------------------------------------
@@ -328,179 +387,6 @@ class TestOpenPr:
 
 
 # ---------------------------------------------------------------------------
-# _preflight_commit_safety (#108.3 worktree-discipline guard)
-# ---------------------------------------------------------------------------
-
-
-# Repo-local git identity for the real-git fixtures. CI runners have NO global
-# user.name/user.email (and may set user.useConfigOnly), so any real commit MUST
-# carry an explicit identity or it aborts with exit 128 ("author identity
-# unknown"). These are passed both as repo config AND inline on every commit
-# (-c) so the fixtures are hermetic regardless of the runner's global git state.
-_GIT_IDENTITY = (
-    "-c",
-    "user.email=test@example.com",
-    "-c",
-    "user.name=Test",
-)
-
-
-def _git(repo: Path, *args: str) -> None:
-    """Run a git command in ``repo``, failing the test loudly on error."""
-    subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True)
-
-
-def _hermetic_seed_commit(repo: Path) -> None:
-    """Create a seed commit in ``repo`` that succeeds with NO global git config.
-
-    Identity is supplied inline (``-c user.*``) so the commit does not depend on
-    a global/system identity (absent on CI), and ``core.hooksPath`` is pointed at
-    a nonexistent dir so the seed itself is never gated by the discipline hook.
-    """
-    (repo / "seed.txt").write_text("seed")
-    _git(repo, "add", ".")
-    _git(
-        repo,
-        *_GIT_IDENTITY,
-        "-c",
-        "core.hooksPath=/nonexistent",
-        "commit",
-        "-m",
-        "seed",
-    )
-
-
-def _git_init_main_tree(repo: Path, *, branch: str = "main", hooks: bool) -> None:
-    """Initialise a real git repo as a MAIN tree on ``branch``.
-
-    ``hooks=True`` installs an executable ``pre-commit`` at the repo's effective
-    hooks path (simulating a discipline-enforced main tree). ``hooks=False``
-    points ``core.hooksPath`` at an empty dir with no ``pre-commit`` (simulating
-    a repo where the branch-protection hook is NOT active), mirroring the
-    isolated-repo fixture used by the submit_governance integration tests.
-
-    The repo is pinned onto ``branch`` via ``symbolic-ref`` (independent of the
-    runner's ``init.defaultBranch``) and given a repo-local identity so later
-    commits succeed even when the runner has no global git identity (CI).
-    """
-    subprocess.run(["git", "init"], cwd=str(repo), check=True, capture_output=True)
-    subprocess.run(
-        ["git", "symbolic-ref", "HEAD", f"refs/heads/{branch}"],
-        cwd=str(repo),
-        check=True,
-        capture_output=True,
-    )
-    # Repo-local identity (belt-and-suspenders alongside the inline -c on commits)
-    # so this repo can commit on a CI runner with no global git identity.
-    _git(repo, "config", "user.email", "test@example.com")
-    _git(repo, "config", "user.name", "Test")
-    hooks_dir = repo / ".git" / ("real-hooks" if hooks else "no-hooks")
-    hooks_dir.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        ["git", "config", "core.hooksPath", str(hooks_dir)],
-        cwd=str(repo),
-        check=True,
-        capture_output=True,
-    )
-    if hooks:
-        pre_commit = hooks_dir / "pre-commit"
-        pre_commit.write_text("#!/bin/bash\nexit 1\n")
-        pre_commit.chmod(0o755)
-
-
-class TestPreflightCommitSafety:
-    @pytest.mark.unit
-    def test_non_repo_is_safe(self, tmp_path: Path) -> None:
-        """A path that is not a git repo cannot be a blocked main tree -> safe."""
-        assert linker._preflight_commit_safety(tmp_path) is None
-
-    @pytest.mark.unit
-    def test_main_tree_on_main_with_active_hook_blocks(self, tmp_path: Path) -> None:
-        """Main tree + protected branch + active pre-commit hook -> structured block."""
-        _git_init_main_tree(tmp_path, branch="main", hooks=True)
-        err = linker._preflight_commit_safety(tmp_path)
-        assert err is not None
-        # Recovery guidance: tell the operator to author from a worktree.
-        assert "worktree" in err.lower()
-
-    @pytest.mark.unit
-    def test_main_tree_on_master_with_active_hook_blocks(self, tmp_path: Path) -> None:
-        """The protected-branch set includes 'master', not only 'main'."""
-        _git_init_main_tree(tmp_path, branch="master", hooks=True)
-        assert linker._preflight_commit_safety(tmp_path) is not None
-
-    @pytest.mark.unit
-    def test_main_tree_without_active_hook_is_safe(self, tmp_path: Path) -> None:
-        """A main tree whose hooks are disabled (no pre-commit) does NOT block.
-
-        This is the isolated-repo fixture shape used by the submit_governance
-        integration tests; the guard must NOT false-positive there.
-        """
-        _git_init_main_tree(tmp_path, branch="main", hooks=False)
-        assert linker._preflight_commit_safety(tmp_path) is None
-
-    @pytest.mark.unit
-    def test_main_tree_on_feature_branch_is_safe(self, tmp_path: Path) -> None:
-        """A main tree sitting on a NON-protected branch would commit fine -> safe.
-
-        Guards against the false-positive HO flagged: detection must key on the
-        protected branch, not merely on 'this is a main tree'.
-        """
-        _git_init_main_tree(tmp_path, branch="feature/x", hooks=True)
-        assert linker._preflight_commit_safety(tmp_path) is None
-
-    @pytest.mark.unit
-    def test_real_worktree_is_safe(self, tmp_path: Path) -> None:
-        """A genuine git worktree (git-dir != git-common-dir) is never blocked."""
-        main_repo = tmp_path / "main"
-        main_repo.mkdir()
-        _git_init_main_tree(main_repo, branch="main", hooks=True)
-        # A repo needs at least one commit before a worktree can be added.
-        _hermetic_seed_commit(main_repo)
-        wt = tmp_path / "wt"
-        _git(main_repo, "worktree", "add", "-b", "governance/x", str(wt), "main")
-        assert linker._preflight_commit_safety(wt) is None
-
-    @pytest.mark.unit
-    def test_worktree_on_protected_branch_is_safe(self, tmp_path: Path) -> None:
-        """A linked worktree checked out ON ``main`` with the hook active is SAFE.
-
-        This is #108.3's core supported authoring path. Conditions (2) protected
-        branch and (3) active pre-commit hook BOTH hold here -- the ONLY thing
-        keeping the commit unblocked is condition (1), the git-dir != common-dir
-        worktree exemption. So this test isolates the worktree discriminator: if
-        the git-dir/common-dir comparison were blinded, this would flip to a
-        false-block (verified out-of-band). The other two discriminators are
-        pinned by the main-tree tests above.
-        """
-        main_repo = tmp_path / "main"
-        main_repo.mkdir()
-        _git_init_main_tree(main_repo, branch="main", hooks=True)
-        _hermetic_seed_commit(main_repo)
-        # Free up ``main`` so a linked worktree can check it out: move the MAIN
-        # tree onto a parking branch. The worktree then sits ON the protected
-        # branch ``main`` while the main tree does not.
-        _git(main_repo, "-c", "core.hooksPath=/nonexistent", "checkout", "-b", "parking")
-        wt = tmp_path / "wt-main"
-        _git(main_repo, "worktree", "add", str(wt), "main")
-
-        # Pre-conditions for the isolation claim: the worktree IS on the
-        # protected branch, and the worktree's git-dir differs from the common
-        # dir (the exemption). If git ever stopped distinguishing them, the
-        # branch+hook conditions would make this a false-block.
-        branch = subprocess.run(
-            ["git", "branch", "--show-current"],
-            cwd=str(wt),
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        assert branch == "main", "worktree must be ON the protected branch for this isolation"
-
-        assert linker._preflight_commit_safety(wt) is None
-
-
-# ---------------------------------------------------------------------------
 # run_linker live-path branches (subprocess + filesystem fully mocked)
 # ---------------------------------------------------------------------------
 
@@ -515,103 +401,71 @@ def _valid_decision(target: Path) -> ValidationResult:
     )
 
 
+def _drive_live(
+    tmp_path: Path,
+    *,
+    write: str | None = None,
+    commit: str | None = None,
+    push: str | None = None,
+    open_pr: tuple[str | None, str | None] = ("http://pr/1", None),
+    worktree: tuple[Path | None, str | None] | None = None,
+    validation: ValidationResult | None = None,
+) -> tuple[dict[str, Any], SimpleNamespace]:
+    """Run run_linker through the live path with every git/fs seam mocked.
+
+    ``worktree`` defaults to a successful ``(tmp_path/'wt', None)``. The returned
+    namespace exposes the ``_remove_worktree`` / ``_delete_branch`` / ``_write_file``
+    / ``_open_pr`` mocks so tests can assert cleanup + skip behaviour.
+    """
+    wt_ret = worktree if worktree is not None else (tmp_path / "wt", None)
+    target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
+    val = validation if validation is not None else _valid_decision(target)
+    with ExitStack() as stack:
+
+        def p(name: str, **kw: object) -> MagicMock:
+            return stack.enter_context(patch(f"{_LINKER}.{name}", **kw))
+
+        p("_create_worktree", return_value=wt_ret)
+        remove = p("_remove_worktree")
+        delete = p("_delete_branch")
+        write_file = p("_write_file", return_value=write)
+        p("write_manifest")
+        p("_git_add_and_commit", return_value=commit)
+        push_branch = p("_push_branch", return_value=push)
+        p("_resolve_github_token", return_value=None)
+        open_pr_mock = p("_open_pr", return_value=open_pr)
+        out = run_linker(tmp_path, val, "===DECISION_RECORD===\n", False)
+    return out, SimpleNamespace(
+        remove=remove,
+        delete=delete,
+        write_file=write_file,
+        push_branch=push_branch,
+        open_pr=open_pr_mock,
+    )
+
+
 class TestRunLinkerLivePath:
     @pytest.mark.unit
-    def test_create_branch_failure_aborts_early(self, tmp_path: Path) -> None:
-        """A branch-creation failure returns immediately with the error set."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with patch(f"{_LINKER}._create_branch", return_value="branch boom"):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
-        assert out["error"] == "branch boom"
-        assert out["pr_url"] is None
-        assert out["dry_run"] is False
+    def test_worktree_creation_failure_aborts_early(self, tmp_path: Path) -> None:
+        """A worktree-creation failure returns immediately, touching nothing else.
 
-    @pytest.mark.unit
-    def test_preflight_block_aborts_before_branch_creation(self, tmp_path: Path) -> None:
-        """A discipline-enforced main tree aborts BEFORE any branch is created.
-
-        #108.3: when the pre-flight guard fires, run_linker must return a
-        structured failure (success-shape: error set, pr_url None) and must NOT
-        invoke ``_create_branch`` -- so no orphan branch and no staged state is
-        ever produced (the orphan-branch defect cannot occur).
+        Nothing was created, so there is no worktree to remove and no branch to
+        roll back: ``_remove_worktree`` / ``_delete_branch`` / ``_write_file`` must
+        never run, and the result carries no branch.
         """
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._preflight_commit_safety", return_value="BLOCKED: use a worktree"),
-            patch(f"{_LINKER}._create_branch") as create_branch,
-            patch(f"{_LINKER}._write_file") as write_file,
-            patch(f"{_LINKER}.subprocess.run") as run,
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
-        assert out["error"] == "BLOCKED: use a worktree"
-        assert out["pr_url"] is None
-        assert out["dry_run"] is False
-        # No branch was created, nothing was written, no subprocess ran: zero
-        # partial state (no orphan branch, no staged changes).
+        out, h = _drive_live(tmp_path, worktree=(None, "worktree boom"))
+        assert out["error"] == "worktree boom"
         assert out["branch"] is None
+        assert out["pr_url"] is None
         assert out["staged_uncommitted"] is False
-        create_branch.assert_not_called()
-        write_file.assert_not_called()
-        run.assert_not_called()
+        assert out["dry_run"] is False
+        h.remove.assert_not_called()
+        h.delete.assert_not_called()
+        h.write_file.assert_not_called()
 
     @pytest.mark.unit
-    def test_preflight_safe_proceeds_to_branch_creation(self, tmp_path: Path) -> None:
-        """When pre-flight returns safe (None), the existing happy path proceeds."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
-            patch(f"{_LINKER}._create_branch", return_value=None) as create_branch,
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value=None),
-            patch(f"{_LINKER}._push_branch", return_value=None),
-            patch(f"{_LINKER}._resolve_github_token", return_value=None),
-            patch(f"{_LINKER}._open_pr", return_value=("http://pr/1", None)),
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
-        assert out["error"] is None
-        assert out["pr_url"] == "http://pr/1"
-        create_branch.assert_called_once()
-
-    @pytest.mark.unit
-    def test_dry_run_skips_preflight(self, tmp_path: Path) -> None:
-        """dry_run must not invoke the pre-flight probe (no git side-channel work)."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with patch(f"{_LINKER}._preflight_commit_safety") as preflight:
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", True)
-        assert out["dry_run"] is True
-        preflight.assert_not_called()
-
-    @pytest.mark.unit
-    def test_commit_failure_surfaces_branch_and_staged_state(self, tmp_path: Path) -> None:
-        """A post-branch commit failure must surface the created branch + staged state.
-
-        #108.3: when a step after branch creation fails, the result must make the
-        partial state explicit (the branch that WAS created, and that changes were
-        staged) so the operator can recover -- not silently return a branch name
-        that looks clean.
-        """
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value="git commit failed: boom"),
-            patch(f"{_LINKER}._open_pr") as pr,
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
-        assert out["error"] is not None
-        assert "git commit failed" in out["error"]
-        # The created branch is surfaced (not None) so the operator can recover it.
-        assert out["branch"] and out["branch"].startswith("governance/")
-        # The result flags that local state was left partially applied.
-        assert out.get("staged_uncommitted") is True
-        pr.assert_not_called()
-
-    @pytest.mark.unit
-    def test_target_path_none_on_live_path_errors(self, tmp_path: Path) -> None:
-        """A live run with target_path=None returns the explicit guard error."""
+    def test_target_path_none_skips_worktree_creation(self, tmp_path: Path) -> None:
+        """A live run with target_path=None errors BEFORE any worktree is created."""
         validation = ValidationResult(
             valid=True,
             errors=[],
@@ -619,35 +473,35 @@ class TestRunLinkerLivePath:
             card_type="DECISION_RECORD",
             target_path=None,
         )
-        with patch(f"{_LINKER}._create_branch", return_value=None):
+        with patch(f"{_LINKER}._create_worktree") as create_worktree:
             out = run_linker(tmp_path, validation, "===DECISION_RECORD===\n", False)
         assert out["error"] is not None
         assert "target_path is None" in out["error"]
+        assert out["branch"] is None
+        create_worktree.assert_not_called()
 
     @pytest.mark.unit
-    def test_write_failure_aggregates_error(self, tmp_path: Path) -> None:
-        """A write failure surfaces in the aggregated error and stops the flow."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value="write boom"),
-            patch(f"{_LINKER}.write_manifest") as wm,
-            patch(f"{_LINKER}._git_add_and_commit") as commit,
-            patch(f"{_LINKER}._open_pr") as pr,
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+    def test_write_failure_aggregates_and_rolls_back(self, tmp_path: Path) -> None:
+        """A write failure stops the flow, removes the worktree, and rolls back the branch."""
+        out, h = _drive_live(tmp_path, write="write boom")
         assert out["error"] == "write boom"
-        # On a write error we must NOT continue to manifest/commit/PR.
-        wm.assert_not_called()
-        commit.assert_not_called()
-        pr.assert_not_called()
+        # Branch never reached origin -> reported None and rolled back locally.
+        assert out["branch"] is None
+        assert out["staged_uncommitted"] is False
+        # PR is never attempted on a write error.
+        h.open_pr.assert_not_called()
+        # The worktree is always removed; the half-built branch is deleted.
+        h.remove.assert_called_once()
+        h.delete.assert_called_once()
 
     @pytest.mark.unit
     def test_manifest_failure_is_non_fatal(self, tmp_path: Path) -> None:
         """A write_manifest exception is logged, not fatal; commit/PR proceed."""
         target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
         with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._create_worktree", return_value=(tmp_path / "wt", None)),
+            patch(f"{_LINKER}._remove_worktree"),
+            patch(f"{_LINKER}._delete_branch"),
             patch(f"{_LINKER}._write_file", return_value=None),
             patch(f"{_LINKER}.write_manifest", side_effect=RuntimeError("manifest boom")),
             patch(f"{_LINKER}._git_add_and_commit", return_value=None),
@@ -662,53 +516,39 @@ class TestRunLinkerLivePath:
 
     @pytest.mark.unit
     def test_commit_failure_aggregates_and_skips_pr(self, tmp_path: Path) -> None:
-        """A commit failure aborts before PR creation."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value="commit boom"),
-            patch(f"{_LINKER}._open_pr") as pr,
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        """A commit failure aborts before PR creation and rolls the branch back."""
+        out, h = _drive_live(tmp_path, commit="commit boom")
         assert out["error"] == "commit boom"
-        pr.assert_not_called()
+        assert out["branch"] is None
+        h.open_pr.assert_not_called()
+        h.remove.assert_called_once()
+        h.delete.assert_called_once()
 
     @pytest.mark.unit
-    def test_pr_failure_aggregates_error(self, tmp_path: Path) -> None:
-        """A PR-creation error is aggregated into the final error string."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value=None),
-            patch(f"{_LINKER}._push_branch", return_value=None),
-            patch(f"{_LINKER}._resolve_github_token", return_value="ghp_x"),
-            patch(f"{_LINKER}._open_pr", return_value=(None, "pr boom")),
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+    def test_pr_failure_keeps_pushed_branch(self, tmp_path: Path) -> None:
+        """A PR error after a successful push keeps the (pushed) branch, no rollback.
+
+        The branch already reached origin, so it is surfaced for recovery and the
+        local ref is NOT deleted; only the PR step failed.
+        """
+        out, h = _drive_live(tmp_path, push=None, open_pr=(None, "pr boom"))
         assert out["error"] == "pr boom"
         assert out["pr_url"] is None
+        assert out["branch"] and out["branch"].startswith("governance/")
+        h.remove.assert_called_once()
+        h.delete.assert_not_called()
 
     @pytest.mark.unit
     def test_push_failure_aggregates_and_skips_pr(self, tmp_path: Path) -> None:
-        """A push failure surfaces as a structured error and aborts before PR (PROD I4)."""
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value=None),
-            patch(f"{_LINKER}._push_branch", return_value="push boom"),
-            patch(f"{_LINKER}._open_pr") as pr,
-        ):
-            out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
+        """A push failure surfaces as a structured error, aborts PR, rolls back (PROD I4)."""
+        out, h = _drive_live(tmp_path, push="push boom")
         assert out["error"] == "push boom"
         assert out["pr_url"] is None
-        # PR creation must NOT be attempted when the push fails.
-        pr.assert_not_called()
+        # Push failed -> branch never persisted -> rolled back and reported None.
+        assert out["branch"] is None
+        h.open_pr.assert_not_called()
+        h.remove.assert_called_once()
+        h.delete.assert_called_once()
 
     @pytest.mark.unit
     def test_push_precedes_pr_create_at_subprocess_boundary(self, tmp_path: Path) -> None:
@@ -719,8 +559,8 @@ class TestRunLinkerLivePath:
         aborts ("you must first push the current branch to a remote").
 
         We let the real `_push_branch` and `_open_pr` run, stubbing only the
-        shared `subprocess.run` boundary, and assert the recorded git-push call
-        precedes the gh-pr-create call.
+        shared `subprocess.run` boundary (and the worktree lifecycle), and assert
+        the recorded git-push call precedes the gh-pr-create call.
         """
         target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
         calls: list[list[str]] = []
@@ -732,7 +572,9 @@ class TestRunLinkerLivePath:
             return _fake_completed(0)
 
         with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._create_worktree", return_value=(tmp_path / "wt", None)),
+            patch(f"{_LINKER}._remove_worktree"),
+            patch(f"{_LINKER}._delete_branch"),
             patch(f"{_LINKER}._write_file", return_value=None),
             patch(f"{_LINKER}.write_manifest"),
             patch(f"{_LINKER}._git_add_and_commit", return_value=None),
@@ -757,23 +599,30 @@ class TestRunLinkerLivePath:
         assert push_idx < pr_idx, f"push (idx {push_idx}) must precede pr-create (idx {pr_idx})"
 
     @pytest.mark.unit
-    def test_dry_run_neither_pushes_nor_creates_pr(self, tmp_path: Path) -> None:
-        """dry_run must touch NO subprocess: no push, no PR (PROD I5 / Human Primacy)."""
+    def test_dry_run_neither_creates_worktree_nor_subprocess(self, tmp_path: Path) -> None:
+        """dry_run must touch NO subprocess and create NO worktree (PROD I5)."""
         target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        with patch(f"{_LINKER}.subprocess.run") as run:
+        with (
+            patch(f"{_LINKER}.subprocess.run") as run,
+            patch(f"{_LINKER}._create_worktree") as create_worktree,
+        ):
             out = run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", True)
         assert out["dry_run"] is True
         assert out["pr_url"] is None
         assert out["error"] is None
-        # No git push and no gh pr create -- in fact no subprocess at all.
+        # dry_run still reports the would-be branch name.
+        assert out["branch"] and out["branch"].startswith("governance/")
         run.assert_not_called()
+        create_worktree.assert_not_called()
 
     @pytest.mark.unit
     def test_full_live_success(self, tmp_path: Path) -> None:
-        """Happy live path: branch + write + manifest + commit + push + PR all succeed."""
+        """Happy live path: worktree + write + manifest + commit + push + PR all succeed."""
         target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
         with (
-            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._create_worktree", return_value=(tmp_path / "wt", None)),
+            patch(f"{_LINKER}._remove_worktree") as remove,
+            patch(f"{_LINKER}._delete_branch") as delete,
             patch(f"{_LINKER}._write_file", return_value=None),
             patch(f"{_LINKER}.write_manifest"),
             patch(f"{_LINKER}._git_add_and_commit", return_value=None),
@@ -785,92 +634,64 @@ class TestRunLinkerLivePath:
         assert out["error"] is None
         assert out["pr_url"] == "http://pr/1"
         assert out["branch"].startswith("governance/")
+        assert out["staged_uncommitted"] is False
         # The branch was pushed before the PR was opened.
         push.assert_called_once()
+        # The worktree is always cleaned up; a successful push leaves the branch.
+        remove.assert_called_once()
+        delete.assert_not_called()
         # gh_token resolution feeds _open_pr.
         assert pr.call_args.args[-1] == "ghp_x" or pr.call_args.kwargs.get("gh_token") == "ghp_x"
 
 
 # ---------------------------------------------------------------------------
-# staged_uncommitted contract (cubic P2): True IFF the branch was created AND
-# the commit did NOT succeed (changes staged but not committed). MUST be False
-# whenever the commit succeeded -- including when a later push or PR step fails.
-# Fully mocked => hermetic (no real git).
+# Branch-persistence + cleanup contract (worktree model). The invoking tree is
+# never mutated, so ``staged_uncommitted`` is ALWAYS False on the live path.
+# ``branch`` is non-None ONLY when the branch reached origin (a push succeeded);
+# any pre-push failure rolls the local branch back. Fully mocked => hermetic.
 # ---------------------------------------------------------------------------
 
 
-class TestStagedUncommittedContract:
-    @staticmethod
-    def _run(tmp_path: Path, **overrides: object) -> dict[str, object]:
-        """Drive run_linker through the live path with all seams mocked.
-
-        ``overrides`` replaces individual seam return values (e.g.
-        ``commit="boom"``) so each test pins one outcome.
-        """
-        target = tmp_path / ".hestai" / "decisions" / "x.oct.md"
-        commit = overrides.get("commit")  # str error or None
-        push = overrides.get("push")  # str error or None
-        open_pr = overrides.get("open_pr", ("http://pr/1", None))  # (url, err)
-        with (
-            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
-            patch(f"{_LINKER}._create_branch", return_value=None),
-            patch(f"{_LINKER}._write_file", return_value=None),
-            patch(f"{_LINKER}.write_manifest"),
-            patch(f"{_LINKER}._git_add_and_commit", return_value=commit),
-            patch(f"{_LINKER}._push_branch", return_value=push),
-            patch(f"{_LINKER}._resolve_github_token", return_value=None),
-            patch(f"{_LINKER}._open_pr", return_value=open_pr),
-        ):
-            return run_linker(tmp_path, _valid_decision(target), "===DECISION_RECORD===\n", False)
-
+class TestBranchPersistenceContract:
     @pytest.mark.unit
-    def test_commit_fails_is_staged_uncommitted(self, tmp_path: Path) -> None:
-        """Commit FAILED -> staged_uncommitted True (the genuine staged state)."""
-        out = self._run(tmp_path, commit="git commit failed: boom")
-        assert out["staged_uncommitted"] is True
+    def test_commit_fails_rolls_back_branch(self, tmp_path: Path) -> None:
+        """Commit FAILED -> branch rolled back (None), staged_uncommitted False."""
+        out, h = _drive_live(tmp_path, commit="git commit failed: boom")
+        assert out["staged_uncommitted"] is False
         assert out["error"] is not None and "git commit failed" in out["error"]
-        assert out["branch"] and str(out["branch"]).startswith("governance/")
+        assert out["branch"] is None
+        h.delete.assert_called_once()
 
     @pytest.mark.unit
-    def test_push_fails_after_commit_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
-        """Commit OK + push FAILS -> staged_uncommitted False (it committed).
-
-        RED on the old ``bool(errors)`` flag: the push error made errors truthy
-        even though the commit landed, mislabelling a committed state as
-        staged-uncommitted. Recovery for a push failure is described by ``error``.
-        """
-        out = self._run(tmp_path, commit=None, push="push boom")
+    def test_push_fails_rolls_back_branch(self, tmp_path: Path) -> None:
+        """Commit OK + push FAILS -> branch never persisted, rolled back to None."""
+        out, h = _drive_live(tmp_path, commit=None, push="push boom")
         assert out["staged_uncommitted"] is False
         assert out["error"] == "push boom"
-        assert out["branch"] and str(out["branch"]).startswith("governance/")
+        assert out["branch"] is None
+        h.delete.assert_called_once()
 
     @pytest.mark.unit
-    def test_pr_fails_after_commit_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
-        """Commit OK + push OK + PR FAILS -> staged_uncommitted False (committed+pushed).
-
-        RED on the old ``bool(errors)`` flag.
-        """
-        out = self._run(tmp_path, commit=None, push=None, open_pr=(None, "pr boom"))
+    def test_pr_fails_after_push_keeps_branch(self, tmp_path: Path) -> None:
+        """Commit OK + push OK + PR FAILS -> branch persisted on origin, kept."""
+        out, h = _drive_live(tmp_path, commit=None, push=None, open_pr=(None, "pr boom"))
         assert out["staged_uncommitted"] is False
         assert out["error"] == "pr boom"
+        assert out["branch"] and out["branch"].startswith("governance/")
+        h.delete.assert_not_called()
 
     @pytest.mark.unit
-    def test_full_success_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
-        """Full success -> staged_uncommitted False (regression guard)."""
-        out = self._run(tmp_path, commit=None, push=None, open_pr=("http://pr/1", None))
+    def test_full_success_keeps_branch(self, tmp_path: Path) -> None:
+        """Full success -> branch persisted, staged_uncommitted False, no rollback."""
+        out, h = _drive_live(tmp_path, commit=None, push=None, open_pr=("http://pr/1", None))
         assert out["staged_uncommitted"] is False
         assert out["error"] is None
+        assert out["branch"] and out["branch"].startswith("governance/")
+        h.delete.assert_not_called()
 
     @pytest.mark.unit
-    def test_traversal_reject_is_not_staged_uncommitted(self, tmp_path: Path) -> None:
-        """Path-traversal reject -> staged_uncommitted False: no `git add` ran yet.
-
-        The branch exists (surfaced via ``branch`` + ``error``) but nothing was
-        staged, so the literal "staged but not committed" flag is False.
-        """
-        # target_path OUTSIDE working_dir triggers the traversal guard, which
-        # returns before any write/add. ``_create_branch`` is stubbed so the
-        # branch-creation step "succeeds" and we reach the traversal guard.
+    def test_traversal_reject_skips_worktree(self, tmp_path: Path) -> None:
+        """Path-traversal reject -> no worktree created, branch None, nothing staged."""
         outside = tmp_path.parent / "elsewhere" / "x.oct.md"
         validation = ValidationResult(
             valid=True,
@@ -880,14 +701,15 @@ class TestStagedUncommittedContract:
             target_path=outside,
         )
         with (
-            patch(f"{_LINKER}._preflight_commit_safety", return_value=None),
-            patch(f"{_LINKER}._create_branch", return_value=None),
+            patch(f"{_LINKER}._create_worktree") as create_worktree,
             patch(f"{_LINKER}._git_add_and_commit") as commit,
         ):
             out = run_linker(tmp_path, validation, "===DECISION_RECORD===\n", False)
         assert "path traversal rejected" in out["error"]
         assert out["staged_uncommitted"] is False
-        # The commit step was never reached.
+        assert out["branch"] is None
+        # No worktree was created and no commit ran.
+        create_worktree.assert_not_called()
         commit.assert_not_called()
 
 

--- a/tests/unit/tools/governance/test_linker_two_birds.py
+++ b/tests/unit/tools/governance/test_linker_two_birds.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 from hestai_context_mcp.tools.governance.linker import _stamp_human_adr_ref, run_linker
 from hestai_context_mcp.tools.governance.type_checker import (
@@ -72,6 +73,29 @@ def _init_isolated_git_repo(repo: Path) -> None:
     subprocess.run(
         ["git", "commit", "-m", "initial"], cwd=str(repo), check=True, capture_output=True
     )
+    _attach_origin_remote(repo)
+
+
+def _attach_origin_remote(repo: Path) -> None:
+    """Give ``repo`` a bare ``origin`` remote on ``main``.
+
+    run_linker now cuts the governance branch from ``origin/main`` inside a
+    dedicated worktree (``git fetch origin`` + ``git worktree add ... origin/main``),
+    so the integration fixture must expose a real ``origin`` with a ``main`` ref.
+    The bare lives beside the repo so it is cleaned up with the pytest tmp tree.
+    """
+    subprocess.run(["git", "branch", "-M", "main"], cwd=str(repo), check=True, capture_output=True)
+    bare = repo.parent / f"{repo.name}-origin.git"
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare)],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"], cwd=str(repo), check=True, capture_output=True
+    )
 
 
 def _validation(target: Path) -> ValidationResult:
@@ -82,6 +106,51 @@ def _validation(target: Path) -> ValidationResult:
         card_type="DECISION_RECORD",
         target_path=target,
     )
+
+
+def _show_on_branch(repo: Path, branch: str, rel_path: str) -> str:
+    """Return the content of ``rel_path`` as committed on ``branch`` in ``repo``.
+
+    run_linker commits inside a throwaway worktree that is then removed, so the
+    governance files never appear in the operator's working tree. They live on
+    the ``governance/...`` branch ref (kept locally after the worktree is gone),
+    which this reads via ``git show``.
+    """
+    return subprocess.run(
+        ["git", "show", f"{branch}:{rel_path}"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _branch_files(repo: Path, branch: str) -> str:
+    """Return the newline-joined tracked paths on ``branch``."""
+    return subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", branch],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _assert_main_tree_untouched(repo: Path) -> None:
+    """The operator's working tree must still be on ``main`` with no governance file.
+
+    This is the core #108 invariant: run_linker must NEVER move or dirty the
+    invoking working tree.
+    """
+    current = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert current == "main", f"invoking tree was left on {current!r}, expected 'main'"
+    assert not (repo / ".hestai" / "decisions" / f"{_TOKEN}.oct.md").exists()
 
 
 class TestStampHumanAdrRef:
@@ -214,38 +283,55 @@ class TestStampHumanAdrRef:
 
 
 class TestLinkerDualWrite:
+    # The PR boundary (gh) is stubbed so the push to the bare ``origin`` is real
+    # (the commit lands on the branch) without needing a GitHub remote. The
+    # governance files are then read from the committed branch, since the
+    # worktree they were written in is removed before run_linker returns.
+    _PR_OK = (
+        "https://github.com/elevanaltd/hestai-context-mcp/pull/1",
+        None,
+    )
+
     def test_adr_prose_writes_verbatim_doc(self, tmp_path: Path) -> None:
         # RED #2: docs/adr/<TOKEN>.md written byte-exact to the prose.
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        run_linker(
-            working_dir=tmp_path,
-            validation=_validation(target),
-            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
-            dry_run=False,
-            adr_prose=_ADR_PROSE,
-        )
-        adr_path = tmp_path / "docs" / "adr" / f"{_TOKEN}.md"
-        assert adr_path.is_file()
-        # VERBATIM: byte-exact, no AI/OCTAVE/marker mutation.
-        assert adr_path.read_text(encoding="utf-8") == _ADR_PROSE
+        with patch(
+            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
+        ):
+            output = run_linker(
+                working_dir=tmp_path,
+                validation=_validation(target),
+                octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+                dry_run=False,
+                adr_prose=_ADR_PROSE,
+            )
+        assert output["branch"], output["error"]
+        # VERBATIM: byte-exact on the branch, no AI/OCTAVE/marker mutation.
+        committed = _show_on_branch(tmp_path, output["branch"], f"docs/adr/{_TOKEN}.md")
+        assert committed == _ADR_PROSE
+        # The invoking working tree is untouched (#108).
+        _assert_main_tree_untouched(tmp_path)
 
     def test_both_files_staged_in_one_commit(self, tmp_path: Path) -> None:
         # RED #3: AGR + ADR land in the SAME commit on one branch.
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        output = run_linker(
-            working_dir=tmp_path,
-            validation=_validation(target),
-            octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
-            dry_run=False,
-            adr_prose=_ADR_PROSE,
-        )
-        # Branch created; no orphan-state error from the write/commit steps.
-        assert output["branch"]
-        # HEAD commit contains BOTH files.
+        with patch(
+            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
+        ):
+            output = run_linker(
+                working_dir=tmp_path,
+                validation=_validation(target),
+                octave_content=_stamp_human_adr_ref(_AGR_OCTAVE, _TOKEN),
+                dry_run=False,
+                adr_prose=_ADR_PROSE,
+            )
+        # Branch pushed; no orphan-state error from the write/commit steps.
+        assert output["branch"], output["error"]
+        # The branch tip commit contains BOTH files.
         files = subprocess.run(
-            ["git", "show", "--name-only", "--pretty=format:", "HEAD"],
+            ["git", "show", "--name-only", "--pretty=format:", output["branch"]],
             cwd=str(tmp_path),
             check=True,
             capture_output=True,
@@ -253,17 +339,24 @@ class TestLinkerDualWrite:
         ).stdout
         assert f".hestai/decisions/{_TOKEN}.oct.md" in files
         assert f"docs/adr/{_TOKEN}.md" in files
+        _assert_main_tree_untouched(tmp_path)
 
     def test_no_adr_prose_writes_no_doc(self, tmp_path: Path) -> None:
         # RED #1: absent adr_prose -> no docs/adr write (back-compat).
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        run_linker(
-            working_dir=tmp_path,
-            validation=_validation(target),
-            octave_content=_AGR_OCTAVE,
-            dry_run=False,
-        )
+        with patch(
+            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
+        ):
+            output = run_linker(
+                working_dir=tmp_path,
+                validation=_validation(target),
+                octave_content=_AGR_OCTAVE,
+                dry_run=False,
+            )
+        assert output["branch"], output["error"]
+        # No docs/adr path on the committed branch, and none in the working tree.
+        assert f"docs/adr/{_TOKEN}.md" not in _branch_files(tmp_path, output["branch"])
         assert not (tmp_path / "docs" / "adr").exists()
 
 

--- a/tests/unit/tools/governance/test_linker_two_birds.py
+++ b/tests/unit/tools/governance/test_linker_two_birds.py
@@ -296,9 +296,7 @@ class TestLinkerDualWrite:
         # RED #2: docs/adr/<TOKEN>.md written byte-exact to the prose.
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        with patch(
-            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
-        ):
+        with patch("hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK):
             output = run_linker(
                 working_dir=tmp_path,
                 validation=_validation(target),
@@ -317,9 +315,7 @@ class TestLinkerDualWrite:
         # RED #3: AGR + ADR land in the SAME commit on one branch.
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        with patch(
-            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
-        ):
+        with patch("hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK):
             output = run_linker(
                 working_dir=tmp_path,
                 validation=_validation(target),
@@ -345,9 +341,7 @@ class TestLinkerDualWrite:
         # RED #1: absent adr_prose -> no docs/adr write (back-compat).
         _init_isolated_git_repo(tmp_path)
         target = tmp_path / ".hestai" / "decisions" / f"{_TOKEN}.oct.md"
-        with patch(
-            "hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK
-        ):
+        with patch("hestai_context_mcp.tools.governance.linker._open_pr", return_value=self._PR_OK):
             output = run_linker(
                 working_dir=tmp_path,
                 validation=_validation(target),

--- a/tests/unit/tools/test_submit_governance.py
+++ b/tests/unit/tools/test_submit_governance.py
@@ -71,6 +71,20 @@ def _init_isolated_git_repo(repo: Path) -> None:
         check=True,
         capture_output=True,
     )
+    # run_linker cuts the governance branch from ``origin/main`` inside a
+    # throwaway worktree, so the repo needs a real ``origin`` exposing ``main``.
+    subprocess.run(["git", "branch", "-M", "main"], cwd=str(repo), check=True, capture_output=True)
+    bare = repo.parent / f"{repo.name}-origin.git"
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare)],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"], cwd=str(repo), check=True, capture_output=True
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -924,13 +938,13 @@ class TestLinkerIntegration:
     def test_linker_creates_branch_commits_writes_file(
         self, tmp_path: Path, decision_record_octave: str
     ) -> None:
-        """Linker (dry_run=False) creates branch, writes file, commits.
+        """Linker (dry_run=False) creates the branch in a worktree, commits, and
+        leaves the invoking working tree untouched.
 
         gh pr create is mocked at the linker module level to avoid real GitHub
-        interaction while allowing real git operations.
+        interaction while allowing real git operations (the push to the bare
+        ``origin`` is real, so the commit lands on the branch).
         """
-        # Real git repo with hooks disabled so the linker's internal
-        # checkout/add/commit are not blocked by a developer's global git hooks.
         _init_isolated_git_repo(tmp_path)
 
         from hestai_context_mcp.tools.governance.linker import run_linker
@@ -939,20 +953,12 @@ class TestLinkerIntegration:
         result = validate_octave_content(tmp_path, decision_record_octave)
         assert result.valid is True
 
-        # Mock the remote boundary (push + _open_pr) in the linker module to
-        # avoid real network/GitHub interaction while exercising real git-local
-        # operations (branch/write/commit). The temp repo has no `origin`
-        # remote, so the push must be stubbed (issue #73 added the push step).
+        # Stub only the PR boundary (gh): the worktree creation, write, commit,
+        # and push to the bare ``origin`` all run for real.
         pr_url = "https://github.com/elevanaltd/hestai-context-mcp/pull/999"
-        with (
-            patch(
-                "hestai_context_mcp.tools.governance.linker._push_branch",
-                return_value=None,
-            ),
-            patch(
-                "hestai_context_mcp.tools.governance.linker._open_pr",
-                return_value=(pr_url, None),
-            ),
+        with patch(
+            "hestai_context_mcp.tools.governance.linker._open_pr",
+            return_value=(pr_url, None),
         ):
             output = run_linker(
                 working_dir=tmp_path,
@@ -961,6 +967,29 @@ class TestLinkerIntegration:
                 dry_run=False,
             )
 
-        assert output["branch"] is not None
-        target = tmp_path / ".hestai" / "decisions" / "HO-CONTEXT-MCP-TEST-DECISION-20260531.oct.md"
-        assert target.exists()
+        # The branch was pushed to origin (non-None branch) and the PR opened.
+        assert output["branch"] is not None, output["error"]
+        assert output["pr_url"] == pr_url
+
+        rel = ".hestai/decisions/HO-CONTEXT-MCP-TEST-DECISION-20260531.oct.md"
+        # The file is committed ON THE BRANCH, not in the operator's working tree.
+        committed = subprocess.run(
+            ["git", "show", f"{output['branch']}:{rel}"],
+            cwd=str(tmp_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert committed == decision_record_octave
+
+        # Core #108 invariant: the invoking tree never moved off main and the
+        # governance file was never written into it.
+        current = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=str(tmp_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert current == "main"
+        assert not (tmp_path / rel).exists()


### PR DESCRIPTION
## Problem

`submit_governance` → `run_linker` created the governance branch in-place with `git checkout -b governance/...`, which mutates the HEAD of the **invoking working tree**. Run against a main repo on `main`, the checkout moved to `governance/...` and was never restored — leaving the operator's main checkout stranded on the governance branch. This is the inverse of the worktree-discipline conflict reported in #108: the tool brute-forced a branch change on a tree that must always stay on `main`.

## Fix

Replace the in-place `checkout -b` with a **hermetic throwaway worktree**:

1. `git fetch origin`
2. `git worktree add -b governance/<date>-<slug> <tmp> origin/main`
3. write → commit → push → PR entirely **inside** that worktree
4. `git worktree remove --force` in a `finally` — always

Consequences:
- **The invoking tree's HEAD is never moved.** Main stays on main, structurally guaranteed.
- Commits always come from a real worktree, so the worktree-discipline pre-commit hook is satisfied by construction — the now-redundant `_preflight_commit_safety` guard was removed (dead code).
- `branch` is reported for recovery **only when it actually reached origin** (a push succeeded); any pre-push failure rolls the local branch back instead of returning a phantom name (the other half of #108).
- `staged_uncommitted` is now always `False` on the live path — nothing is ever staged in the operator's tree.

Base ref is `origin/main` (after a fetch), keeping the branch base identical to the PR base. No new dependency: the flow already required an `origin` for push/PR; fetch failures now surface as a clear structured error before anything is created.

## Tests

- **Two-birds integration tests** prove it end-to-end with real git: files land on the branch, and new assertions confirm the invoking tree is left on `main` with no governance file written into it.
- `test_linker.py` rewritten for the worktree model: worktree-creation failure aborts cleanly; pre-push failures roll the branch back; PR-failure-after-push keeps the pushed branch; the worktree is always removed.
- `_init_isolated_git_repo` fixtures now provision a bare `origin` with `main`.

Local: ruff + mypy clean; governance/intake suites 386 passed; full suite green (one unrelated flaky `test_clock_in` AI-synthesis test, passes in isolation).

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates governance branches in a temporary `git worktree` cut from `origin/main` so the operator’s working tree never moves; all write/commit/push/PR run inside the worktree and it’s always cleaned up. Also hardens cleanup to roll back any unpushed local branch even on unexpected exceptions; `branch` is only returned after a successful push.

- **Bug Fixes**
  - Build branches in a throwaway worktree after `git fetch origin`; the invoking tree stays on `main`.
  - Always remove the worktree; delete the local branch whenever it never reached `origin` (including pre-push exceptions).
  - Write/commit/push/PR run in the worktree; `staged_uncommitted` is always False.
  - Path traversal checks happen before creating the worktree; on reject, nothing is created.

- **Refactors**
  - Removed the in-place `checkout -b` path and the preflight hook guard.
  - MANIFEST updates now run inside the worktree; failure remains non‑fatal.
  - Tests updated: fixtures attach a bare `origin` and assert the invoking tree remains on `main`; branch contents are verified via `git show`; adds a regression test for branch rollback on unexpected exceptions.
  - Style-only: formatted two-birds linker tests to satisfy `black`.

<sup>Written for commit a51aac6fb1044500dd6c9dcc4ba9fd1bdba60bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/hestai-context-mcp/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

